### PR TITLE
chore: drop support for unused browsers

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,3 +1,7 @@
 > 1%
-last 2 versions
 not dead
+last 2 chrome major versions
+last 2 firefox major versions
+last 2 safari major versions
+last 2 opera major versions
+last 2 edge major versions


### PR DESCRIPTION
By changing the browser support to only mainstream browsers (Chrome, Edge, Safari, Opera, Firefox) will increase build speed and reduce resources!

Browser coverage drops from 90% to 88%, but I don't think this is significant:
 - [Current coverage](https://browserslist.dev/?q=PiAxJSxsYXN0IDIgdmVyc2lvbnMsbm90IGRlYWQ%3D)
 - [Proposed coverage](https://browserslist.dev/?q=PiAxJSxub3QgZGVhZCxsYXN0IDIgY2hyb21lIG1ham9yIHZlcnNpb25zLGxhc3QgMiBmaXJlZm94IG1ham9yIHZlcnNpb25zLGxhc3QgMiBzYWZhcmkgbWFqb3IgdmVyc2lvbnMsbGFzdCAyIG9wZXJhIG1ham9yIHZlcnNpb25zLGxhc3QgMiBlZGdlIG1ham9yIHZlcnNpb25z)

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>