### PR TITLE
fix: use correct temperature_store_size for temps

### DIFF
--- a/src/components/widgets/thermals/ThermalChart.vue
+++ b/src/components/widgets/thermals/ThermalChart.vue
@@ -204,8 +204,8 @@ export default class ThermalChart extends Vue {
         boundaryGap: false,
         max: 'dataMax',
         min: (value: any) => {
-          const serverConfig = this.$store.getters['server/getConfig']
-          return value.max - (serverConfig.server.temperature_store_size * 1000)
+          const temperature_store_size = this.$store.getters['charts/getChartRetention']
+          return value.max - (temperature_store_size * 1000)
         },
         axisTick: {
           show: false

--- a/src/store/charts/getters.ts
+++ b/src/store/charts/getters.ts
@@ -25,12 +25,9 @@ export const getters: GetterTree<ChartState, RootState> = {
    */
   getChartRetention: (state, getters, rootState, rootGetters) => {
     const config = rootGetters['server/getConfig']
-    return (
-      'server' in config &&
-      'temperature_store_size' in config.server
-    )
-      ? config.server.temperature_store_size
-      : Globals.CHART_HISTORY_RETENTION
+    return config.data_store?.temperature_store_size ??
+      config.server?.temperature_store_size ??
+      Globals.CHART_HISTORY_RETENTION
   },
 
   /**

--- a/src/store/printer/actions.ts
+++ b/src/store/printer/actions.ts
@@ -145,9 +145,11 @@ export const actions: ActionTree<PrinterState, RootState> = {
       }
 
       // Add a temp chart entry
-      const retention = (rootState.server)
-        ? rootState.server.config.server.temperature_store_size
-        : Globals.CHART_HISTORY_RETENTION
+      const rootStateServerConfig = rootState.server?.config
+      const retention =
+        rootStateServerConfig?.data_store?.temperature_store_size ??
+        rootStateServerConfig?.server?.temperature_store_size ??
+        Globals.CHART_HISTORY_RETENTION
       handleAddChartEntry(retention, getters.getChartableSensors)
     }
   }

--- a/src/store/server/index.ts
+++ b/src/store/server/index.ts
@@ -21,10 +21,7 @@ export const defaultState = (): ServerState => {
       authorization: {
         enabled: true
       },
-      server: {
-        gcode_store_size: 1000,
-        temperature_store_size: 1200
-      }
+      server: {}
     },
     moonraker_stats: [],
     throttled_state: {

--- a/src/store/server/types.ts
+++ b/src/store/server/types.ts
@@ -113,6 +113,6 @@ export interface ServerConfiguration {
 }
 
 export interface DataStoreConfiguration {
-  gcode_store_size: number;
-  temperature_store_size: number;
+  gcode_store_size?: number;
+  temperature_store_size?: number;
 }

--- a/src/store/server/types.ts
+++ b/src/store/server/types.ts
@@ -100,6 +100,7 @@ export interface DistroVersionParts {
 export interface ServerConfig {
   authorization: ServerAuthorization;
   server: ServerConfiguration;
+  data_store?: DataStoreConfiguration;
 }
 
 export interface ServerAuthorization {
@@ -107,6 +108,11 @@ export interface ServerAuthorization {
 }
 
 export interface ServerConfiguration {
+  gcode_store_size?: number;
+  temperature_store_size?: number;
+}
+
+export interface DataStoreConfiguration {
   gcode_store_size: number;
   temperature_store_size: number;
 }


### PR DESCRIPTION
We were lucky as @majcn found the problem was with the `temperature_store_size` (it can be in either `data_store` or `server`)

I've managed to confirm and reproduce the incorrect behavior, and this PR should fix the problem completely.

Special thanks also to @BeardedTinker and @Arksine for helping with this issue.

Fixes #453

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>