### PR TITLE
fix: thumbnail URI encoding

### DIFF
--- a/src/store/helpers.ts
+++ b/src/store/helpers.ts
@@ -27,8 +27,8 @@ export const getThumb = (thumbnails: Thumbnail[], path: string, large = true) =>
         if (thumb.relative_path && thumb.relative_path.length > 0) {
           const url = new URL(apiUrl ?? document.location.origin)
           url.pathname = (path === '')
-            ? `/server/files/gcodes/${thumb.relative_path}`
-            : `/server/files/gcodes/${path}/${thumb.relative_path}`
+            ? `/server/files/gcodes/${encodeURI(thumb.relative_path)}`
+            : `/server/files/gcodes/${encodeURI(path)}/${encodeURI(thumb.relative_path)}`
 
           return {
             ...thumb,


### PR DESCRIPTION
We had to revert #618 as it was targeting the master branch when it was merged.

This PR is a "cherry-pick" of the changes from that PR to the correct develop branch.

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>