### PR TITLE
feat: adds optional confirmation for power device toggle

### DIFF
--- a/src/components/common/SystemCommands.vue
+++ b/src/components/common/SystemCommands.vue
@@ -161,9 +161,19 @@ export default class SystemCommands extends Mixins(StateMixin, ServicesMixin) {
       })
   }
 
-  togglePowerDevice (device: Device, wait?: string) {
-    const state = (device.status === 'on') ? 'off' : 'on'
-    SocketActions.machineDevicePowerToggle(device.device, state, wait)
+  async togglePowerDevice (device: Device, wait?: string) {
+    const confirmOnPowerDeviceChange = this.$store.state.config.uiSettings.general.confirmOnPowerDeviceChange
+    let res: boolean | undefined = true
+    if (confirmOnPowerDeviceChange) {
+      res = await this.$confirm(
+        this.$tc('app.general.simple_form.msg.confirm_power_device_toggle'),
+        { title: this.$tc('app.general.label.confirm'), color: 'card-heading', icon: '$error' }
+      )
+    }
+    if (res) {
+      const state = (device.status === 'on') ? 'off' : 'on'
+      SocketActions.machineDevicePowerToggle(device.device, state, wait)
+    }
   }
 
   getPowerIcon (device: Device) {

--- a/src/components/settings/GeneralSettings.vue
+++ b/src/components/settings/GeneralSettings.vue
@@ -48,6 +48,19 @@
           class="mb-5"
         ></v-switch>
       </app-setting>
+
+      <v-divider></v-divider>
+
+      <app-setting
+        :title="$t('app.setting.label.confirm_on_power_device_change')"
+      >
+        <v-switch
+          @click.native.stop
+          v-model="confirmOnPowerDeviceChange"
+          hide-details
+          class="mb-5"
+        ></v-switch>
+      </app-setting>
     </v-card>
   </div>
 </template>
@@ -105,6 +118,18 @@ export default class GeneralSettings extends Mixins(StateMixin) {
   set confirmOnEstop (value: boolean) {
     this.$store.dispatch('config/saveByPath', {
       path: 'uiSettings.general.confirmOnEstop',
+      value,
+      server: true
+    })
+  }
+
+  get confirmOnPowerDeviceChange () {
+    return this.$store.state.config.uiSettings.general.confirmOnPowerDeviceChange
+  }
+
+  set confirmOnPowerDeviceChange (value: boolean) {
+    this.$store.dispatch('config/saveByPath', {
+      path: 'uiSettings.general.confirmOnPowerDeviceChange',
       value,
       server: true
     })

--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -257,6 +257,7 @@ app:
         confirm: Are you sure?
         confirm_reboot_host: Are you sure? This will reboot your host system.
         confirm_shutdown_host: Are you sure? This will shutdown your host system.
+        confirm_power_device_toggle: Are you sure? This will toggle the power of this device.
     table:
       header:
         actions: Actions
@@ -342,6 +343,7 @@ app:
       camera_stream_type: Stream type
       camera_url: Camera Url
       confirm_on_estop: Require confirm on Emergency Stop
+      confirm_on_power_device_change: Require confirm on Device Power changes
       dark_mode: Dark mode
       default_extrude_length: Default extrude length
       default_extrude_speed: Default extrude speed

--- a/src/store/config/index.ts
+++ b/src/store/config/index.ts
@@ -52,7 +52,8 @@ export const defaultState = (): ConfigState => {
         useGcodeCoords: false,
         zAdjustDistances: [0.005, 0.01, 0.025, 0.050],
         enableVersionNotifications: true,
-        confirmOnEstop: false
+        confirmOnEstop: false,
+        confirmOnPowerDeviceChange: false
       },
       theme: {
         isDark: true,

--- a/src/store/config/types.ts
+++ b/src/store/config/types.ts
@@ -47,6 +47,7 @@ export interface GeneralConfig {
   zAdjustDistances: number[];
   enableVersionNotifications: boolean;
   confirmOnEstop: boolean;
+  confirmOnPowerDeviceChange: boolean;
 }
 
 // Config stored in moonraker db


### PR DESCRIPTION
Implements #386, by adding a new setting that allow to indicate if a confirmation dialog should be shown when the user toggles a device power.

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>