### PR TITLE
fix: fully unload dialogs when not in use

### DIFF
--- a/src/components/common/SystemPrinters.vue
+++ b/src/components/common/SystemPrinters.vue
@@ -42,6 +42,7 @@
     </v-list-item>
 
     <add-instance-dialog
+      v-if="instanceDialogOpen"
       v-model="instanceDialogOpen"
       @resolve="activateInstance"
     />

--- a/src/components/layout/AppBar.vue
+++ b/src/components/layout/AppBar.vue
@@ -100,6 +100,7 @@
     </template>
 
     <user-password-dialog
+      v-if="dialog"
       v-model="dialog"
     />
   </v-app-bar>

--- a/src/components/settings/VersionSettings.vue
+++ b/src/components/settings/VersionSettings.vue
@@ -106,6 +106,7 @@
     </v-card>
 
     <version-commit-history-dialog
+      v-if="informationDialogState.open"
       v-model="informationDialogState.open"
       :component="informationDialogState.component"
     />

--- a/src/components/widgets/filesystem/FileNameDialog.vue
+++ b/src/components/widgets/filesystem/FileNameDialog.vue
@@ -2,7 +2,7 @@
   <v-dialog
     :value="value"
     :max-width="320"
-    @input="$emit('input', value)"
+    @input="$emit('input', $event)"
   >
     <v-form
       ref="addInstanceForm"

--- a/src/components/widgets/filesystem/FileSystem.vue
+++ b/src/components/widgets/filesystem/FileSystem.vue
@@ -95,12 +95,14 @@
     />
 
     <file-system-download-dialog
+      v-if="currentDownload !== null"
       :value="currentDownload !== null"
       :file="currentDownload"
       @cancel="handleCancelDownload"
     />
 
     <file-system-upload-dialog
+      v-if="currentUploads.length > 0"
       :value="currentUploads.length > 0"
       :files="currentUploads"
       @cancel="handleCancelUpload"

--- a/src/components/widgets/gcode-preview/GcodePreviewCard.vue
+++ b/src/components/widgets/gcode-preview/GcodePreviewCard.vue
@@ -13,6 +13,7 @@
 
     <v-card-text>
       <GcodePreviewParserProgressDialog
+        v-if="showParserProgressDialog"
         :value="showParserProgressDialog"
         :progress="parserProgress"
         :file="file"


### PR DESCRIPTION
As it currently stands, most dialogs are loaded on the Vue object tree but kept hidden until needed, something I believe we actually do not need, so this PR changes that!

Before:

![image](https://user-images.githubusercontent.com/85504/163171657-c726700c-4769-4c06-bac6-40af2b670a82.png)

After:

![image](https://user-images.githubusercontent.com/85504/163172137-9d1a920a-8bf3-4dcf-9fbb-9e7a4bc9875a.png)

The `UpdatingDialog` works a bit differently, so that one I kept as is.

I've also fixed a bug on the `FileNameDialog`, where clicking outside the dialog would close it but we wouldn't be able to open it again!

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>