### PR TITLE
fix(layout): move gcode controls to dropdown; fix vertical layout

### DIFF
--- a/src/components/widgets/gcode-preview/GcodePreview.vue
+++ b/src/components/widgets/gcode-preview/GcodePreview.vue
@@ -531,6 +531,8 @@ export default class GcodePreview extends Mixins(StateMixin) {
   outline: none;
   overflow: hidden;
   border: 1px solid black;
+  max-height: 50vh;
+  aspect-ratio: 1;
 
   &:focus {
     border-color: grey;

--- a/src/components/widgets/gcode-preview/GcodePreview.vue
+++ b/src/components/widgets/gcode-preview/GcodePreview.vue
@@ -531,7 +531,7 @@ export default class GcodePreview extends Mixins(StateMixin) {
   outline: none;
   overflow: hidden;
   border: 1px solid black;
-  max-height: 50vh;
+  max-height: 67vh;
   aspect-ratio: 1;
 
   &:focus {

--- a/src/components/widgets/gcode-preview/GcodePreview.vue
+++ b/src/components/widgets/gcode-preview/GcodePreview.vue
@@ -531,7 +531,7 @@ export default class GcodePreview extends Mixins(StateMixin) {
   outline: none;
   overflow: hidden;
   border: 1px solid black;
-  max-height: 67vh;
+  max-height: calc(100vh * 2/3);
   aspect-ratio: 1;
 
   &:focus {

--- a/src/components/widgets/gcode-preview/GcodePreviewCard.vue
+++ b/src/components/widgets/gcode-preview/GcodePreviewCard.vue
@@ -5,6 +5,15 @@
     layout-path="dashboard.gcode-preview-card"
     :draggable="true"
   >
+    <template #menu>
+      <app-btn-collapse-group
+        :collapsed="true"
+        menu-icon="$cog"
+      >
+        <GcodePreviewControls :disabled="!fileLoaded" />
+      </app-btn-collapse-group>
+    </template>
+
     <v-card-text v-if="file">
       {{ file.name }}
     </v-card-text>
@@ -21,11 +30,7 @@
       />
 
       <v-row>
-        <v-col
-          cols="12"
-          lg="9"
-          md="7"
-        >
+        <v-col cols="8">
           <v-row>
             <v-col>
               <app-slider
@@ -55,25 +60,13 @@
               />
             </v-col>
           </v-row>
-          <v-row>
-            <v-col>
-              <gcode-preview
-                width="100%"
-                :layer="currentLayer"
-                :progress="moveProgress"
-                :disabled="!fileLoaded"
-              />
-            </v-col>
-          </v-row>
         </v-col>
         <v-col
-          cols="12"
-          lg="3"
-          md="5"
+          cols="4"
         >
           <v-card
             outlined
-            class="px-2 py-1 text-center stat-square"
+            class="px-2 py-1 text-center stat-square justify-center"
           >
             <div class="">
               {{ $t('app.gcode.label.layers') }}
@@ -88,7 +81,17 @@
               {{ currentLayerHeight }}
             </div>
           </v-card>
-          <GcodePreviewControls :disabled="!fileLoaded" />
+        </v-col>
+      </v-row>
+
+      <v-row>
+        <v-col>
+          <gcode-preview
+            width="100%"
+            :layer="currentLayer"
+            :progress="moveProgress"
+            :disabled="!fileLoaded"
+          />
         </v-col>
       </v-row>
     </v-card-text>

--- a/src/components/widgets/gcode-preview/GcodePreviewCard.vue
+++ b/src/components/widgets/gcode-preview/GcodePreviewCard.vue
@@ -6,22 +6,20 @@
     :draggable="true"
   >
     <template #menu>
-      <app-btn-collapse-group>
-        <app-btn
-          :disabled="!printerFile || printerFileLoaded"
-          color="primary"
-          small
-          @click="loadCurrent"
-        >
-          {{ $t('app.gcode.btn.load_current_file') }}
-        </app-btn>
+      <app-btn
+        :disabled="!printerFile || printerFileLoaded"
+        color="primary"
+        small
+        @click="loadCurrent"
+      >
+        {{ $t('app.gcode.btn.load_current_file') }}
+      </app-btn>
 
-        <app-btn-collapse-group
-          :collapsed="true"
-          menu-icon="$cog"
-        >
-          <GcodePreviewControls :disabled="!fileLoaded" />
-        </app-btn-collapse-group>
+      <app-btn-collapse-group
+        :collapsed="true"
+        menu-icon="$cog"
+      >
+        <GcodePreviewControls :disabled="!fileLoaded" />
       </app-btn-collapse-group>
     </template>
 

--- a/src/components/widgets/gcode-preview/GcodePreviewCard.vue
+++ b/src/components/widgets/gcode-preview/GcodePreviewCard.vue
@@ -41,7 +41,10 @@
       />
 
       <v-row>
-        <v-col cols="8">
+        <v-col
+          cols="12"
+          md="8"
+        >
           <v-row>
             <v-col>
               <app-slider
@@ -73,7 +76,8 @@
           </v-row>
         </v-col>
         <v-col
-          cols="4"
+          cols="12"
+          md="4"
         >
           <v-row>
             <v-col>

--- a/src/components/widgets/gcode-preview/GcodePreviewCard.vue
+++ b/src/components/widgets/gcode-preview/GcodePreviewCard.vue
@@ -6,20 +6,22 @@
     :draggable="true"
   >
     <template #menu>
-      <app-btn
-        :disabled="!printerFile || printerFileLoaded"
-        color="primary"
-        small
-        @click="loadCurrent"
-      >
-        {{ $t('app.gcode.btn.load_current_file') }}
-      </app-btn>
+      <app-btn-collapse-group>
+        <app-btn
+          :disabled="!printerFile || printerFileLoaded"
+          color="primary"
+          small
+          @click="loadCurrent"
+        >
+          {{ $t('app.gcode.btn.load_current_file') }}
+        </app-btn>
 
-      <app-btn-collapse-group
-        :collapsed="true"
-        menu-icon="$cog"
-      >
-        <GcodePreviewControls :disabled="!fileLoaded" />
+        <app-btn-collapse-group
+          :collapsed="true"
+          menu-icon="$cog"
+        >
+          <GcodePreviewControls :disabled="!fileLoaded" />
+        </app-btn-collapse-group>
       </app-btn-collapse-group>
     </template>
 

--- a/src/components/widgets/gcode-preview/GcodePreviewControls.vue
+++ b/src/components/widgets/gcode-preview/GcodePreviewControls.vue
@@ -1,7 +1,7 @@
 <template>
-  <div>
+  <div class="px-2 mt-n2 mb-2">
     <gcode-preview-control-checkbox
-      :disabled="disabled || !printerFileLoaded"
+      :disabled="disabled || !canFollowProgress"
       name="followProgress"
       :label="$t('app.gcode.label.follow_progress')"
     />
@@ -41,27 +41,6 @@
       name="showRetractions"
       :label="$t('app.gcode.label.show_retractions')"
     />
-
-    <app-btn
-      :disabled="!printerFile || printerFileLoaded"
-      color="primary"
-      class="mt-3"
-      block
-      small
-      @click="loadCurrent"
-    >
-      {{ $t('app.gcode.btn.load_current_file') }}
-    </app-btn>
-
-    <app-btn
-      :disabled="noMoves"
-      color="secondary"
-      class="mt-3"
-      block
-      @click="resetFile"
-    >
-      {{ $t('app.general.btn.reset_file') }}
-    </app-btn>
   </div>
 </template>
 
@@ -70,8 +49,6 @@ import { Component, Mixins, Prop } from 'vue-property-decorator'
 import StateMixin from '@/mixins/state'
 import GcodePreviewControlCheckbox from '@/components/widgets/gcode-preview/GcodePreviewControlCheckbox.vue'
 import FilesMixin from '@/mixins/files'
-import { AppFile } from '@/store/files/types'
-import { AxiosResponse } from 'axios'
 
 @Component({
   components: { GcodePreviewControlCheckbox }
@@ -80,49 +57,11 @@ export default class GcodePreviewControls extends Mixins(StateMixin, FilesMixin)
   @Prop({ type: Boolean, default: false })
   disabled!: boolean
 
-  get printerFile (): AppFile | undefined {
-    const currentFile = this.$store.state.printer.printer.current_file
-
-    if (currentFile.filename) {
-      return currentFile
-    }
-  }
-
-  get printerFileLoaded () {
+  get canFollowProgress () {
     const file = this.$store.getters['gcodePreview/getFile']
-    const printerFile = this.printerFile
+    const printerFile = this.$store.state.printer.printer.current_file
 
-    if (!file || !printerFile || (file.path + '/' + file.filename) !== (printerFile.path + '/' + printerFile.filename)) {
-      this.$store.commit('gcodePreview/setViewerState', { followProgress: false })
-
-      return false
-    }
-
-    return true
-  }
-
-  get noMoves () {
-    return this.$store.getters['gcodePreview/getMoves'].length === 0
-  }
-
-  async loadCurrent () {
-    const file = this.$store.state.printer.printer.current_file as AppFile
-    this.getGcode(file)
-      .then(response => response?.data)
-      .then((gcode: AxiosResponse) => {
-        this.$store.dispatch('gcodePreview/loadGcode', {
-          file,
-          gcode
-        })
-      })
-      .catch(e => e)
-      .finally(() => {
-        this.$store.dispatch('files/removeFileDownload')
-      })
-  }
-
-  resetFile () {
-    this.$store.dispatch('gcodePreview/reset')
+    return file && printerFile && (file.path + '/' + file.filename) === (printerFile.path + '/' + printerFile.filename)
   }
 }
 </script>


### PR DESCRIPTION
Moves the gcode preview related settings to a dropdown and fixes the layout to be compatible with vertical monitors
![image](https://user-images.githubusercontent.com/25269274/170486312-94a65b29-5fd0-4b17-8384-a4a00023eda8.png)
![image](https://user-images.githubusercontent.com/25269274/170486332-93570df0-a29e-4d0d-80b8-5caa71791e61.png)

Not sure if the "Load current file" and "Clear file" buttons should also go there, LMK what you think..

Closes #690