### PR TITLE
fix: movable color picker behavior

### DIFF
--- a/src/components/ui/AppColorPicker.vue
+++ b/src/components/ui/AppColorPicker.vue
@@ -171,7 +171,7 @@ export default class AppColorPicker extends Vue {
   menu = false
 
   @Ref('card')
-  card!: Vue
+  card?: Vue
 
   dragging = false
   lastPointerPosition: PointerPosition = { x: 0, y: 0 }
@@ -298,19 +298,22 @@ export default class AppColorPicker extends Vue {
   }
 
   relativeMove (newPosition: PointerPosition) {
-    const parent = this.card.$el.parentElement as HTMLElement
+    if (!this.card) {
+      return
+    }
 
+    const parent = this.card.$el.parentElement as HTMLElement
     parent.style.left = (parseFloat(parent.style.left) + (newPosition.x - this.lastPointerPosition.x)) + 'px'
     parent.style.top = (parseFloat(parent.style.top) + (newPosition.y - this.lastPointerPosition.y)) + 'px'
   }
 
   pointerMove (event: TouchEvent | MouseEvent) {
     let newPosition
-    if (event instanceof TouchEvent) {
+    if (window.TouchEvent && event instanceof TouchEvent) {
       event.preventDefault()
       newPosition = { x: event.touches[0].clientX, y: event.touches[0].clientY }
     } else if (this.dragging) {
-      newPosition = { x: event.clientX, y: event.clientY }
+      newPosition = { x: (event as MouseEvent).clientX, y: (event as MouseEvent).clientY }
     } else {
       return
     }


### PR DESCRIPTION
Fixes two issues with the movable color picker:
- Firefox Desktop does not implement the TouchEvent API, leading to errors in the `mousemove` event
- The `cards` ref isn't populated when the color picker isn't open, resulting in property access on undefined

Closes #601 