### PR TITLE
Fix: sorting directories

### DIFF
--- a/src/plugins/filters.ts
+++ b/src/plugins/filters.ts
@@ -156,7 +156,10 @@ export const Filters = {
     return items.sort((a: any, b: any) => {
       for (let i = 0; i < sortBy.length; i++) {
         const sortKey = sortBy[i]
-
+        
+        if (null!==a && "directory"===a.type && ".."===a.name) return -1;
+        if (null!==b && "directory"===b.type && ".."===b.name) return 1;
+        
         let sortA = getObjectValueByPath(a, sortKey)
         let sortB = getObjectValueByPath(b, sortKey)
 


### PR DESCRIPTION
The top directory ".." should always be the first in the list when sorting.