### PR TITLE
feat: idle FPS

### DIFF
--- a/src/components/settings/cameras/CameraConfigDialog.vue
+++ b/src/components/settings/cameras/CameraConfigDialog.vue
@@ -91,6 +91,20 @@
 
         <v-divider v-if="camera.type === 'mjpgadaptive'" />
 
+        <app-setting v-if="camera.type === 'mjpgadaptive'" :title="$t('app.setting.label.fps_idle_target')">
+          <v-text-field
+            class="mt-5"
+            filled
+            dense
+            single-line
+            hide-details="auto"
+            v-model.number="camera.fpsidletarget"
+            :rules="[rules.required]"
+          ></v-text-field>
+        </app-setting>
+
+        <v-divider v-if="camera.type === 'mjpgadaptive'" />
+
         <app-setting :title="$t('app.setting.label.camera_url')">
           <v-text-field
             class="mt-5"

--- a/src/components/widgets/camera/CameraItem.vue
+++ b/src/components/widgets/camera/CameraItem.vue
@@ -141,7 +141,7 @@ export default class CameraItem extends Vue {
       this.camera &&
       this.camera.type === 'mjpgadaptive'
     ) {
-      const fpsTarget = this.camera.fpstarget || 10
+      const fpsTarget = document.hasFocus() ? (this.camera.fpstarget || 10) : (this.camera.fpsidletarget || 1)
       const end_time = performance.now()
       const current_time = end_time - this.start_time
       this.time = (this.time * this.time_smoothing) + (current_time * (1.0 - this.time_smoothing))

--- a/src/components/widgets/camera/CameraItem.vue
+++ b/src/components/widgets/camera/CameraItem.vue
@@ -123,6 +123,7 @@ export default class CameraItem extends Vue {
         const hostUrl = new URL(document.URL)
         const url = new URL(this.cameraUrl, hostUrl.origin)
         url.searchParams.set('cacheBust', this.refresh.toString())
+        this.request_start_time = performance.now()
         this.cameraUrl = url.toString()
       })
     } else {

--- a/src/locales/de.yaml
+++ b/src/locales/de.yaml
@@ -281,6 +281,7 @@ app:
       enable: Aktivieren
       enable_notifications: Aktiviere Benachrichtigung
       fps_target: FPS Ziel
+      fps_idle_target: FPS Ziel im Ruhezustand
       gcode_coords: GCode Koordinaten verwenden
       invert_x_control: X-Steuerung invertieren
       invert_y_control: Y-Steuerung invertieren

--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -363,6 +363,7 @@ app:
       flip_horizontal: Horizontal Flip
       flip_vertical: Vertical Flip
       fps_target: FPS Target
+      fps_idle_target: FPS Target when not in focus
       height: Height
       gcode_coords: Use GCode Coordinates
       invert_x_control: Invert X control

--- a/src/store/cameras/types.ts
+++ b/src/store/cameras/types.ts
@@ -10,6 +10,7 @@ export interface CameraConfig {
   type: 'mjpgadaptive' | 'mjpgstream' | 'ipstream' | 'iframe';
   url: string;
   fpstarget?: number;
+  fpsidletarget?: number;
   flipX: boolean;
   flipY: boolean;
   height?: number;


### PR DESCRIPTION
Implementation of FR "Lower FPS when not focused" (closes #314)
Also fixes broken frame request scheduler (https://github.com/fluidd-core/fluidd/commit/f5ad536ffd8b78f702639812116439acc3d08486)

Example image showing two cameras idling with their idle FPS to 5fps and 1fps:
![image](https://user-images.githubusercontent.com/25269274/151718263-147e085c-83e0-48e9-a70f-07fc74fdbf1f.png)

Camera settings:
![image](https://user-images.githubusercontent.com/25269274/151718272-322f3991-8914-41b7-8433-ea3bd513289e.png)
