### PR TITLE
fix: keep camera select menu always enabled

### DIFF
--- a/src/components/widgets/camera/CameraMenu.vue
+++ b/src/components/widgets/camera/CameraMenu.vue
@@ -8,7 +8,6 @@
   >
   <template v-slot:activator="{ on, attrs, value }">
     <app-btn
-      :disabled="!klippyReady"
       v-bind="attrs" v-on="on"
       small
     >


### PR DESCRIPTION
This leaves the camera select menu enabled even when klipper is disconnected.

For issue: https://github.com/fluidd-core/fluidd/issues/470