### PR TITLE
fix: allow decimals in slider bound text controls

### DIFF
--- a/src/components/ui/AppSlider.vue
+++ b/src/components/ui/AppSlider.vue
@@ -19,7 +19,7 @@
         class="py-0"
       >
         <v-text-field
-          v-model="internalValue"
+          v-model="internalStringValue"
           :suffix="suffix"
           :rules="textRules"
           :readonly="isLocked"
@@ -32,7 +32,8 @@
           outlined
           hide-details
           @change="handleChange($event)"
-          @focus="$event.target.select()"
+          @focus="directInput = true; $event.target.select()"
+          @blur="directInput = false"
         >
           <template #prepend>
             <v-btn
@@ -85,6 +86,7 @@
       :disabled="disabled || loading || isLocked || overridden"
       dense
       hide-details
+      @start="directInput=false"
       @change="handleChange($event)"
     />
   </v-form>
@@ -92,9 +94,8 @@
 
 <script lang="ts">
 import { Component, Prop, Watch, Mixins, Ref } from 'vue-property-decorator'
-import VSlider from 'vuetify/lib/components/VSlider.vue'
 import StateMixin from '@/mixins/state'
-import { VForm } from '@/types/vuetify'
+import { VForm, VSlider } from '@/types/vuetify'
 
 @Component({})
 export default class AppSlider extends Mixins(StateMixin) {
@@ -143,7 +144,9 @@ export default class AppSlider extends Mixins(StateMixin) {
   valid = true
   lockState = false
   overridden = false
-  internalValue = this.value
+  internalStringValue: string = this.value.toString()
+  internalValue: number = this.value
+  directInput = false
   internalMax = this.max
   pending = false
 
@@ -152,17 +155,17 @@ export default class AppSlider extends Mixins(StateMixin) {
   onValue (value: string | number) {
     value = +value
     if (value !== this.internalValue) {
-      this.internalValue = +value
+      this.internalValue = value
     }
     this.pending = false
   }
 
   // If one of our controls updates the value.
-  @Watch('internalValue')
-  onInternalValue (value: string | number) {
+  @Watch('internalStringValue')
+  onInternalStringValue (value: string) {
     if (this.valid) {
       if (
-        value > this.max &&
+        +value > this.max &&
         this.overridable
       ) {
         // This is overridable, and the user wants to increase
@@ -175,8 +178,18 @@ export default class AppSlider extends Mixins(StateMixin) {
         this.overridden = false
         this.internalMax = this.max
       }
-      this.$emit('input', +value)
+
+      this.internalValue = +value
     }
+  }
+
+  @Watch('internalValue')
+  onInternalValue (value: number) {
+    if (!this.directInput) {
+      this.internalStringValue = value.toString()
+    }
+
+    this.$emit('input', value)
   }
 
   get isLocked () {
@@ -201,6 +214,7 @@ export default class AppSlider extends Mixins(StateMixin) {
     // Apply a min and max rule as per the slider.
     const rules = [
       ...this.rules,
+      (v: string) => !isNaN(+v) || this.$t('app.general.simple_form.error.invalid_number'),
       (v: string) => +v >= this.min || this.$t('app.general.simple_form.error.min', { min: this.min })
     ]
     if (!this.overridable) {

--- a/src/components/widgets/toolhead/PressureAdvanceAdjust.vue
+++ b/src/components/widgets/toolhead/PressureAdvanceAdjust.vue
@@ -26,7 +26,7 @@
         :label="$t('app.general.label.smooth_time')"
         suffix="s"
         :value="activeExtruder.smooth_time || 0"
-        :overridable="true"
+        :overridable="false"
         :reset-value="activeExtruder.config_smooth_time || 0"
         :disabled="!klippyReady || hasWait(waits.onSetPressureAdvance)"
         :locked="(!klippyReady || isMobile)"

--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -260,6 +260,7 @@ app:
       error:
         arrayofnums: Only numbers
         exists: Already exists
+        invalid_number: Invalid Number
         invalid_url: Invalid URL
         invalid_expression: Invalid Expression
         max: Max %{max}

--- a/src/types/vuetify.ts
+++ b/src/types/vuetify.ts
@@ -3,3 +3,7 @@ export type VForm = Vue & {
   reset: () => boolean;
   resetValidation: () => boolean;
 }
+
+export type VSlider = Vue & {
+  value: number
+}


### PR DESCRIPTION
This should hopefully allow to enter "0.02" on text field and still work correctly!

Tested under Edge and Firefox.

Fixes #603 

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>