### PR TITLE
fix: layout resize wrapping

### DIFF
--- a/src/components/widgets/toolhead/Toolhead.vue
+++ b/src/components/widgets/toolhead/Toolhead.vue
@@ -5,13 +5,13 @@
       align="start"
       class="mb-2"
     >
-      <v-col cols="auto">
+      <v-col class="controls-wrapper">
         <extruder-selection v-if="multipleExtruders" />
         <toolhead-moves v-if="!printerPrinting" />
         <z-height-adjust v-if="printerPrinting" />
       </v-col>
 
-      <v-col style="min-width: 380px; max-width: 420px;">
+      <v-col class="controls-wrapper">
         <toolhead-position />
         <extruder-moves v-if="!printerPrinting" />
         <z-height-adjust v-if="!printerPrinting" />
@@ -52,3 +52,10 @@ export default class Toolhead extends Mixins(StateMixin) {
   }
 }
 </script>
+
+<style type="scss" scoped>
+  .controls-wrapper {
+    min-width: 380px !important;
+    max-width: 450px !important;
+  }
+</style>


### PR DESCRIPTION
Improves tool window layout when resizing the window!

Idle layout:

![Animation](https://user-images.githubusercontent.com/85504/165740849-7efc72df-02fb-4e8b-9e4a-710ed7729ff8.gif)

Printing layout:

![Animation2](https://user-images.githubusercontent.com/85504/165740868-48148910-64c7-4439-a9ae-53e77ee2ad8b.gif)

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>