### PR TITLE
Add camera iframe option with height option

### DIFF
--- a/src/components/settings/cameras/CameraConfigDialog.vue
+++ b/src/components/settings/cameras/CameraConfigDialog.vue
@@ -66,7 +66,8 @@
             :items="[
               { text: $t('app.setting.camera_type_options.mjpegadaptive'), value: 'mjpgadaptive' },
               { text: $t('app.setting.camera_type_options.mjpegstream'), value: 'mjpgstream' },
-              { text: $t('app.setting.camera_type_options.video'), value: 'ipstream' }
+              { text: $t('app.setting.camera_type_options.video'), value: 'ipstream' },
+              { text: $t('app.setting.camera_type_options.iframe'), value: 'iframe' }
             ]"
             item-value="value"
             item-text="text"
@@ -98,6 +99,20 @@
             single-line
             hide-details="auto"
             v-model="camera.url"
+            :rules="[rules.required]"
+          ></v-text-field>
+        </app-setting>
+
+        <v-divider />
+
+        <app-setting v-if="camera.type === 'iframe'" :title="$t('app.setting.label.height')">
+          <v-text-field
+            class="mt-5"
+            filled
+            dense
+            single-line
+            hide-details="auto"
+            v-model.number="camera.height"
             :rules="[rules.required]"
           ></v-text-field>
         </app-setting>

--- a/src/components/widgets/camera/CameraItem.vue
+++ b/src/components/widgets/camera/CameraItem.vue
@@ -22,6 +22,15 @@
         :style="cameraTransformStyle"
       />
 
+      <iframe
+        v-if="camera.type === 'iframe'"
+        :src="cameraUrl"
+        class="camera-image"
+        :style="cameraTransformStyle"
+        :height="cameraHeight"
+        frameBorder="0"
+      />
+
       <div
         v-if="camera.name"
         class="camera-name"
@@ -61,6 +70,9 @@ export default class CameraItem extends Vue {
 
   // URL used by camera
   cameraUrl = ''
+
+  // iframe height
+  cameraHeight = 720
 
   // Maintains the last cachebust string
   refresh = new Date().getTime()
@@ -156,6 +168,8 @@ export default class CameraItem extends Vue {
       const hostUrl = new URL(document.URL)
       const url = new URL(baseUrl, hostUrl.origin)
 
+      this.cameraHeight = this.camera.height || 720
+
       if (type === 'mjpgstream') {
         url.searchParams.append('cacheBust', this.refresh.toString())
         if (!url.searchParams.get('action')?.startsWith('stream')) {
@@ -173,7 +187,7 @@ export default class CameraItem extends Vue {
         this.cameraUrl = url.toString()
       }
 
-      if (type === 'ipstream') {
+      if (type === 'ipstream' || type === 'iframe') {
         this.cameraUrl = baseUrl
       }
     } else {

--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -334,6 +334,7 @@ app:
       mjpegadaptive: MJPEG Adaptive
       mjpegstream: MJPEG Stream
       video: IP Camera
+      iframe: HTTP page
     label:
       all_off: All off
       all_on: All on
@@ -355,6 +356,7 @@ app:
       flip_horizontal: Horizontal Flip
       flip_vertical: Vertical Flip
       fps_target: FPS Target
+      height: Height
       gcode_coords: Use GCode Coordinates
       invert_x_control: Invert X control
       invert_y_control: Invert Y control

--- a/src/store/cameras/index.ts
+++ b/src/store/cameras/index.ts
@@ -18,7 +18,8 @@ export const defaultState = (): CamerasState => {
         fpstarget: 15,
         url: '/webcam/?action=stream',
         flipX: false,
-        flipY: false
+        flipY: false,
+        height: 720
       }
     ]
   }

--- a/src/store/cameras/types.ts
+++ b/src/store/cameras/types.ts
@@ -7,9 +7,10 @@ export interface CameraConfig {
   id: string;
   enabled: boolean;
   name: string;
-  type: 'mjpgadaptive' | 'mjpgstream' | 'ipstream';
+  type: 'mjpgadaptive' | 'mjpgstream' | 'ipstream' | 'iframe';
   url: string;
   fpstarget?: number;
   flipX: boolean;
   flipY: boolean;
+  height?: number;
 }


### PR DESCRIPTION
Hi :)
I just started setting up my klipper setup with fluidd and found out that you can not setup camera as a simple iframe.
I am using https://github.com/dans98/pi-h264-to-browser with works much better then any mjpeg options.
Uses less bandwidth and runs with hw accel in your browser but needs to be setup as a simple web page.
So I add an iframe option named "HTTP Page".
I also add to it an height option, it is a not perfect workaround around the iframe not scaling automatic.
Another option to fix that would be onLoad on the iframe but that would work only if the webserwer and camera are on the same origin with isn't always the case.
My first time writing code for vue, so any suggestion are welcome if something isn't up to the standards. 
In general works really well:
![image](https://user-images.githubusercontent.com/1771469/136438748-016b64a7-1ffa-48ee-a3f4-faf740e02f99.png)
