### PR TITLE
fix: SI units

### DIFF
--- a/src/mixins/files.ts
+++ b/src/mixins/files.ts
@@ -35,7 +35,7 @@ export default class FilesMixin extends Vue {
    * Loads a gcode file and parses for the gcode-viewer.
    */
   async getGcode (file: AppFile) {
-    const sizeInMB = file.size / 1024 / 1024
+    const sizeInMB = file.size / 1000 / 1000
     let res: boolean | undefined = true
 
     if (sizeInMB >= 100) {
@@ -92,8 +92,8 @@ export default class FilesMixin extends Vue {
         const delta = performance.now() - startTime
         if (delta > 0) {
           speed = progressEvent.loaded / delta
-          while (speed > 1024) {
-            speed /= 1024
+          while (speed > 1000) {
+            speed /= 1000
             i = Math.min(2, i + 1)
           }
         }
@@ -197,8 +197,8 @@ export default class FilesMixin extends Vue {
             const delta = performance.now() - startTime
             if (delta > 0) {
               speed = progressEvent.loaded / delta
-              while (speed > 1024) {
-                speed /= 1024
+              while (speed > 1000) {
+                speed /= 1000
                 i = Math.min(2, i + 1)
               }
             }

--- a/src/plugins/filters.ts
+++ b/src/plugins/filters.ts
@@ -125,9 +125,9 @@ export const Filters = {
     const byteUnits = [' kB', ' MB', ' GB', ' TB', 'PB', 'EB', 'ZB', 'YB']
     if (fileSizeInBytes === 0) return `0${byteUnits[0]}`
     do {
-      fileSizeInBytes = fileSizeInBytes / 1024
+      fileSizeInBytes = fileSizeInBytes / 1000
       i++
-    } while (fileSizeInBytes > 1024)
+    } while (fileSizeInBytes > 1000)
 
     return Math.max(fileSizeInBytes, 0.1).toFixed(1) + byteUnits[i]
   },


### PR DESCRIPTION
Currently, Fluidd displays file sizes based on powers of 2 (binary units), but uses units meant for calculations based on powers of 10 (metric units, e.g. kB, MB).
This might be confusing and leads to rounding errors / wrong values being displayed (i.e. showing 7.5GB of RAM instead of 8GB):
![RPi RAM](https://user-images.githubusercontent.com/25269274/139689473-3f078b81-8b60-499e-84a1-4272c0ad6c38.png)

Opting to switch to the use of powers of 10 here because most users know kB only; showing KiB in the UI would be confusing too.

ref: https://en.wikipedia.org/wiki/Byte#Multiple-byte_units