### PR TITLE
filters.ts: Support endpoints hosted in a subdirectory

### DIFF
--- a/src/plugins/filters.ts
+++ b/src/plugins/filters.ts
@@ -195,8 +195,8 @@ export const Filters = {
     const _url = new URL(url)
     const wsProtocol = _url.protocol === 'https:' ? 'wss://' : 'ws://'
     const o = {
-      apiUrl: `${_url.protocol}//${_url.host}`,
-      socketUrl: `${wsProtocol}${_url.host}/websocket`
+      apiUrl: `${_url.protocol}//${_url.host}${_url.pathname}`,
+      socketUrl: `${wsProtocol}${_url.host}${_url.pathname}/websocket`
     }
     return o
   },


### PR DESCRIPTION
I host Moonraker behind a reverse proxy under a subdirectory (e.g., `https://print.myhost.tld/moonraker`), and the current behavior of Fluidd is as follows:

1. In the Add Printer dialog, I enter `https://print.myhost.tld/moonraker/`
1. `AddInstanceDialog.vue` concatenates the test URL correctly, successfully tests the endpoint and allows me to add it :heavy_check_mark: 
1. `$filters.getApiUrls` strips the pathname from the URL and the incorrect endpoint is then added :interrobang:
1. I get a sad error screen :frowning_face: 