### PR TITLE
fix: idle fps behavior

### DIFF
--- a/src/components/settings/cameras/CameraConfigDialog.vue
+++ b/src/components/settings/cameras/CameraConfigDialog.vue
@@ -129,7 +129,6 @@
             single-line
             hide-details="auto"
             v-model.number="camera.fpsidletarget"
-            :rules="[rules.required]"
           ></v-text-field>
         </app-setting>
 

--- a/src/components/widgets/camera/CameraItem.vue
+++ b/src/components/widgets/camera/CameraItem.vue
@@ -166,7 +166,7 @@ export default class CameraItem extends Vue {
       this.camera &&
       this.camera.type === 'mjpgadaptive'
     ) {
-      const fpsTarget = document.hasFocus() ? (this.camera.fpstarget || 10) : (this.camera.fpsidletarget || 1)
+      const fpsTarget = (!document.hasFocus() && this.camera.fpsidletarget) || this.camera.fpstarget || 10
       const end_time = performance.now()
       const current_time = end_time - this.start_time
       this.time = (this.time * this.time_smoothing) + (current_time * (1.0 - this.time_smoothing))


### PR DESCRIPTION
Fixes some user complaints on the Discord:
* idle fps input is no longer required
* idle fps default to fps target to restore previous behavior