### PR TITLE
fix: hide card buttons and menus in layout view

### DIFF
--- a/src/components/common/CollapsableCard.vue
+++ b/src/components/common/CollapsableCard.vue
@@ -26,6 +26,7 @@
         </v-col>
 
         <v-col
+          v-if="!inLayout"
           cols="auto"
           align-self="center"
         >


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/85504/173028076-fb3da98e-c83d-4181-b788-b0f3a97a968c.png)

After:

![image](https://user-images.githubusercontent.com/85504/173027991-81de1d4c-9427-4682-ba4e-2aa915f49129.png)

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>