### PR TITLE
fix: show temp item as selected by default

### DIFF
--- a/src/components/widgets/thermals/TemperatureTargets.vue
+++ b/src/components/widgets/thermals/TemperatureTargets.vue
@@ -40,7 +40,7 @@
           </td>
           <td class="temp-name">
             <span
-              :class="{ 'active': chartSelectedLegends[item.name] }"
+              :class="{ 'active': !(item.name in chartSelectedLegends) || chartSelectedLegends[item.name] }"
               class="legend-item"
               @click="$emit('legendClick', item)"
             >


### PR DESCRIPTION
Minor UI issue, caused by the fact `selectedLegends = {}` is the default state when we start a new install, and that incorrectly shows the items as disabled.

Before:

![localhost_8080_](https://user-images.githubusercontent.com/85504/166677671-abe7ce7c-46b0-450e-9301-5229bd4218f1.png)

After:

![localhost_8080_](https://user-images.githubusercontent.com/85504/166677629-98b18aa2-1019-466c-83fb-94bece8722a5.png)

The default is all temp items selected, so let's show that accordingly!

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>