### PR TITLE
fix: IPv6 support for thumbnails

### DIFF
--- a/src/store/helpers.ts
+++ b/src/store/helpers.ts
@@ -25,11 +25,14 @@ export const getThumb = (thumbnails: Thumbnail[], path: string, large = true) =>
       }
       if (thumb) {
         if (thumb.relative_path && thumb.relative_path.length > 0) {
+          const url = new URL(apiUrl ?? document.location.origin)
+          url.pathname = (path === '')
+            ? `/server/files/gcodes/${thumb.relative_path}`
+            : `/server/files/gcodes/${path}/${thumb.relative_path}`
+
           return {
             ...thumb,
-            absolute_path: (path === '')
-              ? encodeURI(`${apiUrl}/server/files/gcodes/${thumb.relative_path}`)
-              : encodeURI(`${apiUrl}/server/files/gcodes/${path}/${thumb.relative_path}`)
+            absolute_path: url.toString()
           }
         }
         if (thumb.data) {


### PR DESCRIPTION
Requires https://github.com/fluidd-core/FluiddPI/pull/9 for NGINX IPv6 support

---

![Broken Thumbnail and URL](https://user-images.githubusercontent.com/25269274/134822000-e8587488-a0ed-47b1-9f53-e8fac3d2aee7.png)

IPv6 support for encodeURI() is [broken](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURI#encoding_for_ipv6).
![Malformed IPv6 URL](https://user-images.githubusercontent.com/25269274/134821729-fbf421cb-1db5-411d-be61-5d05a1a343fc.png) <small>This should, instead of showing `%5B` and `%5D`, show `[` and `]`, respectively<small>

Mozilla's fix for this is, however, dirty, and may break other URLs.

This PR replaces encodeURI() with an implementation using the URL API, fully supporting IPv6.
![Properly encoded URL using the URL API](https://user-images.githubusercontent.com/25269274/134821794-78163d1d-ae53-4c5e-8cfd-6731a7850f64.png)

Assumes the document origin as a default location when no `apiUrl` is set, as an empty URL() constructor is forbidden. An `apiUrl` is (should?) always be set, however, because the thumbnails will only be retrieved after adding a backend.

---

Mainsail solves this by not encoding the URI at all, not sure if this is feasible here: https://github.com/meteyou/mainsail/blob/5dbffdb1675ccdfc84211ab53cd0519ace9b2f97/src/pages/Files.vue#L873

When using `encodeURI`, they also only encode the path instead of the full URI: https://github.com/meteyou/mainsail/blob/f1094e9c29ab78ae5f6208ab309510565759eef6/src/store/editor/actions.ts#L16

Either of those might be a solution, but I haven't tried them yet.