### PR TITLE
chore: use locked dependency versions on server

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
           node-version: '16'
 
       - name: Install deps
-        run: npm install
+        run: npm ci --no-optional
 
       - name: Run lint
         run: npm run lint -- --no-fix

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
           node-version: '16'
 
       - name: Install deps
-        run: npm install
+        run: npm ci --no-optional
 
       - name: Run tests
         run: npm run test:unit


### PR DESCRIPTION
This will make installing the dependency packages faster and ensure reproducible builds by only installing locked versions.

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>