### PR TITLE
chore: removes deprecated vue-headful dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,6 @@
         "vue-class-component": "^7.2.3",
         "vue-debounce-decorator": "^1.0.1",
         "vue-echarts": "^6.0.2",
-        "vue-headful": "^2.1.0",
         "vue-i18n": "^8.24.5",
         "vue-inline-svg": "^2.0.0",
         "vue-meta": "^2.4.0",
@@ -15674,12 +15673,6 @@
       "bin": {
         "he": "bin/he"
       }
-    },
-    "node_modules/headful": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/headful/-/headful-1.0.3.tgz",
-      "integrity": "sha512-vF9Vfddn1QWmziliht2mji6ayI78+hUuSC+Kt0GEqLw/51zWgi1KF7oLtIQf3nlkg8sQQOlznkkIaF4W9lIt9w==",
-      "deprecated": "Project will no longer receive updates."
     },
     "node_modules/hex-color-regex": {
       "version": "1.1.0",
@@ -31431,18 +31424,6 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/vue-headful": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/vue-headful/-/vue-headful-2.1.0.tgz",
-      "integrity": "sha512-HXMdJfVDgD3eoh8qk9Laz2wGraPVGYDbvfXd7+i1MVziWMXGHUm8gpRC2p11ugYYXKRAcaS2g6ycq4Pr+eqb7g==",
-      "deprecated": "Please use 'vue-meta' instead.",
-      "dependencies": {
-        "headful": "^1.0.3"
-      },
-      "peerDependencies": {
-        "vue": "2.x"
-      }
-    },
     "node_modules/vue-hot-reload-api": {
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/vue-hot-reload-api/-/vue-hot-reload-api-2.3.4.tgz",
@@ -45698,11 +45679,6 @@
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
     },
-    "headful": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/headful/-/headful-1.0.3.tgz",
-      "integrity": "sha512-vF9Vfddn1QWmziliht2mji6ayI78+hUuSC+Kt0GEqLw/51zWgi1KF7oLtIQf3nlkg8sQQOlznkkIaF4W9lIt9w=="
-    },
     "hex-color-regex": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
@@ -58221,14 +58197,6 @@
             "estraverse": "^4.1.1"
           }
         }
-      }
-    },
-    "vue-headful": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/vue-headful/-/vue-headful-2.1.0.tgz",
-      "integrity": "sha512-HXMdJfVDgD3eoh8qk9Laz2wGraPVGYDbvfXd7+i1MVziWMXGHUm8gpRC2p11ugYYXKRAcaS2g6ycq4Pr+eqb7g==",
-      "requires": {
-        "headful": "^1.0.3"
       }
     },
     "vue-hot-reload-api": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "vue-class-component": "^7.2.3",
     "vue-debounce-decorator": "^1.0.1",
     "vue-echarts": "^6.0.2",
-    "vue-headful": "^2.1.0",
     "vue-i18n": "^8.24.5",
     "vue-inline-svg": "^2.0.0",
     "vue-meta": "^2.4.0",

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,12 +1,6 @@
 <template>
   <v-app v-if="loading"></v-app>
   <v-app v-else class="fluidd">
-    <vue-headful
-      :title="pageTitle"
-      :head="pageIcon"
-    >
-    </vue-headful>
-
     <app-tools-drawer v-model="toolsdrawer"></app-tools-drawer>
     <app-nav-drawer v-model="navdrawer"></app-nav-drawer>
 
@@ -81,8 +75,19 @@ import { Component, Mixins } from 'vue-property-decorator'
 import { EventBus, FlashMessage } from '@/eventBus'
 import StateMixin from './mixins/state'
 import { Waits } from './globals'
+import { LinkPropertyHref } from 'vue-meta'
 
-@Component({})
+@Component<App>({
+  metaInfo () {
+    const pageTitle = this.pageTitle
+    const pageIcon = this.pageIcon
+
+    return {
+      title: pageTitle,
+      link: pageIcon
+    }
+  }
+})
 export default class App extends Mixins(StateMixin) {
   toolsdrawer: boolean | null = null
   navdrawer: boolean | null = null
@@ -129,7 +134,7 @@ export default class App extends Mixins(StateMixin) {
     }
   }
 
