### PR TITLE
fix: websocket cache issue (arrayMerge)

### DIFF
--- a/src/plugins/socketClient.ts
+++ b/src/plugins/socketClient.ts
@@ -164,7 +164,7 @@ export class WebSocketClient {
                   : new Date().getTime()
                 this.cache = (!this.cache)
                   ? { timestamp: date, params: d.params[0] }
-                  : { timestamp: this.cache.timestamp, params: deepMerge(this.cache.params, d.params[0]) }
+                  : { timestamp: this.cache.timestamp, params: deepMerge(this.cache.params, d.params[0], { arrayMerge: (x, y) => y }) }
 
                 // If there's a second or more difference, flush the cache.
                 if (this.cache && date - this.cache.timestamp >= 1000) {


### PR DESCRIPTION
- DeepMerge was appending the array instead of merging.

Thanks @pedrolamas

Signed-of-by: Biorn <biorn@me.com>