### PR TITLE
fix: add missing default for idle fps input

### DIFF
--- a/src/components/settings/cameras/Cameras.vue
+++ b/src/components/settings/cameras/Cameras.vue
@@ -90,6 +90,7 @@ export default class CameraSettings extends Vue {
       name: '',
       type: 'mjpgadaptive',
       fpstarget: 15,
+      fpsidletarget: 5,
       url: Globals.DEFAULTS.CAMERA_URL
     }
 

--- a/src/store/cameras/index.ts
+++ b/src/store/cameras/index.ts
@@ -16,6 +16,7 @@ export const defaultState = (): CamerasState => {
         name: 'Default',
         type: 'mjpgadaptive',
         fpstarget: 15,
+        fpsidletarget: 5,
         url: '/webcam/?action=stream',
         flipX: false,
         flipY: false,


### PR DESCRIPTION
Adds the missing type and default value for the "FPS Target when not in focus" input field in the "Add Camera" dialog