### PR TITLE
feat: option to flip console direction

### DIFF
--- a/src/components/widgets/console/Console.vue
+++ b/src/components/widgets/console/Console.vue
@@ -1,6 +1,12 @@
 <template>
   <div
     class="console">
+    <console-command
+      v-if="!readonly && flipLayout"
+      v-model="consoleCommand"
+      @send="sendCommand"
+    >
+    </console-command>
     <v-card
       flat
       class="console-wrapper"
@@ -36,7 +42,7 @@
       </DynamicScroller>
     </v-card>
     <console-command
-      v-if="!readonly"
+      v-if="!readonly && !flipLayout"
       v-model="consoleCommand"
       @send="sendCommand"
     >
@@ -83,6 +89,10 @@ export default class Console extends Mixins(StateMixin) {
 
   set consoleCommand (val: string) {
     this.$store.commit('console/setConsoleCommand', val)
+  }
+
+  get flipLayout (): boolean {
+    return this.$store.state.config.uiSettings.general.flipConsoleLayout
   }
 
   mounted () {

--- a/src/components/widgets/console/Console.vue
+++ b/src/components/widgets/console/Console.vue
@@ -80,6 +80,7 @@ export default class Console extends Mixins(StateMixin) {
   @Ref('scroller') dynamicScroller: any
 
   _lastScroll = 0
+  _lastHeight = 0
   _pauseScroll = false
 
   get availableCommands () {
@@ -127,6 +128,14 @@ export default class Console extends Mixins(StateMixin) {
       val.length !== oldVal.length
     ) {
       this.scrollToLatest()
+      if (this.dynamicScroller) {
+        if (this.flipLayout && this._pauseScroll) {
+          const el = this.dynamicScroller.$el
+          el.scrollTop += el.scrollHeight - this._lastHeight
+        }
+
+        this._lastHeight = this.dynamicScroller.$el.scrollHeight
+      }
     }
   }
 

--- a/src/components/widgets/console/Console.vue
+++ b/src/components/widgets/console/Console.vue
@@ -14,9 +14,9 @@
     >
       <DynamicScroller
         ref="scroller"
-        :items="items"
+        :items="flipLayout ? [...items].reverse() : items"
         :min-item-size="24"
-        @resize="scrollToBottom()"
+        @resize="scrollToLatest()"
         :style="{ height: height + 'px' }"
         :key-field="keyField"
         :buffer="600"
@@ -98,9 +98,13 @@ export default class Console extends Mixins(StateMixin) {
     return this.$store.state.config.uiSettings.general.flipConsoleLayout
   }
 
+  set flipLayout (_) {
+    this.scrollToLatest(true)
+  }
+
   mounted () {
     this.$nextTick(() => {
-      this.scrollToBottom()
+      this.scrollToLatest()
       this.watchScroll()
     })
   }
@@ -122,7 +126,7 @@ export default class Console extends Mixins(StateMixin) {
       (item.id !== oldItem.id) ||
       val.length !== oldVal.length
     ) {
-      this.scrollToBottom()
+      this.scrollToLatest()
     }
   }
 
@@ -149,20 +153,17 @@ export default class Console extends Mixins(StateMixin) {
     })
   }
 
