### PR TITLE
Feat: Non-controllable fan On/Off

### DIFF
--- a/src/components/widgets/outputs/OutputFan.vue
+++ b/src/components/widgets/outputs/OutputFan.vue
@@ -45,7 +45,7 @@ export default class OutputFan extends Mixins(StateMixin) {
   get prettyValue () {
     return (this.value === 0)
       ? this.$t('app.general.label.off')
-      : `${this.value.toFixed()}<small>%</small>`
+      : this.$t('app.general.label.on')
   }
 
   get value () {

--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -211,6 +211,7 @@ app:
       name: Name
       new_password: New password
       no_notifications: No notifications
+      'on': 'On'
       'off': 'Off'
       password: Password
       power: Power


### PR DESCRIPTION
Changing the status of uncontrollable fan to On/Off instead of useless percentage.
In the same minding of this #391 .

Signed-off by Biorn : biorn@me.com