### PR TITLE
feat: show klipper warnings

### DIFF
--- a/src/components/common/AppWarnings.vue
+++ b/src/components/common/AppWarnings.vue
@@ -9,6 +9,13 @@
       </ul>
     </div>
 
+    <div v-if="klipperWarnings.length > 0">
+      <div class="mb-2">{{ $t('app.general.error.app_warnings_found', { appName: 'Klipper' }) }}</div>
+      <ul class="mb-4">
+        <li v-for="(warning, index) in klipperWarnings" :key="index" v-html="warning.message"></li>
+      </ul>
+    </div>
+
     <div v-if="moonrakerFailedComponents.length > 0">
       <div class="mb-2">{{ $t('app.general.error.failed_components') }}</div>
       <ul class="mb-4">
@@ -67,6 +74,10 @@ export default class AppWarnings extends Mixins(StateMixin) {
 
   get printerWarnings () {
     return this.$store.getters['printer/getPrinterWarnings']
+  }
+
+  get klipperWarnings () {
+    return this.$store.getters['printer/getKlipperWarnings']
   }
 
   get moonrakerFailedComponents () {

--- a/src/store/printer/getters.ts
+++ b/src/store/printer/getters.ts
@@ -576,7 +576,8 @@ export const getters: GetterTree<PrinterState, RootState> = {
   getHasWarnings: (state, getters, rootState) => {
     if (
       (rootState.socket && rootState.socket.open && rootState.socket.ready) &&
-      (getters.getPrinterWarnings.length > 0 || getters.getMoonrakerFailedComponents.length > 0 || getters.getMoonrakerWarnings.length > 0)
+      (getters.getPrinterWarnings.length > 0 || getters.getKlipperWarnings.length > 0 ||
+        getters.getMoonrakerFailedComponents.length > 0 || getters.getMoonrakerWarnings.length > 0)
     ) {
       return true
     } else {
@@ -607,6 +608,10 @@ export const getters: GetterTree<PrinterState, RootState> = {
       warnings.push({ message: 'CANCEL_PRINT macro not found in configuration.' })
     }
     return warnings
+  },
+
+  getKlipperWarnings: (state) => {
+    return state.printer?.configfile?.warnings || []
   },
 
   getMoonrakerFailedComponents: (state, getters, rootState, rootGetters) => {

--- a/src/store/printer/index.ts
+++ b/src/store/printer/index.ts
@@ -23,6 +23,7 @@ export const defaultState = (): PrinterState => {
         state_message: ''
       },
       configfile: {
+        warnings: [],
         save_config_pending: false,
         config: {
           virtual_sdcard: {},


### PR DESCRIPTION
Here's an example for a deprecated configuration option.

![image](https://user-images.githubusercontent.com/85504/152208868-c89884f2-a38e-4a17-80df-c7a2815169b4.png)

I haven't added any link back to Klipper docs but want to put that into consideration before merging this PR!

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>