### PR TITLE
feat: TURN_OFF_HEATERS confirmation in temperature presets

### DIFF
--- a/src/components/widgets/thermals/TemperatureCard.vue
+++ b/src/components/widgets/thermals/TemperatureCard.vue
@@ -166,7 +166,18 @@ export default class TemperatureCard extends Mixins(StateMixin) {
     }
   }
 
-  handleApplyOff () {
+  async handleApplyOff () {
+    if (this.$store.getters['printer/getPrinterState'] === 'busy') {
+      const result = await this.$confirm(
+        this.$tc('app.general.label.heaters_busy'),
+        { title: this.$tc('app.general.simple_form.msg.confirm'), color: 'card-heading', icon: '$error' }
+      )
+
+      if (!result) {
+        return
+      }
+    }
+
     this.sendGcode('TURN_OFF_HEATERS')
   }
 }

--- a/src/components/widgets/thermals/TemperatureCard.vue
+++ b/src/components/widgets/thermals/TemperatureCard.vue
@@ -167,7 +167,7 @@ export default class TemperatureCard extends Mixins(StateMixin) {
   }
 
   async handleApplyOff () {
-    if (this.$store.getters['printer/getPrinterState'] === 'busy') {
+    if (['printing', 'busy', 'paused'].includes(this.$store.getters['printer/getPrinterState'])) {
       const result = await this.$confirm(
         this.$tc('app.general.label.heaters_busy'),
         { title: this.$tc('app.general.simple_form.msg.confirm'), color: 'card-heading', icon: '$error' }

--- a/src/locales/de.yaml
+++ b/src/locales/de.yaml
@@ -208,6 +208,9 @@ app:
       finish_time: Fertig um
       flow: Flow
       free: frei
+      heaters_busy: >-
+        Der Drucker ist momentan beschäftigt.
+        Das Ausschalten der Heizelemente könnte zu einem fehlgeschlagenen Druck führen.
       high: Höchste
       host: Host
       layer: Schicht

--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -206,6 +206,7 @@ app:
       finish_time: Finish
       flow: Flow
       free: free
+      heaters_busy: The printer is currently busy. Turning off the heaters may result in a failed print.
       high: High
       host: Host
       layer: Layer


### PR DESCRIPTION
As requested by NewCalJs in the Discord server.
Adds a confirmation modal to the `Heaters off` button under temperature presets when the printer is busy.
![image](https://user-images.githubusercontent.com/25269274/154813697-d6130ff7-edf1-4247-9d72-ffdaef046883.png)
