### PR TITLE
fix: improves macro params default values parsing

### DIFF
--- a/src/components/ui/AppMacroBtn.vue
+++ b/src/components/ui/AppMacroBtn.vue
@@ -91,6 +91,7 @@
 import { Component, Prop, Mixins } from 'vue-property-decorator'
 import StateMixin from '@/mixins/state'
 import { Macro } from '@/store/macros/types'
+import gcodeMacroParams from '@/util/gcode-macro-params'
 
 @Component({})
 export default class AppMacroBtn extends Mixins(StateMixin) {
@@ -129,11 +130,7 @@ export default class AppMacroBtn extends Mixins(StateMixin) {
   mounted () {
     if (!this.macro.config || !this.macro.config.gcode) return []
     if (this.macro.config.gcode) {
-      for (const [, name, rest] of this.macro.config.gcode.matchAll(/params\.(\w+)(.*)/gi)) {
-        const valueMatch = /\|\s*default\s*\(\s*([^,)]+)/i.exec(rest)
-
-        const value = ((valueMatch && valueMatch[1]) || '').trim()
-
+      for (const { name, value } of gcodeMacroParams(this.macro.config.gcode)) {
         if (!this.params[name]) {
           this.$set(this.params, name, { value, reset: value })
         }

--- a/src/util/__tests__/gcode-macro-params.spec.ts
+++ b/src/util/__tests__/gcode-macro-params.spec.ts
@@ -1,0 +1,22 @@
+import { gcodeMacroParamDefault } from '../gcode-macro-params'
+
+describe('gcodeMacroParamDefault', () => {
+  it.each([
+    [' | default(0, true) | float', '0'],
+    [' | int | default(0.005, true) | float', '0.005'],
+    [' | default("PLA", true)', '"PLA"'],
+    [' | default("PLA")', '"PLA"'],
+    ['| int | default(0.2)', '0.2'],
+    ['| int | default(-0.2)', '-0.2'],
+    ['| int | default( -0.2 )', '-0.2'],
+    ['| int | default( - 0.2 )', ''],
+    ['|default(printer)|int', ''],
+    ['|default(-somevar)|int', ''],
+    ['|default(printer.configfile.settings.printer.max_velocity)|int', ''],
+    ['|default("this, \\"works,\\"" , true)|trim', '"this, \\"works,\\""'],
+    ['|default(",\\"fine,\\"",true)|trim', '",\\"fine,\\""'],
+    ['|default(\',2\',true)|trim', '\',2\'']
+  ])('Expects param default of "%s" to be %s', (param, expected) => {
+    expect(gcodeMacroParamDefault(param)).toBe(expected)
+  })
+})

--- a/src/util/gcode-macro-params.ts
+++ b/src/util/gcode-macro-params.ts
@@ -1,0 +1,17 @@
+const paramRegExp = /params\.(\w+)(.*)/gi
+const defaultValueRegExp = /\|\s*default\s*\(\s*((["'])(?:\\.|[^\2])*\2|-?[0-9][^,)]*)/i
+
+export const gcodeMacroParamDefault = (param: string) => {
+  const valueMatch = defaultValueRegExp.exec(param)
+
+  return ((valueMatch && valueMatch[1]) || '').trim()
+}
+
+const gcodeMacroParams = (gcode: string) => {
+  return [...gcode.matchAll(paramRegExp)].map(([, name, rest]) => ({
+    name,
+    value: gcodeMacroParamDefault(rest)
+  }))
+}
+
+export default gcodeMacroParams


### PR DESCRIPTION
Tested with the following example:

```
[gcode_macro TEST]
gcode:
  {% set A = params.A | default(0, true) | float %}
  {% set B = params.B | int | default(0.005, true) | float %}
  {% set C = params.C | default("PLA", true) %}
  {% set D = params.D | default("PLA") %}
  {% set E = params.E | int | default(0.2) %}
  {% set F = params.F|default(printer.configfile.settings.printer.max_velocity)|int %}
  {% set G = params.G|default("this \"works\"")|int %}
```

Before (F has default value when should not):

![image](https://user-images.githubusercontent.com/85504/166076491-655bad70-8892-4d68-8e0c-2837c348f06f.png)


After (no default value on F):

![image](https://user-images.githubusercontent.com/85504/166076450-4af64f92-d3ef-482f-b336-d406bf1f92a3.png)

Refactored the gcode macro params default values parsing so we can easily run a suite of tests on it.

Fixes #650

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>