### PR TITLE
fix: layout database data handling

### DIFF
--- a/src/store/layout/mutations.ts
+++ b/src/store/layout/mutations.ts
@@ -43,7 +43,11 @@ export const mutations: MutationTree<LayoutState> = {
       // Missing compontents? Add'em.
       supportedComponents.forEach(o => {
         if (o.layout && o.container) {
-          payload.layouts[o.layout][o.container].push(o)
+          if (payload.layouts[o.layout][o.container]) {
+            payload.layouts[o.layout][o.container].push(o)
+          } else {
+            payload.layouts[o.layout][o.container] = [o]
+          }
         }
       })
       Object.assign(state, payload)


### PR DESCRIPTION
Fixes an issue where the moonraker db entry for the layout would be missing a whole side (container) of the dashboard, making other components fail to load:
```
mutations.ts:46 Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'push')
    at mutations.ts:46:50
    at Array.forEach (<anonymous>)
    at mutations.ts:44:27
    at v.setInitLayout (mutations.ts:22:53)

```