### PR TITLE
fix: gcode preview initial layout

### DIFF
--- a/src/components/widgets/gcode-preview/GcodePreviewCard.vue
+++ b/src/components/widgets/gcode-preview/GcodePreviewCard.vue
@@ -119,6 +119,7 @@
         <v-col>
           <gcode-preview
             width="100%"
+            height="100%"
             :layer="currentLayer"
             :progress="moveProgress"
             :disabled="!fileLoaded"


### PR DESCRIPTION
Minor fix/improvement for the layout of the gcode previewer.

## Before (build plate not fully visible, lower part hidden)

![image](https://user-images.githubusercontent.com/85504/176159180-d932d656-6840-443f-a26a-a5aa35eb9387.png)

## After (build plate fully visible)

![image](https://user-images.githubusercontent.com/85504/176159270-94a60e01-e6fd-4e8a-8d75-436ad54ae56a.png)

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>