### PR TITLE
fix: disable positioning mode buttons when klippy is not ready

### DIFF
--- a/src/components/widgets/toolhead/ToolheadPosition.vue
+++ b/src/components/widgets/toolhead/ToolheadPosition.vue
@@ -71,7 +71,7 @@
               <app-btn
                 v-bind="attrs"
                 class="positioning-toggle-button"
-                :disabled="printerBusy"
+                :disabled="!klippyReady || printerBusy"
                 v-on="on"
               >
                 <v-icon small>
@@ -86,7 +86,7 @@
               <app-btn
                 v-bind="attrs"
                 class="positioning-toggle-button"
-                :disabled="printerBusy"
+                :disabled="!klippyReady || printerBusy"
                 v-on="on"
               >
                 <v-icon small>


### PR DESCRIPTION
Signed-off-by: Mathis Mensing <matmen@dreadful.tech>