-  get pageIcon () {
+  get pageIcon (): LinkPropertyHref[] {
     let icon
     const theme = this.$store.getters['config/getTheme']
     if (this.printerPrinting) {
@@ -172,14 +177,20 @@ export default class App extends Mixins(StateMixin) {
     // Build a base64 encoded version of our svg with the correct theme color.
     const svg_xml = 'data:image/svg+xml;base64,' + btoa(`<svg width="56" height="64" viewBox="0 0 314 361" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><g transform="translate(-162.000000, -110.000000)"><path d="M234.444,327.531 L309.066,389.594 C309.906,390.313 310.81,390.928 311.759,391.436 L311.759,391.436 L311.771,391.442 L312.055,391.589 L312.163,391.643 L312.356,391.737 L312.534,391.821 L312.668,391.883 L312.902,391.987 L312.974,392.017 C314.656,392.733 316.433,393.128 318.217,393.206 L318.217,393.206 L318.278,393.209 L318.562,393.218 L318.674,393.22 L318.904,393.221 L319.104,393.22 L319.231,393.218 L319.529,393.208 L319.571,393.207 C321.359,393.128 323.142,392.733 324.829,392.013 L324.829,392.013 L324.877,391.993 L325.143,391.875 L325.244,391.829 L325.438,391.737 L325.643,391.638 L325.731,391.593 L326.012,391.447 L326.042,391.432 C326.989,390.925 327.891,390.311 328.729,389.593 L328.729,389.593 L398.493,331.574 L434.768,355.517 L318.896,470.422 L198.4,350.923 L234.444,327.531 Z M237.067,234.697 L310.465,281.908 C313.075,283.623 315.986,284.481 318.897,284.482 C321.805,284.482 324.713,283.626 327.325,281.912 L327.325,281.912 L400.727,234.702 L456.849,263.367 L318.897,378.093 L180.945,263.359 L237.067,234.697 Z M318.897,110.68 L475.771,168.448 L318.897,269.344 L162.024,168.44 L318.897,110.68 Z" id="Combined-Shape" fill="${theme.currentTheme.primaryOffset}"></path><path d="M318.897,110.68 L475.771,168.448 L319,269.278 L319,111 L318.028,111 L318.897,110.68 Z" id="Combined-Shape" fill="${theme.currentTheme.primary}"></path><path d="M400.727,234.702 L456.849,263.367 L319,378.007 L319.000106,284.481641 C321.735222,284.46261 324.467243,283.686291 326.949875,282.151021 L327.325,281.912 L400.727,234.702 Z" id="Combined-Shape" fill="${theme.currentTheme.primary}"></path><path d="M398.493,331.574 L434.768,355.517 L319,470.319 L319,393.22 L319.104,393.22 L319.231,393.218 L319.529,393.208 L319.571,393.207 C321.359,393.128 323.142,392.733 324.829,392.013 L324.829,392.013 L324.877,391.993 L325.143,391.875 L325.244,391.829 L325.438,391.737 L325.643,391.638 L325.731,391.593 L326.012,391.447 L326.042,391.432 C326.989,390.925 327.891,390.311 328.729,389.593 L328.729,389.593 L398.493,331.574 Z" id="Combined-Shape" fill="${theme.currentTheme.primary}"></path></g></svg>`)
 
-    return {
-      'link[rel="icon"][sizes="32x32"]': {
+    return [
+      {
+        rel: 'icon',
+        type: 'image/svg+xml',
+        sizes: '32x32',
         href: icon || svg_xml
       },
-      'link[rel="icon"][sizes="16x16"]': {
+      {
+        rel: 'icon',
+        type: 'image/svg+xml',
+        sizes: '16x16',
         href: icon || svg_xml
       }
-    }
+    ]
   }
 
   mounted () {
@@ -189,6 +200,16 @@ export default class App extends Mixins(StateMixin) {
       this.flashMessage.type = (payload && payload.type) || undefined
       this.flashMessage.timeout = (payload && payload.timeout !== undefined) ? payload.timeout : undefined
       this.flashMessage.open = true
+    })
+
+    const legacyFavIcons = document.querySelectorAll("link[rel*='icon'][type='image/png']")
+
+    legacyFavIcons.forEach(item => {
+      const parentElement = item.parentElement
+
+      if (parentElement) {
+        parentElement.removeChild(item)
+      }
     })
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,7 +20,6 @@ import vuetify from './plugins/vuetify'
 import VueVirtualScroller from 'vue-virtual-scroller'
 import VueMeta from 'vue-meta'
 import VuetifyConfirm from 'vuetify-confirm'
-import vueHeadful from 'vue-headful'
 import { InlineSvgPlugin } from 'vue-inline-svg'
 import { loadWASM } from 'onigasm'
 
@@ -61,9 +60,6 @@ import Blur from '@/directives/blur'
 
 // Directives...
 Vue.directive('blur', Blur)
-
-// ...and 3rd party
-Vue.component('vue-headful', vueHeadful)
 
 // Use any Plugins
 

--- a/src/vue-headful.d.ts
+++ b/src/vue-headful.d.ts
@@ -1,3 +1,0 @@
-declare module 'vue-headful' {
-  export const vueHeadful: any
-}


### PR DESCRIPTION
[vue-headful](https://www.npmjs.com/package/vue-headful) has been marked as deprecated with a note to use [vue-meta](https://www.npmjs.com/package/vue-meta), which we already do anyway!

So I've completely removed the deprecated vue-headful dependency and ensured that we only use the correct vue-meta.

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>