### PR TITLE
feat(ui): display localized printer state in printer status card

### DIFF
--- a/src/components/widgets/status/PrinterStatusCard.vue
+++ b/src/components/widgets/status/PrinterStatusCard.vue
@@ -20,7 +20,7 @@
           <v-icon left>
             $printer3d
           </v-icon>
-          {{ printerState }}
+          {{ $t('app.printer.state.' + printerState) || printerState }}
         </v-tab>
         <v-tab
           v-if="supportsHistoryComponent"


### PR DESCRIPTION
before:
![image](https://user-images.githubusercontent.com/25269274/156931664-2ef69ab1-9354-42c1-868c-ac49b4e33c47.png)

after:
![image](https://user-images.githubusercontent.com/25269274/156931651-39d10827-3b1a-423d-b0fe-89990ce98136.png)
