### PR TITLE
fix(i18n-FR): fix typo in French translation

### DIFF
--- a/src/locales/fr.yaml
+++ b/src/locales/fr.yaml
@@ -447,7 +447,7 @@ app:
       os_packages: Paquets du système d'exploitation
       package_list: Liste des paquets
       up_to_date: A JOUR
-      updates_available: Mises à jour disponnibles
+      updates_available: Mises à jour disponibles
     status:
       finished: Mises à jour terminées
       updating: Mise à jour ...


### PR DESCRIPTION
fix: Fix a typo in French translations: 

`app.version.label.updates_available`: `disponnibles` -> `disponibles`

Signed-off-by: Samori Gorse <samori@codeinstyle.io>
