### PR TITLE
fix: show simple editor on mobile

### DIFF
--- a/src/components/widgets/filesystem/FileEditor.vue
+++ b/src/components/widgets/filesystem/FileEditor.vue
@@ -114,7 +114,7 @@ export default class FileEditor extends Vue {
 }
 </script>
 
-<style lang="scss">
+<style lang="scss" scoped>
   .editor {
     // margin-top: 12px;
     min-width: 100%;

--- a/src/components/widgets/filesystem/FileEditorDialog.vue
+++ b/src/components/widgets/filesystem/FileEditorDialog.vue
@@ -98,7 +98,15 @@
       </v-toolbar>
 
       <file-editor
-        v-if="contents !== undefined"
+        v-if="contents !== undefined && !isMobile"
+        v-model="updatedContent"
+        :filename="filename"
+        :readonly="readonly"
+        @ready="editorReady = true"
+      />
+
+      <file-editor-text-only
+        v-if="contents !== undefined && isMobile"
         v-model="updatedContent"
         :filename="filename"
         :readonly="readonly"
@@ -116,10 +124,13 @@
 import { Component, Mixins, Prop } from 'vue-property-decorator'
 import StateMixin from '@/mixins/state'
 import FileEditor from './FileEditor.vue'
+import FileEditorTextOnly from './FileEditorTextOnly.vue'
+import isMobile from '@/util/is-mobile'
 
 @Component({
   components: {
-    FileEditor
+    FileEditor,
+    FileEditorTextOnly
   }
 })
 export default class FileEditorDialog extends Mixins(StateMixin) {
@@ -152,6 +163,10 @@ export default class FileEditorDialog extends Mixins(StateMixin) {
       this.editorReady &&
       !this.isUploading
     )
+  }
+
+  get isMobile () {
+    return isMobile()
   }
 
   get isUploading (): boolean {

--- a/src/components/widgets/filesystem/FileEditorTextOnly.vue
+++ b/src/components/widgets/filesystem/FileEditorTextOnly.vue
@@ -3,6 +3,7 @@
     class="editor v-input v-textarea theme--dark"
     :readonly="readonly"
     :value="value"
+    :spellcheck="false"
     @change="emitChange($event.target.value)"
   />
 </template>
@@ -35,7 +36,6 @@ export default class FileEditorText extends Vue {
     font-size: 1rem;
     font-weight: 100 !important;
     min-width: 100%;
-    height: 90% !important;
     height: calc(100% - 48px) !important;
     resize: none;
   }

--- a/src/components/widgets/filesystem/FileEditorTextOnly.vue
+++ b/src/components/widgets/filesystem/FileEditorTextOnly.vue
@@ -1,6 +1,6 @@
 <template>
   <textarea
-    class="editor v-input v-textarea theme--dark"
+    class="editor v-input v-textarea theme--dark px-2"
     :readonly="readonly"
     :value="value"
     :spellcheck="false"

--- a/src/components/widgets/filesystem/FileEditorTextOnly.vue
+++ b/src/components/widgets/filesystem/FileEditorTextOnly.vue
@@ -1,0 +1,42 @@
+<template>
+  <textarea
+    class="editor v-input v-textarea theme--dark"
+    :readonly="readonly"
+    :value="value"
+    @change="emitChange($event.target.value)"
+  />
+</template>
+
+<script lang="ts">
+import { Vue, Component, Prop } from 'vue-property-decorator'
+
+@Component({})
+export default class FileEditorText extends Vue {
+  @Prop({ type: String, required: true })
+  value!: string;
+
+  @Prop({ type: Boolean, default: false })
+  readonly!: boolean;
+
+  emitChange (value: string | undefined) {
+    this.$emit('change', value)
+    this.$emit('input', value)
+  }
+
+  mounted () {
+    this.$emit('ready')
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+  .editor {
+    font-family: monospace;
+    font-size: 1rem;
+    font-weight: 100 !important;
+    min-width: 100%;
+    height: 90% !important;
+    height: calc(100% - 48px) !important;
+    resize: none;
+  }
+</style>

--- a/src/util/is-mobile.ts
+++ b/src/util/is-mobile.ts
@@ -1,0 +1,5 @@
+const isMobile = () => {
+  return /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)
+}
+
+export default isMobile

--- a/src/util/is-mobile.ts
+++ b/src/util/is-mobile.ts
@@ -1,5 +1,5 @@
 const isMobile = () => {
-  return /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)
+  return (navigator as any).userAgentData?.mobile ?? /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)
 }
 
 export default isMobile


### PR DESCRIPTION
Monaco Editor is not supported on mobile devices (it says so on [their page](https://microsoft.github.io/monaco-editor/)), so instead of having a broken editing experience in mobile devices, better to just use a simple text area!

This change can be easily tested by changing the browser User Agent to a mobile one.

Screenshot from my own OnePlus Android phone:

![image](https://user-images.githubusercontent.com/85504/165805482-10cd947f-58ed-4683-9192-8a5d27ef789f.png)

Fixes #380

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>