### PR TITLE
fix: Toolhead and ZHeightAdjust layout

### DIFF
--- a/src/components/widgets/toolhead/Toolhead.vue
+++ b/src/components/widgets/toolhead/Toolhead.vue
@@ -11,7 +11,7 @@
         <z-height-adjust v-if="printerPrinting" />
       </v-col>
 
-      <v-col style="min-width: 280px; max-width: 420px;">
+      <v-col style="min-width: 380px; max-width: 420px;">
         <toolhead-position />
         <extruder-moves v-if="!printerPrinting" />
         <z-height-adjust v-if="!printerPrinting" />

--- a/src/components/widgets/toolhead/ZHeightAdjust.vue
+++ b/src/components/widgets/toolhead/ZHeightAdjust.vue
@@ -12,7 +12,6 @@
         v-model="moveDistance"
         mandatory
         dense
-        class="ml-2 d-inline-block"
       >
         <app-btn
           v-for="(value, i) in zAdjustValues"


### PR DESCRIPTION
Fixes incorrect wrapping of Z-offset controls

Before:

![image](https://user-images.githubusercontent.com/85504/159577760-5f06248b-770c-4705-a76c-7feb7f704664.png)

After:

![image](https://user-images.githubusercontent.com/85504/159537666-aacc1197-2731-4bbd-98c5-7628a8000fb5.png)

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>