### PR TITLE
feat: calculate linear progress

### DIFF
--- a/src/store/printer/getters.ts
+++ b/src/store/printer/getters.ts
@@ -101,6 +101,19 @@ export const getters: GetterTree<PrinterState, RootState> = {
   },
 
   getPrintProgress: (state) => {
+    const { gcode_start_byte, gcode_end_byte, filename } = state.printer.current_file ?? {}
+    const { file_position } = state.printer.virtual_sdcard ?? {}
+
+    if (gcode_start_byte && gcode_end_byte && file_position && filename === state.printer.print_stats?.filename) {
+      if (file_position <= gcode_start_byte) return 0
+      if (file_position >= gcode_end_byte) return 1
+
+      const currentPosition = file_position - gcode_start_byte
+      const endPosition = gcode_end_byte - gcode_start_byte
+
+      if (currentPosition > 0 && endPosition > 0) return currentPosition / endPosition
+    }
+
     return state.printer.display_status.progress || 0
   },
 


### PR DESCRIPTION
Klipper calculates progress by calculating `current_file_position / file_length`, but that can lead to progress starting on a non 0% value and the print complete before it reaches 100% (in my tests, I've seen it start at 46% and end at 97%)

The reason for this is that G-code files can have a lot of metadata on the start (thumbnails for example) and end of the file, thus causing the above problem.

As Moonraker reports the start byte and end byte of the G-code, we can use that together with the current file position and calculate a more correct progress value!

Having a "better" progress value will also lead to more accurate timing reports!

Before:

![Animation](https://user-images.githubusercontent.com/85504/164240580-75c77c19-5771-4897-8c93-0c912ab00385.gif)

After:

![Animation2](https://user-images.githubusercontent.com/85504/164240603-96169d0e-108e-41be-92fe-90dd450737cc.gif)

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>