### PR TITLE
fix: nginx 502 error when restarting moonraker

### DIFF
--- a/src/api/httpClient.ts
+++ b/src/api/httpClient.ts
@@ -20,9 +20,14 @@ const unauthenticatedPaths = [
 
 // For these paths, we don't emit an error because we handle them
 // downstream.
-const handledErrorRequests = [
-  '/access/login'
-]
+const handledErrorRequests = {
+  400: [
+    '/access/login'
+  ],
+  502: [
+    '/access/oneshot_token'
+  ]
+}
 
 const requestInterceptor = async (config: AxiosRequestConfig) => {
   if (!config.headers) {
@@ -98,9 +103,10 @@ const errorInterceptor = (error: AxiosError<string | { error?: { message?: strin
       consola.debug(error.response.status, error.message, message)
       EventBus.$emit(message || 'Server error', { type: FlashMessageTypes.error })
       break
+    case 502:
     case 400:
       consola.debug(error.response.status, error.message, message)
-      if (!handledErrorRequests.includes(url)) {
+      if (!handledErrorRequests[error.response.status].includes(url)) {
         EventBus.$emit(message || 'Server error', { type: FlashMessageTypes.error })
       }
       break


### PR DESCRIPTION
Quite a few times we've seen users reporting a 502 error, most of the times mentioning nginx, and I've finally managed to reproduce and fix it!

![image](https://user-images.githubusercontent.com/85504/176717884-b2001a78-4180-4fcd-9638-6f64a4d0b33d.png)

Nginx (and possibly other reverse proxies) will return 502 if they can't reach the server (moonraker), which is expected if we have just restarted the service from Fluidd (and thus a "/access/oneshot_token" call can happen)

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>