### PR TITLE
chore: removes unused vuex-class dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -101,7 +101,6 @@
         "vue-jest": "^3.0.7",
         "vue-template-compiler": "^2.6.14",
         "vuetify-loader": "^1.7.2",
-        "vuex-class": "^0.3.2",
         "webpack-bundle-analyzer": "^4.4.2",
         "yaml-loader": "^0.6.0"
       },
@@ -31696,17 +31695,6 @@
         "vue": "^2.0.0"
       }
     },
-    "node_modules/vuex-class": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/vuex-class/-/vuex-class-0.3.2.tgz",
-      "integrity": "sha512-m0w7/FMsNcwJgunJeM+wcNaHzK2KX1K1rw2WUQf7Q16ndXHo7pflRyOV/E8795JO/7fstyjH3EgqBI4h4n4qXQ==",
-      "dev": true,
-      "peerDependencies": {
-        "vue": "^2.5.0",
-        "vue-class-component": "^6.0.0 || ^7.0.0",
-        "vuex": "^3.0.0"
-      }
-    },
     "node_modules/w3c-hr-time": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
@@ -58450,13 +58438,6 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/vuex/-/vuex-3.6.2.tgz",
       "integrity": "sha512-ETW44IqCgBpVomy520DT5jf8n0zoCac+sxWnn+hMe/CzaSejb/eVw2YToiXYX+Ex/AuHHia28vWTq4goAexFbw==",
-      "requires": {}
-    },
-    "vuex-class": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/vuex-class/-/vuex-class-0.3.2.tgz",
-      "integrity": "sha512-m0w7/FMsNcwJgunJeM+wcNaHzK2KX1K1rw2WUQf7Q16ndXHo7pflRyOV/E8795JO/7fstyjH3EgqBI4h4n4qXQ==",
-      "dev": true,
       "requires": {}
     },
     "w3c-hr-time": {

--- a/package.json
+++ b/package.json
@@ -123,7 +123,6 @@
     "vue-jest": "^3.0.7",
     "vue-template-compiler": "^2.6.14",
     "vuetify-loader": "^1.7.2",
-    "vuex-class": "^0.3.2",
     "webpack-bundle-analyzer": "^4.4.2",
     "yaml-loader": "^0.6.0"
   },


### PR DESCRIPTION
There is no reference to the [vuex-class](https://www.npmjs.com/package/vuex-class) package anywhere on the code (in fact, from what I can see on the package instructions, we have it incorrectly added as a dev dependency when it should be a regular one), so I'm removing it here.

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>