### PR TITLE
Revert "fix: thumbnail URI encoding (#618)"

### DIFF
--- a/src/store/helpers.ts
+++ b/src/store/helpers.ts
@@ -27,8 +27,8 @@ export const getThumb = (thumbnails: Thumbnail[], path: string, large = true) =>
         if (thumb.relative_path && thumb.relative_path.length > 0) {
           const url = new URL(apiUrl ?? document.location.origin)
           url.pathname = (path === '')
-            ? `/server/files/gcodes/${encodeURI(thumb.relative_path)}`
-            : `/server/files/gcodes/${encodeURI(path)}/${encodeURI(thumb.relative_path)}`
+            ? `/server/files/gcodes/${thumb.relative_path}`
+            : `/server/files/gcodes/${path}/${thumb.relative_path}`
 
           return {
             ...thumb,


### PR DESCRIPTION
This was incorrectly added to master branch when it should have got to develop, so reverting master changes now

This reverts commit 30efd5ff12848c1c7e7dda654c7cee4a7feb0f65.

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>