### PR TITLE
fix: shows missing macro parameters

### DIFF
--- a/src/components/ui/AppMacroBtn.vue
+++ b/src/components/ui/AppMacroBtn.vue
@@ -132,7 +132,7 @@ export default class AppMacroBtn extends Mixins(StateMixin) {
       for (const [, name, rest] of this.macro.config.gcode.matchAll(/params\.(\w+)(.*)/gi)) {
         const valueMatch = /\|\s*default\s*\(\s*([^,)]+)/i.exec(rest)
 
-        const value = (valueMatch && valueMatch[1] ? valueMatch[1] : '').trim()
+        const value = (valueMatch && valueMatch[1] || '').trim()
 
         if (!this.params[name]) {
           this.$set(this.params, name, { value, reset: value })

--- a/src/components/ui/AppMacroBtn.vue
+++ b/src/components/ui/AppMacroBtn.vue
@@ -132,7 +132,7 @@ export default class AppMacroBtn extends Mixins(StateMixin) {
       for (const [, name, rest] of this.macro.config.gcode.matchAll(/params\.(\w+)(.*)/gi)) {
         const valueMatch = /\|\s*default\s*\(\s*([^,)]+)/i.exec(rest)
 
-        const value = (valueMatch && valueMatch[1] || '').trim()
+        const value = ((valueMatch && valueMatch[1]) || '').trim()
 
         if (!this.params[name]) {
           this.$set(this.params, name, { value, reset: value })

--- a/src/components/ui/AppMacroBtn.vue
+++ b/src/components/ui/AppMacroBtn.vue
@@ -129,19 +129,15 @@ export default class AppMacroBtn extends Mixins(StateMixin) {
   mounted () {
     if (!this.macro.config || !this.macro.config.gcode) return []
     if (this.macro.config.gcode) {
-      const regex = /params\.(\w+).*\|\s*default\s*\(\s*([^,)]+)/gmi
-      let match = regex.exec(this.macro.config.gcode)
-      do {
-        if (match && match[1]) {
-          const name = match[1]
-          const value = (match[2] || '').trim()
-          if (!this.params[name]) {
-            this.$set(this.params, name, { value, reset: value })
-          }
+      for (const [, name, rest] of this.macro.config.gcode.matchAll(/params\.(\w+)(.*)/gi)) {
+        const valueMatch = /\|\s*default\s*\(\s*([^,)]+)/i.exec(rest)
+
+        const value = (valueMatch && valueMatch[1] ? valueMatch[1] : '').trim()
+
+        if (!this.params[name]) {
+          this.$set(this.params, name, { value, reset: value })
         }
-      } while (
-        (match = regex.exec(this.macro.config.gcode)) !== null
-      )
+      }
     }
   }
 }


### PR DESCRIPTION
Fixes issue introduced with #524, were a macro parameter with no default value would not show up in the interface.

Tested with the following example:

```
[gcode_macro TEST]
gcode:
  {% set A = params.A | default(0, true) | float %}
  {% set B = params.B | int | default(0.005, true) | float %}
  {% set C = params.C | default("PLA", true) %}
  {% set D = params.D | default("PLA") %}
  {% set E = params.E | int | default(0.2) %}
  {% set F = params.F %}
```

Before (F missing):

![image](https://user-images.githubusercontent.com/85504/157230658-54b2e5e6-cd6c-4908-a17b-17bbd0e5634b.png)

After (F showing):

![image](https://user-images.githubusercontent.com/85504/157230799-ce8f4154-d1e8-4067-9517-acac82c84d7b.png)

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>