### PR TITLE
fix: mitigates network error with latest Axios

### DIFF
--- a/src/api/httpClient.ts
+++ b/src/api/httpClient.ts
@@ -78,7 +78,7 @@ const errorInterceptor = (error: AxiosError<string | { error?: { message?: strin
   let message: string | undefined
 
   // Check if its a network / server error.
-  if (!error.response) {
+  if (!error.response || error.code === 'ERR_NETWORK') {
     // Network / Server Error.
     if (error.message) message = error.message
     consola.debug(message || 'Network error')


### PR DESCRIPTION
Restarting Moonraker (via Fluidd option or when saving changes to "moonraker.conf") will show the below image, which is an expected error (connection close leads to network error)

![image](https://user-images.githubusercontent.com/85504/173560285-111215b2-6437-4e09-b127-deb6728853ef.png)

This adds a further check for network error issues to the existing code.

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>