### PR TITLE
feat: keep icon buttons visible on mobile view

### DIFF
--- a/src/components/ui/AppBtnCollapseGroup.vue
+++ b/src/components/ui/AppBtnCollapseGroup.vue
@@ -1,6 +1,9 @@
 <template>
   <!-- not collapsed -->
-  <div v-if="!isCollapsed && hasDefaultSlot">
+  <div
+    v-if="!isCollapsed && hasDefaultSlot"
+    class="d-inline-block"
+  >
     <slot />
   </div>
 

--- a/src/components/widgets/gcode-preview/GcodePreviewCard.vue
+++ b/src/components/widgets/gcode-preview/GcodePreviewCard.vue
@@ -15,13 +15,13 @@
         >
           {{ $t('app.gcode.btn.load_current_file') }}
         </app-btn>
+      </app-btn-collapse-group>
 
-        <app-btn-collapse-group
-          :collapsed="true"
-          menu-icon="$cog"
-        >
-          <GcodePreviewControls :disabled="!fileLoaded" />
-        </app-btn-collapse-group>
+      <app-btn-collapse-group
+        :collapsed="true"
+        menu-icon="$cog"
+      >
+        <GcodePreviewControls :disabled="!fileLoaded" />
       </app-btn-collapse-group>
     </template>
 

--- a/src/components/widgets/thermals/TemperatureCard.vue
+++ b/src/components/widgets/thermals/TemperatureCard.vue
@@ -37,33 +37,33 @@
           @applyOff="handleApplyOff"
           @applyPreset="handleApplyPreset"
         />
+      </app-btn-collapse-group>
 
-        <app-btn-collapse-group
-          :collapsed="true"
-          menu-icon="$cog"
-        >
-          <v-checkbox
-            v-model="showRateOfChange"
-            :label="$t('app.setting.label.show_rate_of_change')"
-            color="primary"
-            hide-details
-            class="mx-2 mt-2 mb-2"
-          />
-          <v-checkbox
-            v-model="showRelativeHumidity"
-            :label="$t('app.setting.label.show_relative_humidity')"
-            color="primary"
-            hide-details
-            class="mx-2 mt-2 mb-2"
-          />
-          <v-checkbox
-            v-model="showBarometricPressure"
-            :label="$t('app.setting.label.show_barometric_pressure')"
-            color="primary"
-            hide-details
-            class="mx-2 mt-2 mb-2"
-          />
-        </app-btn-collapse-group>
+      <app-btn-collapse-group
+        :collapsed="true"
+        menu-icon="$cog"
+      >
+        <v-checkbox
+          v-model="showRateOfChange"
+          :label="$t('app.setting.label.show_rate_of_change')"
+          color="primary"
+          hide-details
+          class="mx-2 mt-2 mb-2"
+        />
+        <v-checkbox
+          v-model="showRelativeHumidity"
+          :label="$t('app.setting.label.show_relative_humidity')"
+          color="primary"
+          hide-details
+          class="mx-2 mt-2 mb-2"
+        />
+        <v-checkbox
+          v-model="showBarometricPressure"
+          :label="$t('app.setting.label.show_barometric_pressure')"
+          color="primary"
+          hide-details
+          class="mx-2 mt-2 mb-2"
+        />
       </app-btn-collapse-group>
     </template>
 


### PR DESCRIPTION
Keep the mini buttons on the cards visible on mobile view (affects the Gcode Preview and Temperature cards only)

| before | after |
|--|--|
| ![image](https://user-images.githubusercontent.com/85504/173026763-ba5547f4-9087-406a-98cd-cba8e7ffa03e.png) | ![image](https://user-images.githubusercontent.com/85504/173026646-93c1086b-d7c8-4072-a6e3-eacd92ca3b02.png) |

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>