### PR TITLE
feat: ldap authentication support

### DIFF
--- a/src/api/auth.api.ts
+++ b/src/api/auth.api.ts
@@ -3,12 +3,12 @@ import { AxiosRequestConfig, AxiosResponse } from 'axios'
 import { AppUser } from '@/store/auth/types'
 
 export const authApi = {
-  async login (username: string, password: string): Promise<AxiosResponse> {
-    const login = await httpClient.post('/access/login', {
+  async login (username: string, password: string, source = 'moonraker'): Promise<AxiosResponse> {
+    return await httpClient.post('/access/login', {
       username,
-      password
+      password,
+      source
     })
-    return login
   },
 
   async logout (): Promise<AxiosResponse> {

--- a/src/components/layout/AppUserMenu.vue
+++ b/src/components/layout/AppUserMenu.vue
@@ -31,11 +31,20 @@
           class="mt-3"
         >
           <app-btn
+            :disabled="user.source !== 'moonraker'"
             small
             @click="$emit('change-password')"
           >
-            Change password
+            {{ $t('app.general.label.change_password') }}
           </app-btn>
+          <div
+            v-if="user.source !== 'moonraker'"
+            class="mt-2"
+          >
+            <small>
+              {{ $t('app.general.label.user_managed_source', { source: $t(`app.general.label.${user.source}`) }) }}
+            </small>
+          </div>
         </div>
       </v-card-text>
 

--- a/src/components/settings/auth/AuthSettings.vue
+++ b/src/components/settings/auth/AuthSettings.vue
@@ -48,6 +48,11 @@
       >
         <app-setting
           :key="`user-${user.username}`"
+          :sub-title="
+            user.username === currentUser ? $t('app.general.label.current_user') :
+            user.source !== 'moonraker' ? $t('app.general.label.user_managed_source', { source: $t(`app.general.label.${user.source}`) }) :
+            undefined
+          "
           :r-cols="3"
         >
           <template #title>
@@ -55,7 +60,7 @@
           </template>
 
           <app-btn
-            :disabled="user.username === currentUser"
+            :disabled="user.username === currentUser || user.source !== 'moonraker'"
             fab
             text
             x-small

--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -131,6 +131,7 @@ app:
       add_printer: Add printer
       adjust_layout: Adjust dashboard layout
       all: All
+      auth_unsure: Unsure why you're seeing this?
       calibrate: Calibrate
       cancel: Cancel
       clear_profile: Clear Profile
@@ -140,8 +141,10 @@ app:
       edit: Edit
       exit_layout: Exit layout mode
       extrude: Extrude
+      forgot_password: Forgotten your password?
       heaters_off: Heaters off
       load_all: Load all
+      login: Login
       more_information: More information
       pause: Pause
       preheat: Preheat
@@ -196,6 +199,7 @@ app:
       add_user: Add user
       api_key: Api Key
       api_url: API URL
+      auth_source: Authentication Source
       category: Category
       change_password: Change password
       clear_all: Clear all
@@ -221,9 +225,11 @@ app:
       host: Host
       layer: Layer
       layout: Layout
+      ldap: LDAP
       longest_job: Longest job
       low: Low
       m117: M117
+      moonraker: Moonraker
       name: Name
       new_password: New password
       no_notifications: No notifications
@@ -255,6 +261,7 @@ app:
       unretract_extra_length: Unretract Extra Length
       unretract_speed: Unretract Speed
       used: used
+      username: Username
       variance: Variance
       velocity: Velocity
       visible: Visible
@@ -271,6 +278,7 @@ app:
     simple_form:
       error:
         arrayofnums: Only numbers
+        credentials: Invalid credentials
         exists: Already exists
         invalid_number: Invalid Number
         invalid_url: Invalid URL

--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -206,6 +206,7 @@ app:
       color: Color
       confirm: Confirm
       current_password: Current password
+      current_user: Current user
       disabled_while_printing: Disabled while printing
       edit_camera: Edit Camera
       edit_filter: Edit Filter
@@ -228,6 +229,7 @@ app:
       ldap: LDAP
       longest_job: Longest job
       low: Low
+      user_managed_source: User managed by %{source} authentication
       m117: M117
       moonraker: Moonraker
       name: Name

--- a/src/store/auth/actions.ts
+++ b/src/store/auth/actions.ts
@@ -110,9 +110,9 @@ export const actions: ActionTree<AuthState, RootState> = {
       })
   },
 
-  async login ({ commit }, payload) {
+  async login ({ commit }, { username, password, source }) {
     const keys = getTokenKeys()
-    return authApi.login(payload.username, payload.password)
+    return authApi.login(username, password, source)
       .then(response => response.data.result)
       .then((user) => {
         // Successful login. Set the tokens and auth status and move on.

--- a/src/store/auth/actions.ts
+++ b/src/store/auth/actions.ts
@@ -110,6 +110,21 @@ export const actions: ActionTree<AuthState, RootState> = {
       })
   },
 
+  async getAuthInfo (): Promise<{ defaultSource: string, availableSources: string[] }> {
+    return httpClient.get('/access/info', { withAuth: false })
+      .then(r => {
+        return {
+          defaultSource: r.data.result.default_source,
+          availableSources: r.data.result.available_sources
+        }
+      }).catch(() => {
+        return {
+          defaultSource: 'moonraker',
+          availableSources: ['moonraker']
+        }
+      })
+  },
+
   async login ({ commit }, { username, password, source }) {
     const keys = getTokenKeys()
     return authApi.login(username, password, source)

--- a/src/store/auth/actions.ts
+++ b/src/store/auth/actions.ts
@@ -110,7 +110,7 @@ export const actions: ActionTree<AuthState, RootState> = {
       })
   },
 
-  async getAuthInfo (): Promise<{ defaultSource: string, availableSources: string[] }> {
+  async getAuthInfo () {
     return httpClient.get('/access/info', { withAuth: false })
       .then(r => {
         return {
@@ -118,10 +118,8 @@ export const actions: ActionTree<AuthState, RootState> = {
           availableSources: r.data.result.available_sources
         }
       }).catch(() => {
-        return {
-          defaultSource: 'moonraker',
-          availableSources: ['moonraker']
-        }
+        // external authentication sources not supported
+        return {}
       })
   },
 

--- a/src/store/auth/types.ts
+++ b/src/store/auth/types.ts
@@ -11,5 +11,6 @@ export interface AuthState {
 
 export interface AppUser {
   username: string;
+  source: 'moonraker' | 'ldap';
   created_on: number;
 }

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -22,12 +22,12 @@
             v-if="error"
             type="error"
           >
-            Invalid credentials
+            {{ $t('app.general.simple_form.error.credentials') }}
           </v-alert>
 
           <v-text-field
             v-model="username"
-            label="Username"
+            :label="$t('app.general.label.username')"
             autocomplete="username"
             filled
             dense
@@ -38,13 +38,25 @@
 
           <v-text-field
             v-model="password"
-            label="Password"
+            :label="$t('app.general.label.password')"
             autocomplete="current-password"
             filled
             dense
             type="password"
             hide-details="auto"
             :disabled="loading"
+            class="mb-4"
+          />
+
+          <v-select
+            v-if="availableSources.length > 1"
+            v-model="source"
+            :label="$t('app.general.label.auth_source')"
+            filled
+            dense
+            hide-details="auto"
+            :disabled="loading"
+            :items="availableSources.map(value => ({ text: $t(`app.general.label.${value}`), value }))"
             class="mb-4"
           />
 
@@ -61,7 +73,7 @@
             >
               $loading
             </v-icon>
-            Login
+            {{ $t('app.general.btn.login') }}
           </app-btn>
 
           <app-btn
@@ -71,7 +83,7 @@
             :href="$globals.DOCS_AUTH_LOST_PASSWORD"
             target="_blank"
           >
-            Forgotten your password?
+            {{ $t('app.general.btn.forgot_password') }}
           </app-btn>
 
           <app-btn
@@ -81,7 +93,7 @@
             :href="$globals.DOCS_AUTH"
             target="_blank"
           >
-            Unsure why you're seeing this?
+            {{ $t('app.general.btn.auth_unsure') }}
           </app-btn>
         </div>
       </v-form>
@@ -94,6 +106,7 @@ import { Component, Vue } from 'vue-property-decorator'
 import { appInit } from '@/init'
 import consola from 'consola'
 import { InitConfig } from '@/store/config/types'
+import httpClient from '@/api/httpClient'
 
 @Component({})
 export default class Login extends Vue {
@@ -102,12 +115,24 @@ export default class Login extends Vue {
   valid = true
   error = false
   loading = false
+  source = 'moonraker'
+  availableSources = [this.source]
+
+  mounted () {
+    httpClient.get('/access/info', { withAuth: false })
+      .then(r => {
+        this.source = r.data.result.default_source
+        this.availableSources = r.data.result.available_sources
+      }).catch(() => {
+        // ignore
+      })
+  }
 
   async handleLogin () {
     this.error = false
     this.loading = true
     try {
-      await this.$store.dispatch('auth/login', { username: this.username, password: this.password })
+      await this.$store.dispatch('auth/login', { username: this.username, password: this.password, source: this.source })
     } catch (err) {
       this.error = true
     }

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -106,7 +106,6 @@ import { Component, Vue } from 'vue-property-decorator'
 import { appInit } from '@/init'
 import consola from 'consola'
 import { InitConfig } from '@/store/config/types'
-import httpClient from '@/api/httpClient'
 
 @Component({})
 export default class Login extends Vue {
@@ -118,14 +117,9 @@ export default class Login extends Vue {
   source = 'moonraker'
   availableSources = [this.source]
 
-  mounted () {
-    httpClient.get('/access/info', { withAuth: false })
-      .then(r => {
-        this.source = r.data.result.default_source
-        this.availableSources = r.data.result.available_sources
-      }).catch(() => {
-        // ignore
-      })
+  async mounted () {
+    const authInfo = await this.$store.dispatch('auth/getAuthInfo')
+    Object.assign(this, authInfo)
   }
 
   async handleLogin () {

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -119,7 +119,8 @@ export default class Login extends Vue {
 
   async mounted () {
     const authInfo = await this.$store.dispatch('auth/getAuthInfo')
-    Object.assign(this, authInfo)
+    this.source = authInfo.defaultSource ?? this.source
+    this.availableSources = authInfo.availableSources ?? this.availableSources
   }
 
   async handleLogin () {


### PR DESCRIPTION
Adds a authentication source dropdown to the login page (only if LDAP authentication is configured) with the corresponding default:
![1](https://user-images.githubusercontent.com/25269274/174330779-55910971-7f40-4982-ab4d-3465de43db73.png)
![2](https://user-images.githubusercontent.com/25269274/174330784-68bcefe0-57be-4414-ba3d-04aec9eb55b7.png)

Disables the corresponding user controls when a user is LDAP sourced:
![3](https://user-images.githubusercontent.com/25269274/174330786-0b4b6af3-bd7d-43f1-ba8d-4e904cd071e4.png)
![4](https://user-images.githubusercontent.com/25269274/174330788-3067d4bb-3957-4fe8-88f9-841f3957117b.png)