-  scrollToBottom (force?: boolean) {
+  scrollToLatest (force?: boolean) {
     // If we have auto scroll turned off, then don't do this
-    // unless it's readonly.
+    // unless it's readonly or forced.
     if (this.dynamicScroller) {
-      if (force) {
-        this.dynamicScroller.scrollToBottom()
-        return
-      }
-      if (this._pauseScroll) return
+      if (this._pauseScroll && !force) return
       if (
         this.$store.state.console.autoScroll ||
-        this.readonly
+        this.readonly ||
+        force
       ) {
-        this.dynamicScroller.scrollToBottom()
+        this.dynamicScroller[this.flipLayout ? 'scrollToElement' : 'scrollToBottom'](0)
       }
     }
   }

--- a/src/components/widgets/console/Console.vue
+++ b/src/components/widgets/console/Console.vue
@@ -140,16 +140,16 @@ export default class Console extends Mixins(StateMixin) {
   watchScroll () {
     this.dynamicScroller.$el.addEventListener('scroll', (e: any) => {
       const el = e.target
-      if (el.scrollTop < this._lastScroll) {
+      if (this.flipLayout ? (el.scrollTop > this._lastScroll) : (el.scrollTop < this._lastScroll)) {
         this.updateScrollingPaused(true)
       } else {
         if (this._pauseScroll) {
-          if (el.scrollHeight - el.scrollTop - el.clientHeight < 1) {
+          if (this.flipLayout ? (el.scrollTop < 1) : (el.scrollHeight - el.scrollTop - el.clientHeight < 1)) {
             this.updateScrollingPaused(false)
           }
         }
       }
-      this._lastScroll = el.scrollTop <= 0 ? 0 : el.scrollTop
+      this._lastScroll = el.scrollTop
     })
   }
 
@@ -163,7 +163,8 @@ export default class Console extends Mixins(StateMixin) {
         this.readonly ||
         force
       ) {
-        this.dynamicScroller[this.flipLayout ? 'scrollToElement' : 'scrollToBottom'](0)
+        this.dynamicScroller[this.flipLayout ? 'scrollToItem' : 'scrollToBottom'](0)
+        this.updateScrollingPaused(false)
       }
     }
   }

--- a/src/components/widgets/console/ConsoleCard.vue
+++ b/src/components/widgets/console/ConsoleCard.vue
@@ -41,6 +41,14 @@
           class="mx-2 mb-2"
         >
         </v-checkbox>
+        <v-checkbox
+          v-model="flipLayout"
+          :label="$t('app.console.label.flip_layout')"
+          color="primary"
+          hide-details
+          class="mx-2 mb-2"
+        >
+        </v-checkbox>
 
         <template v-for="(filter, index) in filters">
           <v-divider
@@ -96,6 +104,18 @@ export default class ConsoleCard extends Mixins(StateMixin) {
   set hideTempWaits (value: boolean) {
     this.$store.dispatch('config/saveByPath', {
       path: 'uiSettings.general.hideTempWaits',
+      value,
+      server: true
+    })
+  }
+
+  get flipLayout (): boolean {
+    return this.$store.state.config.uiSettings.general.flipConsoleLayout
+  }
+
+  set flipLayout (value: boolean) {
+    this.$store.dispatch('config/saveByPath', {
+      path: 'uiSettings.general.flipConsoleLayout',
       value,
       server: true
     })

--- a/src/components/widgets/console/ConsoleCard.vue
+++ b/src/components/widgets/console/ConsoleCard.vue
@@ -27,7 +27,7 @@
         @click="console.scrollToLatest(true)"
         color=""
         fab x-small text>
-        <v-icon>$down</v-icon>
+        <v-icon>{{flipLayout ? '$up' : '$down'}}</v-icon>
       </app-btn>
 
       <app-btn-collapse-group

--- a/src/components/widgets/console/ConsoleCard.vue
+++ b/src/components/widgets/console/ConsoleCard.vue
@@ -24,7 +24,7 @@
 
       <app-btn
         v-if="scrollingPaused"
-        @click="console.scrollToBottom(true)"
+        @click="console.scrollToLatest(true)"
         color=""
         fab x-small text>
         <v-icon>$down</v-icon>
@@ -131,6 +131,8 @@ export default class ConsoleCard extends Mixins(StateMixin) {
       value,
       server: true
     })
+
+    this.console.flipLayout = value
   }
 
   get items (): ConsoleEntry[] {
@@ -148,20 +150,20 @@ export default class ConsoleCard extends Mixins(StateMixin) {
   set autoScroll (value: boolean) {
     this.$store.dispatch('console/onUpdateAutoScroll', value)
     if (value) {
-      this.console.scrollToBottom()
+      this.console.scrollToLatest()
     }
   }
 
   @Watch('inLayout')
   inLayoutChange (inLayout: boolean) {
     if (!inLayout) {
-      this.console.scrollToBottom()
+      this.console.scrollToLatest()
     }
   }
 
   handleCollapseChange (collapsed: boolean) {
     if (!collapsed) {
-      this.console.scrollToBottom()
+      this.console.scrollToLatest()
     }
   }
 }

--- a/src/locales/de.yaml
+++ b/src/locales/de.yaml
@@ -38,6 +38,7 @@ app:
   console:
     label:
       auto_scroll: Automatisches Scrollen
+      flip_layout: Layout umkehren
       hide_temp_waits: Temperaturbenachrichtigungen ausblenden
     placeholder:
       command: >-

--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -37,6 +37,7 @@ app:
   console:
     label:
       auto_scroll: Auto scroll
+      flip_layout: Flip layout
       hide_temp_waits: Hide temp waits
     placeholder:
       command: '''tab'' for autocomplete, ''help'' for commands ''arrows'' for history'

--- a/src/store/config/index.ts
+++ b/src/store/config/index.ts
@@ -56,7 +56,8 @@ export const defaultState = (): ConfigState => {
         confirmOnEstop: false,
         confirmOnPowerDeviceChange: false,
         dateformat: 'MMM. DD,',
-        timeformat: 'hh:mm a'
+        timeformat: 'hh:mm a',
+        flipConsoleLayout: false
       },
       theme: {
         isDark: true,

--- a/src/store/config/types.ts
+++ b/src/store/config/types.ts
@@ -51,6 +51,7 @@ export interface GeneralConfig {
   confirmOnPowerDeviceChange: boolean;
   dateformat: string;
   timeformat: string;
+  flipConsoleLayout: boolean;
 }
 
 // Config stored in moonraker db


### PR DESCRIPTION
Adds an option to move the console input field to the top of the console widget.
Not sure if the log direction should be flipped too (most recent at top), and if "Flip layout" is the right wording here.
Closes #511