### PR TITLE
fix: only splice waits if contains item

### DIFF
--- a/src/store/wait/mutations.ts
+++ b/src/store/wait/mutations.ts
@@ -14,7 +14,7 @@ export const mutations: MutationTree<WaitState> = {
    * Add a wait, ensuring we don't add dupes.
    */
   setAddWait (state, payload) {
-    const i = state.waits.findIndex(wait => wait === payload)
+    const i = state.waits.indexOf(payload)
     if (i === -1) state.waits.push(payload)
   },
 
@@ -22,8 +22,7 @@ export const mutations: MutationTree<WaitState> = {
    * Remove a wait, if found.
    */
   setRemoveWait (state, payload) {
-    if (state.waits.length) {
-      state.waits.splice(state.waits.indexOf(payload, 0), 1)
-    }
+    const i = state.waits.indexOf(payload)
+    if (i !== -1) state.waits.splice(i, 1)
   }
 }


### PR DESCRIPTION
Currently, a call to `setRemoveWait` method with an item that is not part of the `state.waits` will still splice it, incorrectly removing the last item (basically, it will run `state.waits.splice(-1, 1)`)

This fix ensures that we do not splice if the item is not part of the `state.waits`.

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>