### PR TITLE
chore: sanitize code editor features

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -41,7 +41,22 @@ module.exports = defineConfig({
     plugins: [
       new MonacoEditorPlugin({
         languages: ['markdown'],
-        features: ['!contextmenu', '!snippets', '!multicursor']
+        features: [
+          '!accessibilityHelp',
+          '!codeAction',
+          '!codelens',
+          '!colorPicker',
+          '!contextmenu',
+          '!folding',
+          '!hover',
+          '!gotoError',
+          '!gotoLine',
+          '!gotoSymbol',
+          '!quickCommand',
+          '!quickHelp',
+          '!referenceSearch',
+          '!snippet'
+        ]
       }),
       new GenerateFilePlugin({
         file: '.version',


### PR DESCRIPTION
I've re-enabled the `multicursor` feature and disabled some other features that I believe are not in use.

From my tests in both Edge and Firefox, this does not seem to limit any existing functionality, but it does decrease the bundle size a bit (while also bringing multi-cursor editing back!)

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>