### PR TITLE
fix: allow omit 0 units in gcode number parsing

### DIFF
--- a/src/workers/parseGcode.ts
+++ b/src/workers/parseGcode.ts
@@ -15,7 +15,7 @@ function parseLine (line: string) {
 
   const argMap: any = {}
 
-  for (const [, key, value] of args.matchAll(/([a-z])[ \t]*(-?\d+(?:\.\d+)?)/ig)) {
+  for (const [, key, value] of args.matchAll(/([a-z])[ \t]*(-?(?:\d+(?:\.\d+)?|\.\d+))/ig)) {
     argMap[key.toLowerCase()] = Number(value)
   }
 


### PR DESCRIPTION
Ensures that the gcode parser can accept ".2" as a valid number (with omited "0" on unit)

This could be easily fixed just by this change:

```diff
- /([a-z])[ \t]*(-?\d+(?:\.\d+)?)/
+ /([a-z])[ \t]*(-?\d*(?:\.\d+)?)/
```

However, the above would allow for empty values (no number), so I opted for allowing the current or ".nnn".

Fixes #674

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>