### PR TITLE
fix: check for root available before listing files

### DIFF
--- a/src/store/history/actions.ts
+++ b/src/store/history/actions.ts
@@ -35,10 +35,13 @@ export const actions: ActionTree<HistoryState, RootState> = {
   /**
    * Update the store with history
    */
-  async onHistoryList ({ commit }, payload) {
+  async onHistoryList ({ commit, rootGetters }, payload) {
     if (payload) {
       commit('setHistoryList', payload)
-      SocketActions.serverFilesGetDirectory('gcodes', 'gcodes')
+
+      if (rootGetters['files/isRootAvailable']('gcodes')) {
+        SocketActions.serverFilesGetDirectory('gcodes', 'gcodes')
+      }
     }
   },
 


### PR DESCRIPTION
Check that `gcodes` root exists before attempting to list the files from it.

Fixes #727 

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>