### PR TITLE
Added thumbnail URI encoding

### DIFF
--- a/src/store/helpers.ts
+++ b/src/store/helpers.ts
@@ -27,8 +27,8 @@ export const getThumb = (thumbnails: Thumbnail[], path: string, large = true) =>
         if (thumb.relative_path && thumb.relative_path.length > 0) {
           const url = new URL(apiUrl ?? document.location.origin)
           url.pathname = (path === '')
-            ? `/server/files/gcodes/${thumb.relative_path}`
-            : `/server/files/gcodes/${path}/${thumb.relative_path}`
+            ? '/server/files/gcodes/' + encodeURIComponent(thumb.relative_path)
+            : '/server/files/gcodes/' + encodeURIComponent(path) + '/' + encodeURIComponent(thumb.relative_path)
 
           return {
             ...thumb,

--- a/src/store/helpers.ts
+++ b/src/store/helpers.ts
@@ -27,8 +27,8 @@ export const getThumb = (thumbnails: Thumbnail[], path: string, large = true) =>
         if (thumb.relative_path && thumb.relative_path.length > 0) {
           const url = new URL(apiUrl ?? document.location.origin)
           url.pathname = (path === '')
-            ? '/server/files/gcodes/' + encodeURIComponent(thumb.relative_path)
-            : '/server/files/gcodes/' + encodeURIComponent(path) + '/' + encodeURIComponent(thumb.relative_path)
+            ? `/server/files/gcodes/${encodeURI(thumb.relative_path)}`
+            : `/server/files/gcodes/${encodeURI(path)}/${encodeURI(thumb.relative_path)}`
 
           return {
             ...thumb,


### PR DESCRIPTION
Noticed that a thumbnail was not displaying when i uploaded a gcode file with "infill 10%" in its name. Turned out the thumbnail name is basically the gcode name and also contained the % character which was not url encoded. Fixed that and also for the path, as the same problem may happen there.

The gcode name was auto-generated by the cura "Gcode Filename Format Plus" plugin.