### PR TITLE
Do not merge: Adding full(er) page camera viewing

### DIFF
--- a/src/components/layout/AppNavDrawer.vue
+++ b/src/components/layout/AppNavDrawer.vue
@@ -42,6 +42,13 @@
           </app-nav-item>
 
           <app-nav-item
+            v-if="hasCameras"
+            icon="$camera"
+            to="/camera">
+            {{ $tc('app.general.title.camera', 2) }}
+          </app-nav-item>
+
+          <app-nav-item
             v-if="supportsHistory"
             icon="$history"
             to="/history">
@@ -108,6 +115,10 @@ export default class AppNavDrawer extends Mixins(StateMixin) {
 
   get isMobile () {
     return this.$vuetify.breakpoint.mobile
+  }
+
+  get hasCameras (): boolean {
+    return this.$store.getters['cameras/getEnabledCameras']?.length
   }
 
   emitChange (e: boolean) {

--- a/src/components/widgets/camera/CameraCard.vue
+++ b/src/components/widgets/camera/CameraCard.vue
@@ -4,7 +4,8 @@
     icon="$camera"
     :lazy="false"
     :draggable="true"
-    layout-path="dashboard.camera-card"
+    :collapsable="collapsable"
+    :layoutPath="layoutPath"
     @collapsed="collapsed = $event">
 
     <template v-slot:menu>
@@ -44,7 +45,6 @@ import { Component, Mixins, Prop } from 'vue-property-decorator'
 import CameraItem from '@/components/widgets/camera/CameraItem.vue'
 import CameraMenu from './CameraMenu.vue'
 import StateMixin from '@/mixins/state'
-// import { CameraConfig } from '@/store/cameras/types'
 
 @Component({
   components: {
@@ -56,10 +56,14 @@ export default class CameraCard extends Mixins(StateMixin) {
   @Prop({ type: Boolean, default: true })
   enabled!: boolean
 
-  dialogState: any = {
-    open: false,
-    camera: null
-  }
+  @Prop({ type: Boolean, default: true })
+  expandable!: boolean
+
+  @Prop({ type: Boolean, default: true })
+  collapsable!: boolean
+
+  @Prop({ type: String, default: 'dashboard.camera-card' })
+  layoutPath!: string
 
   collapsed = false
 

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -4,6 +4,7 @@ import VueRouter, { NavigationGuardNext, Route, RouteConfig } from 'vue-router'
 // Views
 import Dashboard from '@/views/Dashboard.vue'
 import Jobs from '@/views/Jobs.vue'
+import Cameras from '@/views/Cameras.vue'
 import Tune from '@/views/Tune.vue'
 import History from '@/views/History.vue'
 import Configure from '@/views/Configure.vue'
@@ -40,6 +41,12 @@ const routes: Array<RouteConfig> = [
     path: '/jobs',
     name: 'Jobs',
     component: Jobs,
+    beforeEnter: ifAuthenticated
+  },
+  {
+    path: '/camera',
+    name: 'Cameras',
+    component: Cameras,
     beforeEnter: ifAuthenticated
   },
   {

--- a/src/store/cameras/getters.ts
+++ b/src/store/cameras/getters.ts
@@ -1,12 +1,12 @@
 import { GetterTree } from 'vuex'
-import { CamerasState } from './types'
+import { CameraConfig, CamerasState } from './types'
 import { RootState } from '../types'
 
 export const getters: GetterTree<CamerasState, RootState> = {
   /**
    * Return all cameras.
    */
-  getCameras: (state) => {
+  getCameras: (state): CameraConfig[] => {
     return [...state.cameras]
       .sort((a, b) => {
         const name1 = a.name.toLowerCase()
@@ -18,7 +18,7 @@ export const getters: GetterTree<CamerasState, RootState> = {
   /**
    * Return all enabled cameras,
    */
-  getEnabledCameras: (state, getters) => {
+  getEnabledCameras: (state, getters): CameraConfig[] => {
     return [...getters.getCameras]
       .filter(camera => camera.enabled)
   },
@@ -27,7 +27,7 @@ export const getters: GetterTree<CamerasState, RootState> = {
    * Return visible cameras. I.e., return cameras dependent on them being
    * 1. enabled and 2. filtered by the currently active state.
    */
-  getVisibleCameras: (state, getters) => {
+  getVisibleCameras: (state, getters): CameraConfig[] => {
     if (getters.getActiveCamera === 'all') return [...getters.getEnabledCameras]
     return [...getters.getEnabledCameras]
       .filter(camera => camera.id === getters.getActiveCamera)
@@ -36,14 +36,14 @@ export const getters: GetterTree<CamerasState, RootState> = {
   /**
    * Return a camera by its id.
    */
-  getCameraById: (state) => (id: string) => {
+  getCameraById: (state) => (id: string): CameraConfig | undefined => {
     return state.cameras.find(camera => camera.id === id)
   },
 
   /**
    * Return the set active camera, being all or a specific id.
    */
-  getActiveCamera: (state) => {
+  getActiveCamera: (state): string => {
     return state.activeCamera
   }
 }

--- a/src/views/Cameras.vue
+++ b/src/views/Cameras.vue
@@ -1,0 +1,29 @@
+<template>
+  <v-row :dense="$vuetify.breakpoint.smAndDown" justify="center">
+    <v-col cols="12" lg="8" class="fill-height">
+      <router-view v-if="authenticated && socketConnected" />
+      <div v-if="$route.matched.length === 1">
+        <camera-card
+          :expandable="false"
+          :collapsable="false"
+          :layoutPath="null"
+        ></camera-card>
+      </div>
+    </v-col>
+  </v-row>
+</template>
+
+<script lang="ts">
+import { Component, Mixins } from 'vue-property-decorator'
+import StateMixin from '@/mixins/state'
+
+import CameraCard from '@/components/widgets/camera/CameraCard.vue'
+
+@Component({
+  components: {
+    CameraCard
+  }
+})
+export default class Cameras extends Mixins(StateMixin) {
+}
+</script>


### PR DESCRIPTION
Working on adding a full page view of the cameras. Right now you just click the icon in the navbar to go to a "full page" camera view.

The full page needs some work. I'd like to figure out how to get it to expand to the available container without scrolling and scale to fit.

This is for: https://github.com/fluidd-core/fluidd/issues/279

The original request asked about double clicking on a camera. I can probably do that but would need to use CameraItem directly on the Camera page instead of the CameraCard. If I attempt to use the CameraCard, the code might get a little messy.

I'm looking for feedback on
- Exact navigation. Double click only? Navbar? Both? Something else?
- Css and structure (and code) to get the CameraItem to fill the container and scale. With the cols/rows and fill-height and the rest, it is a bit confusing.

Note: How the full page works, that is, going to the Card (with the drop down camera selection) or the Item (directly to the camera viewer) will impact a lot of things, including navigation, so that needs to be decided first.

I am not 100% committed at this point to finishing this depending on the scope of the requested changes. A simple implementation followed by enhancements is my preference. If someone wants to jump in and take this, I have no problems closing out this PR.

Here are some screenshots of how it is working initially:

Multiple Cameras (Dashboard):
![image](https://user-images.githubusercontent.com/7727467/151686303-0c59b681-c5e2-4273-ad5c-be431414448a.png)

Full screen, needs some work:
![image](https://user-images.githubusercontent.com/7727467/151686312-b9f9757f-e314-48cf-83ea-5389bc378ea7.png)

Single Camera (Dashboard):
![image](https://user-images.githubusercontent.com/7727467/151686324-7a412747-73f5-4b73-9736-f6be8c2606e2.png)

Works ok. Needs some css work when resizing the screen smaller
![image](https://user-images.githubusercontent.com/7727467/151686337-c5372691-5ef7-4d1c-8a47-905bf7c59a4f.png)
