### PR TITLE
chore: more typescript typings

### DIFF
--- a/src/components/widgets/toolhead/ExtruderMoves.vue
+++ b/src/components/widgets/toolhead/ExtruderMoves.vue
@@ -26,7 +26,7 @@
           :disabled="!extruderReady || !klippyReady || !valid"
           :elevation="2"
           block
-          @click="sendRetractGcode(extrudeLength, extrudeSpeed, waits.onExtract)"
+          @click="sendRetractGcode(extrudeLength, extrudeSpeed, waits.onExtrude)"
         >
           {{ $t('app.general.btn.retract') }}
           <v-icon>$chevronUp</v-icon>

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -96,8 +96,8 @@ import { Macro } from '@/store/macros/types'
 })
 export default class Dashboard extends Mixins(StateMixin) {
   drag = false
-  container1 = []
-  container2 = []
+  container1: LayoutConfig[] = []
+  container2: LayoutConfig[] = []
 
   mounted () {
     this.container1 = this.layout.container1


### PR DESCRIPTION
Missing typing in Dashboard.vue, and a typo ("onExtract" instead of "onExtrude") on ExtruderMoves.vue

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>