### PR TITLE
feat: adds Pressure Advance support

### DIFF
--- a/src/components/widgets/toolhead/PressureAdvanceAdjust.vue
+++ b/src/components/widgets/toolhead/PressureAdvanceAdjust.vue
@@ -1,0 +1,64 @@
+<template>
+  <v-row>
+    <v-col
+      cols="12"
+      sm="6"
+    >
+      <app-slider
+        :label="$t('app.general.label.pressure_advance')"
+        suffix="mm/s"
+        :value="activeExtruder.pressure_advance || 0"
+        :overridable="true"
+        :reset-value="activeExtruder.config_pressure_advance || 0"
+        :disabled="!klippyReady || hasWait(waits.onSetPressureAdvance)"
+        :locked="(!klippyReady || isMobile)"
+        :min="0"
+        :max="2"
+        :step="0.01"
+        @change="handleSetPressureAdvance"
+      />
+    </v-col>
+    <v-col
+      cols="12"
+      sm="6"
+    >
+      <app-slider
+        :label="$t('app.general.label.smooth_time')"
+        suffix="s"
+        :value="activeExtruder.smooth_time || 0"
+        :overridable="true"
+        :reset-value="activeExtruder.config_smooth_time || 0"
+        :disabled="!klippyReady || hasWait(waits.onSetPressureAdvance)"
+        :locked="(!klippyReady || isMobile)"
+        :min="0"
+        :max="0.2"
+        :step="0.01"
+        @change="handleSetSmoothTime"
+      />
+    </v-col>
+  </v-row>
+</template>
+
+<script lang="ts">
+import { Component, Mixins } from 'vue-property-decorator'
+import StateMixin from '@/mixins/state'
+import ToolheadMixin from '@/mixins/toolhead'
+import { Waits } from '@/globals'
+
+@Component({})
+export default class PressureAdvanceAdjust extends Mixins(StateMixin, ToolheadMixin) {
+  waits = Waits
+
+  handleSetPressureAdvance (val: number) {
+    this.sendGcode('SET_PRESSURE_ADVANCE ADVANCE=' + val, this.waits.onSetPressureAdvance)
+  }
+
+  handleSetSmoothTime (val: number) {
+    this.sendGcode('SET_PRESSURE_ADVANCE SMOOTH_TIME=' + val, this.waits.onSetPressureAdvance)
+  }
+
+  get isMobile () {
+    return this.$vuetify.breakpoint.mobile
+  }
+}
+</script>

--- a/src/components/widgets/toolhead/Toolhead.vue
+++ b/src/components/widgets/toolhead/Toolhead.vue
@@ -20,6 +20,7 @@
 
     <!-- Speed and Flow Adjustments  -->
     <speed-and-flow-adjust />
+    <pressure-advance-adjust />
   </v-card-text>
 </template>
 
@@ -32,6 +33,7 @@ import ExtruderSelection from '@/components/widgets/toolhead/ExtruderSelection.v
 import ToolheadPosition from '@/components/widgets/toolhead/ToolheadPosition.vue'
 import ZHeightAdjust from '@/components/widgets/toolhead/ZHeightAdjust.vue'
 import SpeedAndFlowAdjust from '@/components/widgets/toolhead/SpeedAndFlowAdjust.vue'
+import PressureAdvanceAdjust from '@/components/widgets/toolhead/PressureAdvanceAdjust.vue'
 
 @Component({
   components: {
@@ -40,7 +42,8 @@ import SpeedAndFlowAdjust from '@/components/widgets/toolhead/SpeedAndFlowAdjust
     ExtruderSelection,
     ToolheadPosition,
     ZHeightAdjust,
-    SpeedAndFlowAdjust
+    SpeedAndFlowAdjust,
+    PressureAdvanceAdjust
   }
 })
 export default class Toolhead extends Mixins(StateMixin) {

--- a/src/globals.ts
+++ b/src/globals.ts
@@ -319,6 +319,7 @@ export const Waits = Object.freeze({
   onMacro: 'onMacro',
   onSetSpeed: 'onSetSpeed',
   onSetFlow: 'onSetFlow',
+  onSetPressureAdvance: 'onSetPressureAdvance',
   onSetFanSpeed: 'onSetFanSpeed',
   onSetOutputPin: 'onSetOutputPin',
   onZAdjust: 'onZAdjust',

--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -222,6 +222,7 @@ app:
       'off': 'Off'
       password: Password
       power: Power
+      pressure_advance: Pressure Advance
       printers: Printers
       progress: Progress
       requested_speed: Speed
@@ -230,6 +231,7 @@ app:
       save_as: Save As
       services: Services
       slicer: Slicer
+      smooth_time: Smooth Time
       speed: Speed
       sqv: Square Corner Velocity
       total: Total

--- a/src/store/printer/getters.ts
+++ b/src/store/printer/getters.ts
@@ -222,18 +222,16 @@ export const getters: GetterTree<PrinterState, RootState> = {
     // If we can't find what we need..
     if (!e || !c) return {}
 
-    // The first extruder should include all we need.
-    if (name === 'extruder' && e && c) return { ...e, ...c }
-
     // If we have other extruders, they may inherit some properties
     // from the first depending how they're defined.
-    const d = getters.getPrinterSettings('extruder')
+    const { min_extrude_temp } = name === 'extruder' ? c : getters.getPrinterSettings('extruder')
+
     return {
-      ...{
-        min_extrude_temp: d.min_extrude_temp
-      },
+      min_extrude_temp,
+      ...c,
       ...e,
-      ...c
+      config_pressure_advance: c.pressure_advance,
+      config_smooth_time: c.pressure_advance_smooth_time
     }
   },
 


### PR DESCRIPTION
Adds Pressure Advance and Smooth Time settings to the Tool panel.

![image](https://user-images.githubusercontent.com/85504/158845844-04160c86-e566-4b1e-86ad-5445fe8d0d98.png)

I considered putting this on a new separate panel, but it made sense to be on the Tool as the Extruder selection is made here and in the end, these settings are in regards to the current active extruder!

I also took into consideration putting this under the Tune page, but this is one of those settings that does depend on the type of filament you are currently printing, so it is not as static as the bed mesh, for example.

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>