### PR TITLE
fix: file system browser selection

### DIFF
--- a/src/components/widgets/filesystem/FileSystemBrowser.vue
+++ b/src/components/widgets/filesystem/FileSystemBrowser.vue
@@ -267,8 +267,8 @@ export default class FileSystemBrowser extends Mixins(FilesMixin) {
     // If top two, and filtered results in count -1, set to all.
     if (
       item.value &&
-      this.selectedItems.length + 1 >= (this.files.length - 1) &&
-      this.selectedItems.filter(fileOrFolder => (fileOrFolder.name !== '..')).length + 1 === this.files.length - 1
+      this.selectedItems.length + 1 >= this.files.length &&
+      this.selectedItems.filter(fileOrFolder => (fileOrFolder.name !== '..')).length + 1 === this.files.length
     ) {
       this.selectedItems = this.files
     }


### PR DESCRIPTION
Currently, when selecting `n-1` files of a file system browser with `n` files, all files are selected. This PR fixes the broken logic for determining if all files should be selected.