### PR TITLE
fix: improves macro param default value handling

### DIFF
--- a/src/components/ui/AppMacroBtn.vue
+++ b/src/components/ui/AppMacroBtn.vue
@@ -124,12 +124,12 @@ export default class AppMacroBtn extends Mixins(StateMixin) {
   mounted () {
     if (!this.macro.config || !this.macro.config.gcode) return []
     if (this.macro.config.gcode) {
-      const regex = /params\.(\w*)\|?(default\('?(\w*)'?\))?/gmi
+      const regex = /params\.(\w+).*\|\s*default\s*\(\s*([^,)]+)/gmi
       let match = regex.exec(this.macro.config.gcode)
       do {
         if (match && match[1]) {
           const name = match[1]
-          const value = match[3] || ''
+          const value = (match[2] || '').trim()
           if (!this.params[name]) {
             this.$set(this.params, name, { value, reset: value })
           }


### PR DESCRIPTION
Improves the regular expression used to detect macro parameter defaults. This should be a bit more permissive with white-space and multiple params on the Jinja2 `default` function.

Tested with the following example:

```txt
[gcode_macro TEST]
gcode:
  {% set A = params.A | default(0, true) | float %}
  {% set B = params.B | int | default(0.005, true) | float %}
  {% set C = params.C | default("PLA", true) %}
  {% set D = params.D | default("PLA") %}
  {% set E = params.E | int | default(0.2) %}
```

The above example macro will show like this:

![image](https://user-images.githubusercontent.com/85504/154721987-24edb30e-e677-4b93-a485-60b34ba380d4.png)

Fixes #376 

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>