### PR TITLE
chore: fix GitHub release description

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,11 +32,17 @@ jobs:
           zip -r fluidd.zip ./
           cd ..
 
+      - name: Get version from tag
+        id: tag_name
+        run: |
+          echo ::set-output name=current_version::${GITHUB_REF#refs/tags/v}
+
       - name: Read ChangeLog
         uses: mindsers/changelog-reader-action@v2
         id: changelog
         with:
           validation_depth: 1
+          version: ${{ steps.tag_name.outputs.current_version }}
           path: ./CHANGELOG.md
 
       - name: Create Release


### PR DESCRIPTION
GitHub release notes keep showing incorrect (old) data.

Seems the [changelog-reader-action](https://github.com/mindsers/changelog-reader-action) is the problem here, so I'm updating the workflow to specify the correct version to read, following their own example on how to do this.

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>