### PR TITLE
feat: adds "show current layer" to gcode previewer

### DIFF
--- a/src/components/widgets/gcode-preview/GcodePreview.vue
+++ b/src/components/widgets/gcode-preview/GcodePreview.vue
@@ -114,6 +114,19 @@
           />
         </g>
         <g
+          v-if="getViewerOption('showCurrentLayer')"
+          id="activeLayer"
+          class="layer"
+        >
+          <path
+            stroke="lightgrey"
+            :stroke-width="extrusionLineWidth"
+            stroke-opacity="0.6"
+            :d="svgPathActive.extrusions"
+            :shape-rendering="shapeRendering"
+          />
+        </g>
+        <g
           id="currentLayer"
           class="layer"
         >
@@ -419,6 +432,14 @@ export default class GcodePreview extends Mixins(StateMixin) {
     }
 
     return this.$store.getters['gcodePreview/getPaths'](layer?.move ?? 0, this.progress)
+  }
+
+  get svgPathActive (): LayerPaths {
+    if (this.disabled) {
+      return this.defaultLayerPaths
+    }
+
+    return this.$store.getters['gcodePreview/getLayerPaths'](this.layer)
   }
 
   get svgPathPrevious (): LayerPaths {

--- a/src/components/widgets/gcode-preview/GcodePreviewControls.vue
+++ b/src/components/widgets/gcode-preview/GcodePreviewControls.vue
@@ -8,6 +8,12 @@
 
     <gcode-preview-control-checkbox
       :disabled="disabled"
+      name="showCurrentLayer"
+      :label="$t('app.gcode.label.show_current_layer')"
+    />
+
+    <gcode-preview-control-checkbox
+      :disabled="disabled"
       name="showNextLayer"
       :label="$t('app.gcode.label.show_next_layer')"
     />

--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -113,6 +113,7 @@ app:
       layer: Layer
       layers: Layers
       parsed: Parsed
+      show_current_layer: Show current layer
       show_extrusions: Show extrusions
       show_moves: Show moves
       show_next_layer: Show next layer

--- a/src/store/gcodePreview/index.ts
+++ b/src/store/gcodePreview/index.ts
@@ -16,6 +16,7 @@ export const defaultState = (): GcodePreviewState => {
     parserWorker: null,
 
     viewer: {
+      showCurrentLayer: false,
       showNextLayer: false,
       showPreviousLayer: false,
       showMoves: true,

--- a/src/store/gcodePreview/types.ts
+++ b/src/store/gcodePreview/types.ts
@@ -10,6 +10,7 @@ export interface GcodePreviewState {
   parserWorker: Thread | null;
 
   viewer: {
+    showCurrentLayer: boolean;
     showNextLayer: boolean;
     showPreviousLayer: boolean;
     showMoves: boolean;


### PR DESCRIPTION
Adds a new "Show current layer" option that will ghost the paths for the currently printing layer.

![image](https://user-images.githubusercontent.com/85504/170028376-db24a290-83b9-409b-beca-4bbd21c95c7a.png)

Closes #689 

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>