### PR TITLE
fix: hide Pressure Advance if no default extruder stepper set

### DIFF
--- a/src/components/widgets/toolhead/Toolhead.vue
+++ b/src/components/widgets/toolhead/Toolhead.vue
@@ -20,7 +20,7 @@
 
     <!-- Speed and Flow Adjustments  -->
     <speed-and-flow-adjust />
-    <pressure-advance-adjust />
+    <pressure-advance-adjust v-if="showPressureAdvance" />
   </v-card-text>
 </template>
 
@@ -49,6 +49,11 @@ import PressureAdvanceAdjust from '@/components/widgets/toolhead/PressureAdvance
 export default class Toolhead extends Mixins(StateMixin) {
   get multipleExtruders () {
     return this.$store.getters['printer/getExtruders'].length > 1
+  }
+
+  get showPressureAdvance () {
+    const extruder = this.$store.getters['printer/getActiveExtruder']
+    return extruder?.pressure_advance !== undefined
   }
 }
 </script>


### PR DESCRIPTION
Klipper doesn't seem to provide what `extruder_stepper` is currently active so Moonraker can't make it available to the API consumers.

The only way forward in this for now is to just "hide" the full Pressure Advance controls if no `pressure_advance` values are provided in the active extruder (meaning no stepper is set)

Fixes #681

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>