### PR TITLE
fix: console error from LDAP auth changes

### DIFF
--- a/src/components/layout/AppUserMenu.vue
+++ b/src/components/layout/AppUserMenu.vue
@@ -27,7 +27,7 @@
         <span class="text-h5">{{ currentUser }}</span>
 
         <div
-          v-if="!isTrustedOnly"
+          v-if="user && !isTrustedOnly"
           class="mt-3"
         >
           <app-btn


### PR DESCRIPTION
This issue was introduced with the changes from #721, where we are now accessing `this.user` without performing a null check first!

![image](https://user-images.githubusercontent.com/85504/174820040-067c9743-8cbb-4ae5-83ce-8b4e15779659.png)

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>