### PR TITLE
chore: temporary fix for release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
           echo ::set-output name=current_version::${GITHUB_REF#refs/tags/v}
 
       - name: Read ChangeLog
-        uses: mindsers/changelog-reader-action@v2
+        uses: pedrolamas/changelog-reader-action@d71e9d8dc93a56c192a84bddd8af46cf3b1d284b
         id: changelog
         with:
           validation_depth: 1


### PR DESCRIPTION
At the moment the changelog-reader-action is unable to correctly find patch versions on the CHANGELOG, so our release pipeline is failing.

The issue was fixed here: https://github.com/mindsers/changelog-reader-action/commit/baf2b5f006e435331aa4ea25d1fcdee6c7a7a37d

Once a new upstream version of this action is release, we can revert this change (and update the action version), but for now we are using a personal fork of the action.

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>