### PR TITLE
fix: show temp item as selected by default (cont.)

### DIFF
--- a/src/components/widgets/thermals/TemperatureTargets.vue
+++ b/src/components/widgets/thermals/TemperatureTargets.vue
@@ -99,7 +99,7 @@
           </td>
           <td class="temp-name">
             <span
-              :class="{ 'active': chartSelectedLegends[item.name] }"
+              :class="{ 'active': !(item.name in chartSelectedLegends) || chartSelectedLegends[item.name] }"
               class="legend-item"
               @click="$emit('legendClick', item)"
             >
@@ -163,7 +163,7 @@
           </td>
           <td class="temp-name">
             <span
-              :class="{ 'active': chartSelectedLegends[item.name] }"
+              :class="{ 'active': !(item.name in chartSelectedLegends) || chartSelectedLegends[item.name] }"
               class="legend-item"
               @click="$emit('legendClick', item)"
             >


### PR DESCRIPTION
Continuation of #655, the same fix needs to be applied to `fans` and `sensors` elements

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>