### PR TITLE
fix: service state item layout balance

### DIFF
--- a/src/components/common/SystemCommands.vue
+++ b/src/components/common/SystemCommands.vue
@@ -238,8 +238,9 @@ export default class SystemCommands extends Mixins(StateMixin, ServicesMixin) {
 
 <style lang="scss" scoped>
   ::v-deep .v-list-item__action--stack  {
-    margin: 6px 0;
+    margin: 2px 0;
     margin-right: -6px;
     flex-direction: row;
+    align-items: center;
   }
 </style>


### PR DESCRIPTION
This is minor issue, but it was bugging me and I decided to fix it anyway...

With #504 we now have the possibility to start/restart/stop services, but as vuetify doesn't support multiple horizontal buttons on a single list item, we had to style it ourselves.

There was a minor issue with margins and item alignment that was causing the list item layout to become unbalanced when compared to the rest of the list.

![image](https://user-images.githubusercontent.com/85504/155184727-e75c4e32-bce0-4baa-87d7-746e26671ca8.png)

On the above image, the issue is mostly noticeable on the space between "Services" label and "Klipper" just below it, but with more services it becomes even more prominent

This PR fixes this minor issue.

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>