### PR TITLE
docs: moonraker config refactor

### DIFF
--- a/docs/configuration/moonraker.md
+++ b/docs/configuration/moonraker.md
@@ -38,6 +38,7 @@ provide a gracefull upgrade path in order to re-arrange all of your logs into
 the same place for this to be most benifical.
 
 ```yaml
+[file_manager]
 log_path: ~/klipper_logs
 ```
 
@@ -54,6 +55,7 @@ Temperature store size is in seconds, while the gcode store size is defined
 in an entry count.
 
 ```yaml
+[data_store]
 temperature_store_size: 600
 gcode_store_size: 1000
 ```

--- a/docs/configuration/moonraker.md
+++ b/docs/configuration/moonraker.md
@@ -30,18 +30,20 @@ and
 This configures the general configuration of your moonraker instance. In most
 cases, you shouldn't need to touch anything here.
 
+## [file_manager] block
+
 If you have a FluiddPI installation of `1.14` or below, it may be worth adding a
 logs path, which will expose all logs inside of Fluidd. [KIUAH](/installation/kiauh) can
 provide a gracefull upgrade path in order to re-arrange all of your logs into
 the same place for this to be most benifical.
 
-```sh
+```yaml
 log_path: ~/klipper_logs
 ```
 
 See the [configuration example](/configuration/moonraker_conf) where this belongs.
 
-### Temperature & GCODE store size
+## [data_store] block
 
 Temperature and gcode store sizes can be configured in moonraker.
 This is especially useful for temperature store data, as it

--- a/docs/configuration/moonraker_conf.md
+++ b/docs/configuration/moonraker_conf.md
@@ -19,10 +19,14 @@ Your moonraker configuration can usually be found here: `~/klipper_config/moonra
 host: 0.0.0.0
 port: 7125
 enable_debug_logging: False
+
+[file_manager]
 config_path: ~/klipper_config
+log_path: ~/klipper_logs
+
+[data_store]
 temperature_store_size: 600
 gcode_store_size: 1000
-log_path: ~/klipper_logs
 
 [authorization]
 force_logins: true


### PR DESCRIPTION
## Description

Moonraker changed configuration structure some time ago. fluidd was only using `server` part which is now in `data_store` and `file_manager`,...

I removed code part of changing things which are solved https://github.com/fluidd-core/fluidd/pull/555 and only left docs part