### PR TITLE
Dockerfile Cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,17 @@
-FROM debian as unzip
+FROM alpine:latest as unzip
 
 ARG FRONTEND_ZIP_URL=https://github.com/cadriel/fluidd/releases/latest/download/fluidd.zip
 
-ARG DEBIAN_FRONTEND=noninteractive
 WORKDIR /frontend
 
 ADD ${FRONTEND_ZIP_URL} /tmp/frontend.zip
-RUN apt-get update && apt-get install -y unzip
 RUN unzip /tmp/frontend.zip -d /frontend
 
-FROM nginx:alpine as image
+FROM nginx:alpine
 
 ENV JPEG_STREAM_HOST localhost
 ENV JPEG_STREAM_PORT 8080
 
-#ADD --chown=101:101 common_vars.conf /etc/nginx/conf.d/common_vars.conf 
-#COPY --chown=101:101 upstreams.conf.template /etc/nginx/templates/upstreams.conf.template
 COPY --chown=101:101 server/nginx-site.conf /etc/nginx/conf.d/default.conf
 COPY --from=unzip --chown=101:101 /frontend /usr/share/nginx/html
 COPY --chown=101:101 server/config.json /usr/share/nginx/html/config.json


### PR DESCRIPTION
Changed image used for stage "unzip"; alpine is much smaller and does not need unzip installed.
Removed ARG declared but never referenced.
Removed RUN previously used to install unzip in debian container.
Removed stage name "image" declared but never referenced.
Removed commented lines.