### PR TITLE
fix: revert ECharts changes previously introduced

### DIFF
--- a/src/components/ui/AppChart.vue
+++ b/src/components/ui/AppChart.vue
@@ -10,7 +10,7 @@
         ref="chart"
         :option="opts"
         :setOptionOps="{ notMerge: true }"
-        :init-options="{ renderer: 'svg' }"
+        :initOpts="{ renderer: 'svg' }"
         :events="events"
       >
       </ECharts>

--- a/src/components/widgets/bedmesh/BedMeshChart.vue
+++ b/src/components/widgets/bedmesh/BedMeshChart.vue
@@ -4,7 +4,7 @@
       ref="chart"
       :option="opts"
       :setOptionOps="{ notMerge: false }"
-      :init-options="{ renderer: 'canvas' }"
+      :initOpts="{ renderer: 'canvas' }"
     >
     </ECharts>
 

--- a/src/components/widgets/thermals/ThermalChart.vue
+++ b/src/components/widgets/thermals/ThermalChart.vue
@@ -5,7 +5,7 @@
       style="overflow: initial;"
       :option="options"
       :setOptionOps="{ notMerge: true }"
-      :init-options="{ renderer: 'svg' }"
+      :initOpts="{ renderer: 'svg' }"
       :events="[
         ['legendselectchanged', handleLegendSelectChange ]
       ]"


### PR DESCRIPTION
These were introduced as part of the work for Node 16 support, but we've now come to realize that not only are they not needed, but they are also creating a layout issue on the charts.

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>