### PR TITLE
fix: AppSlider mobile lock disabling

### DIFF
--- a/src/components/ui/AppSlider.vue
+++ b/src/components/ui/AppSlider.vue
@@ -40,7 +40,7 @@
               v-if="isMobile"
               icon
               small
-              :disabled="false"
+              :disabled="disabled"
               style="margin-top: -4px;"
               @click="lockState = !lockState"
             >


### PR DESCRIPTION
Noticed the mobile lock controls aren't actually disabled when the input is, causing some weird behavior