### PR TITLE
fix: filename wrap in status window

### DIFF
--- a/src/components/widgets/status/StatusLabel.vue
+++ b/src/components/widgets/status/StatusLabel.vue
@@ -30,13 +30,10 @@ export default class AppSwitch extends Mixins(StateMixin) {
   }
 
   span.value {
-    // flex: 0 0 auto;
-    // min-width: 0;
     > span {
       display: block;
-      // white-space: nowrap;
       overflow: hidden;
-      word-break: break-all;
+      text-overflow: ellipsis;
     }
   }
 </style>

--- a/src/components/widgets/status/StatusLabel.vue
+++ b/src/components/widgets/status/StatusLabel.vue
@@ -37,7 +37,6 @@ export default class AppSwitch extends Mixins(StateMixin) {
       // white-space: nowrap;
       overflow: hidden;
       word-break: break-all;
-      width: auto;
     }
   }
 </style>

--- a/src/components/widgets/status/StatusLabel.vue
+++ b/src/components/widgets/status/StatusLabel.vue
@@ -35,7 +35,6 @@ export default class AppSwitch extends Mixins(StateMixin) {
     > span {
       display: block;
       // white-space: nowrap;
-      text-overflow: ellipsis;
       overflow: hidden;
       word-break: break-all;
       width: auto;

--- a/src/components/widgets/status/StatusLabel.vue
+++ b/src/components/widgets/status/StatusLabel.vue
@@ -37,7 +37,8 @@ export default class AppSwitch extends Mixins(StateMixin) {
       // white-space: nowrap;
       text-overflow: ellipsis;
       overflow: hidden;
-      text-overflow: ellipsis;
+      word-break: break-all;
+      width: auto;
     }
   }
 </style>

--- a/src/components/widgets/status/StatusTab.vue
+++ b/src/components/widgets/status/StatusTab.vue
@@ -54,7 +54,7 @@
               </status-label>
 
               <status-label :label="$t('app.general.label.file')" v-if="filename !== ''">
-                <span>{{ filename }}</span>
+                <span style="word-break: break-all">{{ filename }}</span>
               </status-label>
             </v-col>
           </v-row>


### PR DESCRIPTION
This issue has bothered me for some time and I figured I would attempt to fix it. If this is not the "best" way to do this please let me know. Tested in several browsers and iOS 15.

**Before the changes:**
<img width="887" alt="Screen Shot 2022-02-27 at 8 07 15 PM" src="https://user-images.githubusercontent.com/2241731/155908786-9d1955f6-34ff-4619-967c-53cf6a9da4ce.png">
<img width="493" alt="Screen Shot 2022-02-27 at 8 07 29 PM" src="https://user-images.githubusercontent.com/2241731/155908795-619802ad-8330-4321-8056-d973844dcfcd.png">

**After the changes:**
<img width="882" alt="Screen Shot 2022-02-27 at 8 04 53 PM" src="https://user-images.githubusercontent.com/2241731/155908809-7e65f2cf-7e8f-43ba-a7e2-9247da408141.png">
<img width="489" alt="Screen Shot 2022-02-27 at 8 04 39 PM" src="https://user-images.githubusercontent.com/2241731/155908826-b1697e11-12d1-44c7-83bd-88693a070576.png">

Signed-off-by: Phillip Hernandez samwiseg00@gmail.com