### PR TITLE
fix: show absolute/relative positioning controls

### DIFF
--- a/src/components/widgets/toolhead/ToolheadPosition.vue
+++ b/src/components/widgets/toolhead/ToolheadPosition.vue
@@ -6,7 +6,7 @@
       no-gutters
     >
       <v-col
-        cols="4"
+        cols="3"
         class="pr-1"
       >
         <v-text-field
@@ -23,7 +23,7 @@
         />
       </v-col>
       <v-col
-        cols="4"
+        cols="3"
         class="pr-1 pl-1"
       >
         <v-text-field
@@ -40,8 +40,8 @@
         />
       </v-col>
       <v-col
-        cols="4"
-        class="pl-1"
+        cols="3"
+        class="pr-1 pl-1"
       >
         <v-text-field
           :label="`Z [ ${livePosition[2].toFixed(2)} ]`"
@@ -55,6 +55,46 @@
           :value="(useGcodeCoords) ? gcodePosition[2].toFixed(2) : toolheadPosition[2].toFixed(2)"
           @change="moveTo('Z', $event)"
         />
+      </v-col>
+      <v-col
+        cols="3"
+        class="pl-1"
+      >
+        <v-btn-toggle
+          v-model="positioning"
+          mandatory
+          dense
+          class="d-block"
+        >
+          <v-tooltip top>
+            <template #activator="{ on, attrs }">
+              <app-btn
+                v-bind="attrs"
+                class="positioning-toggle-button"
+                v-on="on"
+              >
+                <v-icon small>
+                  $absolutePositioning
+                </v-icon>
+              </app-btn>
+            </template>
+            <span>{{ $t('app.tool.tooltip.absolute_positioning') }}</span>
+          </v-tooltip>
+          <v-tooltip top>
+            <template #activator="{ on, attrs }">
+              <app-btn
+                v-bind="attrs"
+                class="positioning-toggle-button"
+                v-on="on"
+              >
+                <v-icon small>
+                  $relativePositioning
+                </v-icon>
+              </app-btn>
+            </template>
+            <span>{{ $t('app.tool.tooltip.relative_positioning') }}</span>
+          </v-tooltip>
+        </v-btn-toggle>
       </v-col>
     </v-row>
 
@@ -113,6 +153,18 @@ export default class ToolheadPosition extends Mixins(StateMixin, ToolheadMixin) 
     return speed.toFixed()
   }
 
+  get usesAbsolutePositioning () {
+    return this.$store.state.printer.printer.gcode_move.absolute_coordinates
+  }
+
+  get positioning () {
+    return this.usesAbsolutePositioning ? 0 : 1
+  }
+
+  set positioning (value: number) {
+    this.sendGcode(`G9${value}`)
+  }
+
   moveTo (axis: string, pos: string) {
     const axisIndexMap: any = { X: 0, Y: 1, Z: 2 }
     const currentPos = (this.useGcodeCoords)
@@ -130,15 +182,8 @@ export default class ToolheadPosition extends Mixins(StateMixin, ToolheadMixin) 
 </script>
 
 <style type="scss" scoped>
-  .coord-wrapper {
-    line-height: 32px;
-    padding: 0 12px;
+  .positioning-toggle-button {
+    min-width: 20px !important;
+    width: 50%;
   }
-  /* .coord-col {
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-    align-items: center;
-    max-height: 36px;
-  } */
 </style>

--- a/src/globals.ts
+++ b/src/globals.ts
@@ -119,7 +119,9 @@ import {
   mdiFileVideoOutline,
   mdiBellSleep,
   mdiChip,
-  mdiViewHeadline
+  mdiViewHeadline,
+  mdiAxisArrow,
+  mdiVectorLine
 } from '@mdi/js'
 
 /**
@@ -308,7 +310,9 @@ export const Icons = Object.freeze({
   video: mdiFileVideoOutline,
   snooze: mdiBellSleep,
   chip: mdiChip,
-  viewHeadline: mdiViewHeadline
+  viewHeadline: mdiViewHeadline,
+  absolutePositioning: mdiAxisArrow,
+  relativePositioning: mdiVectorLine
 })
 
 export const Waits = Object.freeze({

--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -493,12 +493,14 @@ app:
       home_y: 'Y'
       home_all: All
     tooltip:
+      absolute_positioning: Absolute Positioning
       extruder_disabled: extruder disabled, below min_extrude_temp (%{min}<small>°C</small>)
       home_xy: Home XY
       home_z: Home Z
       motors_off: MOTORS OFF
       z_tilt_adjust: Z_Tilt_Adjust
       quad_gantry_level: QGL
+      relative_positioning: Relative Positioning
       screws_tilt_calculate: Screws_Tilt_Calculate
       bed_screws_adjust: BED_SCREWS_ADJUST
   version:


### PR DESCRIPTION
Adds controls to change between relative/absolute positioning mode.

![image](https://user-images.githubusercontent.com/85504/173571749-701aa047-d765-4fdc-8ad7-bd62d02969de.png)

![image](https://user-images.githubusercontent.com/85504/173571807-da7afd28-eb07-40b7-b164-dd847a3d67e2.png)

![image](https://user-images.githubusercontent.com/85504/173571821-5a731449-b8db-4287-b1f5-7133a8d02fff.png)

Related to #395

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>