### PR TITLE
fix: increase PA precision to 0.001

### DIFF
--- a/src/components/widgets/toolhead/PressureAdvanceAdjust.vue
+++ b/src/components/widgets/toolhead/PressureAdvanceAdjust.vue
@@ -14,7 +14,7 @@
         :locked="(!klippyReady || isMobile)"
         :min="0"
         :max="2"
-        :step="0.01"
+        :step="0.001"
         @change="handleSetPressureAdvance"
       />
     </v-col>
@@ -32,7 +32,7 @@
         :locked="(!klippyReady || isMobile)"
         :min="0"
         :max="0.2"
-        :step="0.01"
+        :step="0.001"
         @change="handleSetSmoothTime"
       />
     </v-col>


### PR DESCRIPTION
Run `SET_PRESSURE_ADVANCE ADVANCE=0.096 SMOOTH_TIME=0.025`

Before:

![localhost_8080_](https://user-images.githubusercontent.com/85504/166244778-7b22e235-ebad-477a-83f8-841071f4cab3.png)

After:

![localhost_8080_](https://user-images.githubusercontent.com/85504/166244582-c9dd27f3-0882-4910-9e2d-9d3cf50ac63f.png)

Scrolling does perform quite slower like this, but should still work fine!

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>