### PR TITLE
fix: emergency stop button outside iphone safe zone

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -29,6 +29,7 @@
       fab
       fixed
       bottom left
+      class="ml-2 mb-2"
       color="error"
       @click="emergencyStop()"
     >


### PR DESCRIPTION
Simply adds a 8px margin to the left and bottom of the emergency stop button, moving it back into the iPhone safe area

before:
![old](https://user-images.githubusercontent.com/25269274/156045765-665aab97-9969-4222-a92d-927ab55e442c.png)

after:
![new](https://user-images.githubusercontent.com/25269274/156045768-01654d4c-7f36-4583-8dec-d7c7e8fe1a96.png)

Closes #405