### PR TITLE
chore: split FileEditor into a separate chunk

### DIFF
--- a/src/components/widgets/filesystem/FileEditor.vue
+++ b/src/components/widgets/filesystem/FileEditor.vue
@@ -2,16 +2,24 @@
   <div
     ref="monaco-editor"
     class="editor"
-  />
+  >
+    <div
+      v-if="!editor"
+      class="spinner"
+    >
+      <v-progress-circular
+        indeterminate
+        size="100"
+        color="primary"
+      />
+    </div>
+  </div>
 </template>
 
 <script lang="ts">
 import { Vue, Component, Prop, Ref } from 'vue-property-decorator'
-import * as monaco from 'monaco-editor/esm/vs/editor/editor.api'
-import { IGrammarDefinition, Registry } from 'monaco-textmate'
-import { wireTmGrammars } from 'monaco-editor-textmate'
-import themeDark from '@/monaco/theme/editor.dark.theme.json'
-import themeLight from '@/monaco/theme/editor.light.theme.json'
+import type * as Monaco from 'monaco-editor/esm/vs/editor/editor.api'
+let monaco: typeof Monaco // dynamically imported
 
 @Component({})
 export default class FileEditor extends Vue {
@@ -27,7 +35,7 @@ export default class FileEditor extends Vue {
   @Ref('monaco-editor') monacoEditor!: HTMLElement
 
   // Our editor, once init'd.
-  editor: monaco.editor.IStandaloneCodeEditor | undefined = undefined
+  editor: Monaco.editor.IStandaloneCodeEditor | null = null
 
   // Base editor options.
   opts = {
@@ -54,49 +62,14 @@ export default class FileEditor extends Vue {
   }
 
   async initEditor () {
-    // Register our custom TextMate languages.
-    const registry = new Registry({
-      getGrammarDefinition: async (scopeName): Promise<IGrammarDefinition> => {
-        const fileName = scopeName.split('.').pop()
-        return import(
-          /* webpackChunkName: "grammar-[request]" */
-          `@/monaco/language/${fileName}.tmLanguage.json`
-        )
-          .then(language => {
-            return Promise.resolve({
-              format: 'json',
-              content: language.default
-            })
-          })
-      }
-    })
-
-    // Load our grammars...
-    const grammars = new Map()
-    grammars.set('gcode', 'source.gcode')
-    grammars.set('klipper-config', 'source.klipper-config')
-    grammars.set('log', 'text.log')
-
-    // ... and our languages
-    monaco.languages.register({ id: 'gcode', extensions: ['gcode', 'g', 'gc', 'gco', 'ufp', 'nc'] })
-    monaco.languages.register({ id: 'klipper-config', extensions: ['cfg', 'conf'] })
-    monaco.languages.register({ id: 'log', extensions: ['log'] })
-
-    // Define how commenting works.
-    monaco.languages.setLanguageConfiguration('gcode', {
-      comments: {
-        lineComment: ';'
-      }
-    })
-    monaco.languages.setLanguageConfiguration('klipper-config', {
-      comments: {
-        lineComment: '#'
-      }
-    })
-
-    // Defined the themes.
-    monaco.editor.defineTheme('dark-converted', themeDark as any)
-    monaco.editor.defineTheme('light-converted', themeLight as any)
+    if (!monaco) {
+      const { default: promise } = await import(
+        /* webpackChunkName: "monaco-editor" */
+        /* webpackPrefetch: -100 */
+        './setupMonaco'
+      )
+      monaco = await promise
+    }
 
     // Set the correct theme.
     if (this.$vuetify.theme.dark) {
@@ -104,9 +77,6 @@ export default class FileEditor extends Vue {
     } else {
       monaco.editor.setTheme('light-converted')
     }
-
-    // Wire it up.
-    await wireTmGrammars(monaco, registry, grammars)
 
     // Create an editor instance.
     this.editor = monaco.editor.create(this.monacoEditor, {
@@ -124,27 +94,20 @@ export default class FileEditor extends Vue {
     // Focus the editor.
     this.editor.focus()
 
-    // Fire the editorMounted call.
-    this.editorMounted()
-  }
-
-  editorMounted () {
-    if (this.editor) {
-      this.$emit('ready')
-      this.editor.onDidChangeModelContent(event => {
-        const value = this.editor?.getValue()
-        this.emitChange(value, event)
-      })
-    }
+    this.$emit('ready')
+    this.editor.onDidChangeModelContent(event => {
+      const value = this.editor?.getValue()
+      this.emitChange(value, event)
+    })
   }
 
   // Ensure we dispose of our models and editor.
   destroyed () {
-    monaco.editor.getModels().forEach(model => model.dispose())
+    if (monaco) monaco.editor.getModels().forEach(model => model.dispose())
     if (this.editor) this.editor.dispose()
   }
 
-  emitChange (value: string | undefined, event: monaco.editor.IModelContentChangedEvent) {
+  emitChange (value: string | undefined, event: Monaco.editor.IModelContentChangedEvent) {
     this.$emit('change', value, event)
     this.$emit('input', value)
   }
@@ -157,5 +120,12 @@ export default class FileEditor extends Vue {
     min-width: 100%;
     height: 90%;
     height: calc(100% - 48px);
+  }
+
+  .editor > .spinner {
+    display:flex;
+    justify-content:center;
+    align-items:center;
+    height:100vh;
   }
 </style>

--- a/src/components/widgets/filesystem/setupMonaco.ts
+++ b/src/components/widgets/filesystem/setupMonaco.ts
@@ -1,0 +1,64 @@
+import * as monaco from 'monaco-editor/esm/vs/editor/editor.api'
+import { loadWASM } from 'onigasm'
+import { IGrammarDefinition, Registry } from 'monaco-textmate'
+import { wireTmGrammars } from 'monaco-editor-textmate'
+import themeDark from '@/monaco/theme/editor.dark.theme.json'
+import themeLight from '@/monaco/theme/editor.light.theme.json'
+
+async function setupMonaco () {
+  const wasm = await require('onigasm/lib/onigasm.wasm')
+  await loadWASM(wasm.default)
+
+  // Register our custom TextMate languages.
+  const registry = new Registry({
+    getGrammarDefinition: async (scopeName): Promise<IGrammarDefinition> => {
+      const fileName = scopeName.split('.').pop()
+      return import(
+                /* webpackChunkName: "grammar-[request]" */
+                `@/monaco/language/${fileName}.tmLanguage.json`
+      )
+        .then(language => {
+          return Promise.resolve({
+            format: 'json',
+            content: language.default
+          })
+        })
+    }
+  })
+
+  // Load our grammars...
+  const grammars = new Map()
+  grammars.set('gcode', 'source.gcode')
+  grammars.set('klipper-config', 'source.klipper-config')
+  grammars.set('log', 'text.log')
+
+  // ... and our languages
+  monaco.languages.register({ id: 'gcode', extensions: ['gcode', 'g', 'gc', 'gco', 'ufp', 'nc'] })
+  monaco.languages.register({ id: 'klipper-config', extensions: ['cfg', 'conf'] })
+  monaco.languages.register({ id: 'log', extensions: ['log'] })
+
+  // Define how commenting works.
+  monaco.languages.setLanguageConfiguration('gcode', {
+    comments: {
+      lineComment: ';'
+    }
+  })
+  monaco.languages.setLanguageConfiguration('klipper-config', {
+    comments: {
+      lineComment: '#'
+    }
+  })
+
+  // Defined the themes.
+  monaco.editor.defineTheme('dark-converted', themeDark as any)
+  monaco.editor.defineTheme('light-converted', themeLight as any)
+
+  // Wire it up.
+  await wireTmGrammars(monaco, registry, grammars)
+
+  return monaco
+}
+
+// Exporting a promise ensures that setupMonaco is run only once
+const promise = setupMonaco()
+export default promise

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,7 +21,6 @@ import VueVirtualScroller from 'vue-virtual-scroller'
 import VueMeta from 'vue-meta'
 import VuetifyConfirm from 'vuetify-confirm'
 import { InlineSvgPlugin } from 'vue-inline-svg'
-import { loadWASM } from 'onigasm'
 
 // Init.
 import { appInit } from './init'
@@ -89,13 +88,6 @@ Vue.use(VuetifyConfirm, {
 })
 Vue.use(InlineSvgPlugin)
 // Vue.use(WorkboxPlugin)
-
-const loadOnigasm = async (): Promise<void> => {
-  const wasm = await require('onigasm/lib/onigasm.wasm')
-  await loadWASM(wasm.default)
-}
-
-loadOnigasm()
 
 appInit()
   .then((config: InitConfig) => {


### PR DESCRIPTION
This allows the Monaco editor component to be asynchronously loaded when needed.

The vendor chunk is reduced from 5642.22 KiB  to 2953.59 KiB.
The new chunk weights 2716.54 KiB.

The size could be reduced by shaving off editor features.
Available features are `'accessibilityHelp' | 'anchorSelect' | 'bracketMatching' | 'caretOperations' | 'clipboard' | 'codeAction' | 'codelens' | 'colorPicker' | 'comment' | 'contextmenu' | 'coreCommands' | 'cursorUndo' | 'dnd' | 'documentSymbols' | 'find' | 'folding' | 'fontZoom' | 'format' | 'gotoError' | 'gotoLine' | 'gotoSymbol' | 'hover' | 'iPadShowKeyboard' | 'inPlaceReplace' | 'indentation' | 'inlayHints' | 'inlineCompletions' | 'inspectTokens' | 'lineSelection' | 'linesOperations' | 'linkedEditing' | 'links' | 'multicursor' | 'parameterHints' | 'quickCommand' | 'quickHelp' | 'quickOutline' | 'referenceSearch' | 'rename' | 'smartSelect' | 'snippet' | 'suggest' | 'toggleHighContrast' | 'toggleTabFocusMode' | 'tokenization' | 'unicodeHighlighter' | 'unusualLineTerminators' | 'viewportSemanticTokens' | 'wordHighlighter' | 'wordOperations' | 'wordPartOperations'`
Curently disabled features:  `['!contextmenu', '!snippets', '!multicursor']`


Signed-off-by: Maël Kerbiriou <m431.kerbiriou@gmail.com>