### PR TITLE
feat: adds setting to toggle Codelens visibility

### DIFF
--- a/src/components/settings/FileEditorSettings.vue
+++ b/src/components/settings/FileEditorSettings.vue
@@ -37,6 +37,19 @@
 
       <v-divider />
 
+      <app-setting
+        :title="$t('app.setting.label.show_code_lens')"
+      >
+        <v-switch
+          v-model="codeLens"
+          hide-details
+          class="mb-5"
+          @click.native.stop
+        />
+      </app-setting>
+
+      <v-divider />
+
       <app-setting :title="$t('app.setting.label.reset')">
         <app-btn
           outlined
@@ -83,6 +96,18 @@ export default class FileEditorSettings extends Mixins(StateMixin) {
     this.$store.dispatch('config/saveByPath', {
       path: 'uiSettings.editor.autoEditExtensions',
       value: value.sort(),
+      server: true
+    })
+  }
+
+  get codeLens (): boolean {
+    return this.$store.state.config.uiSettings.editor.codeLens
+  }
+
+  set codeLens (value: boolean) {
+    this.$store.dispatch('config/saveByPath', {
+      path: 'uiSettings.editor.codeLens',
+      value,
       server: true
     })
   }

--- a/src/components/widgets/filesystem/FileEditor.vue
+++ b/src/components/widgets/filesystem/FileEditor.vue
@@ -32,6 +32,9 @@ export default class FileEditor extends Vue {
   @Prop({ type: Boolean, default: false })
   readonly!: boolean;
 
+  @Prop({ type: Boolean, default: true })
+  codeLens!: boolean;
+
   @Ref('monaco-editor') monacoEditor!: HTMLElement
 
   // Our editor, once init'd.
@@ -41,6 +44,7 @@ export default class FileEditor extends Vue {
   opts: Monaco.editor.IStandaloneEditorConstructionOptions = {
     contextmenu: false,
     readOnly: this.readonly,
+    codeLens: this.codeLens,
     automaticLayout: true,
     fontSize: 16,
     scrollbar: {

--- a/src/components/widgets/filesystem/FileEditorDialog.vue
+++ b/src/components/widgets/filesystem/FileEditorDialog.vue
@@ -102,6 +102,7 @@
         v-model="updatedContent"
         :filename="filename"
         :readonly="readonly"
+        :code-lens="codeLens"
         @ready="editorReady = true"
       />
 
@@ -177,6 +178,10 @@ export default class FileEditorDialog extends Mixins(StateMixin) {
 
   get configMap () {
     return this.$store.getters['server/getConfigMapByFilename'](this.filename)
+  }
+
+  get codeLens () {
+    return this.$store.state.config.uiSettings.editor.codeLens
   }
 
   mounted () {

--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -426,6 +426,7 @@ app:
       retraction_icon_size: Retraction Icon Size
       show_animations: Show animations
       show_barometric_pressure: Show barometric pressure
+      show_code_lens: Show CodeLens
       show_rate_of_change: Show temperature rate of change
       show_relative_humidity: Show relative humidity
       starts_with: Starts with

--- a/src/store/config/index.ts
+++ b/src/store/config/index.ts
@@ -77,7 +77,8 @@ export const defaultState = (): ConfigState => {
       },
       editor: {
         confirmDirtyEditorClose: true,
-        autoEditExtensions: ['.cfg', '.conf', '.ini', '.log', '.md', '.sh', '.txt']
+        autoEditExtensions: ['.cfg', '.conf', '.ini', '.log', '.md', '.sh', '.txt'],
+        codeLens: true
       },
       dashboard: {
         tempPresets: []

--- a/src/store/config/types.ts
+++ b/src/store/config/types.ts
@@ -83,6 +83,7 @@ export interface SupportedThemeLogo {
 export interface EditorConfig {
   confirmDirtyEditorClose: boolean;
   autoEditExtensions: string[];
+  codeLens: boolean;
 }
 
 export interface Axis {


### PR DESCRIPTION
Adds new setting to control CodeLens visibility (defaults to true)

![image](https://user-images.githubusercontent.com/85504/173552546-4fd7f1a5-4550-4bbf-8efb-5f5d3182ca7c.png)

Fixes #711 
Fixes #713 

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>