### PR TITLE
feat: pause autoscroll when back scrolling

### DIFF
--- a/src/components/widgets/console/Console.vue
+++ b/src/components/widgets/console/Console.vue
@@ -73,6 +73,9 @@ export default class Console extends Mixins(StateMixin) {
 
   @Ref('scroller') dynamicScroller: any
 
+  _lastScroll = 0
+  _pauseScroll = false
+
   get availableCommands () {
     return this.$store.getters['console/getAllGcodeCommands']
   }
@@ -86,7 +89,10 @@ export default class Console extends Mixins(StateMixin) {
   }
 
   mounted () {
-    this.scrollToBottom()
+    this.$nextTick(() => {
+      this.scrollToBottom()
+      this.watchScroll()
+    })
   }
 
   /**
@@ -110,10 +116,38 @@ export default class Console extends Mixins(StateMixin) {
     }
   }
 
-  scrollToBottom () {
+  updateScrollingPaused (value: boolean) {
+    if (this._pauseScroll !== value) {
+      this._pauseScroll = value
+      this.$emit('update:scrollingPaused', value)
+    }
+  }
+
+  watchScroll () {
+    this.dynamicScroller.$el.addEventListener('scroll', (e: any) => {
+      const el = e.target
+      if (el.scrollTop < this._lastScroll) {
+        this.updateScrollingPaused(true)
+      } else {
+        if (this._pauseScroll) {
+          if (el.scrollHeight - el.scrollTop - el.clientHeight < 1) {
+            this.updateScrollingPaused(false)
+          }
+        }
+      }
+      this._lastScroll = el.scrollTop <= 0 ? 0 : el.scrollTop
+    })
+  }
+
+  scrollToBottom (force?: boolean) {
     // If we have auto scroll turned off, then don't do this
     // unless it's readonly.
     if (this.dynamicScroller) {
+      if (force) {
+        this.dynamicScroller.scrollToBottom()
+        return
+      }
+      if (this._pauseScroll) return
       if (
         this.$store.state.console.autoScroll ||
         this.readonly

--- a/src/components/widgets/console/ConsoleCard.vue
+++ b/src/components/widgets/console/ConsoleCard.vue
@@ -21,6 +21,24 @@
     </template>
 
     <template v-slot:menu>
+
+      <v-tooltip
+        v-if="scrollingPaused"
+        top>
+        <template v-slot:activator="{ on, attrs }">
+          <v-btn
+            @click="console.scrollToBottom(true)"
+            v-bind="attrs"
+            v-on="on"
+            fab
+            small
+            text>
+            <v-icon>$down</v-icon>
+          </v-btn>
+        </template>
+        <span>{{ $t('app.console.placeholder.scroll') }}</span>
+      </v-tooltip>
+
       <app-btn-collapse-group
         :collapsed="true"
         menu-icon="$cog"
@@ -61,6 +79,7 @@
 
     <console
       ref="console"
+      :scrollingPaused.sync="scrollingPaused"
       :items="items"
       :height="300"
     ></console>
@@ -84,6 +103,8 @@ export default class ConsoleCard extends Mixins(StateMixin) {
   enabled!: boolean
 
   @Ref('console') console!: Console
+
+  scrollingPaused = false
 
   get filters () {
     return this.$store.getters['console/getFilters']

--- a/src/components/widgets/console/ConsoleCard.vue
+++ b/src/components/widgets/console/ConsoleCard.vue
@@ -22,22 +22,13 @@
 
     <template v-slot:menu>
 
-      <v-tooltip
+      <app-btn
         v-if="scrollingPaused"
-        top>
-        <template v-slot:activator="{ on, attrs }">
-          <v-btn
-            @click="console.scrollToBottom(true)"
-            v-bind="attrs"
-            v-on="on"
-            fab
-            small
-            text>
-            <v-icon>$down</v-icon>
-          </v-btn>
-        </template>
-        <span>{{ $t('app.console.placeholder.scroll') }}</span>
-      </v-tooltip>
+        @click="console.scrollToBottom(true)"
+        color=""
+        fab x-small text>
+        <v-icon>$down</v-icon>
+      </app-btn>
 
       <app-btn-collapse-group
         :collapsed="true"

--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -40,6 +40,7 @@ app:
       hide_temp_waits: Hide temp waits
     placeholder:
       command: '''tab'' for autocomplete, ''help'' for commands ''arrows'' for history'
+      scroll: Scroll to bottom
   endpoint:
     error:
       cant_connect: >-


### PR DESCRIPTION
When scrolled up, it will "pause" the auto scroll to bottom until you scroll down or click the button to scroll back to the bottom. The button will only be displayed when scrolling is "paused".

This is for https://github.com/fluidd-core/fluidd/issues/343

This was lightly tested with Firefox and Edge in Ubuntu.  Additional testing would be appreciated.