### PR TITLE
feat: add icon to shutdown on AppBar

### DIFF
--- a/src/components/layout/AppBar.vue
+++ b/src/components/layout/AppBar.vue
@@ -87,7 +87,7 @@
               </v-icon>
             </app-btn>
           </template>
-          <span>{{ $t('app.general.btn.shutdown') }}</span>
+          <span>{{ $t('app.general.btn.shutdown') }} ({{ $t('app.general.label.host') }})</span>
         </v-tooltip>
       </div>
 

--- a/src/components/layout/AppBar.vue
+++ b/src/components/layout/AppBar.vue
@@ -226,17 +226,15 @@ export default class AppBar extends Mixins(StateMixin, ServicesMixin) {
     })
   }
 
-  handleHostShutdown () {
-    this.$confirm(
+  async handleHostShutdown () {
+    const res = await this.$confirm(
       this.$tc('app.general.simple_form.msg.confirm_shutdown_host'),
       { title: this.$tc('app.general.label.confirm'), color: 'card-heading', icon: '$error' }
     )
-      .then(res => {
-        if (res) {
-          this.$emit('click')
-          this.hostShutdown()
-        }
-      })
+
+    if (res) {
+      this.hostShutdown()
+    }
   }
 
   saveConfigAndRestart (force = false) {

--- a/src/components/layout/AppBar.vue
+++ b/src/components/layout/AppBar.vue
@@ -70,6 +70,28 @@
       </div>
 
       <div
+        v-if="authenticated && socketConnected && shutdownOnAppBar"
+      >
+        <v-tooltip bottom>
+          <template #activator="{ on, attrs }">
+            <app-btn
+              v-bind="attrs"
+              class="mx-1"
+              depressed
+              color="transparent"
+              v-on="on"
+              @click="handleHostShutdown()"
+            >
+              <v-icon color="primary">
+                $power
+              </v-icon>
+            </app-btn>
+          </template>
+          <span>{{ $t('app.general.btn.shutdown') }}</span>
+        </v-tooltip>
+      </div>
+
+      <div
         v-if="authenticated && socketConnected"
         class="mr-1"
       >
@@ -135,6 +157,7 @@ import PendingChangesDialog from '@/components/settings/PendingChangesDialog.vue
 import AppSaveConfigAndRestartBtn from './AppSaveConfigAndRestartBtn.vue'
 import { defaultState } from '@/store/layout/index'
 import StateMixin from '@/mixins/state'
+import ServicesMixin from '@/mixins/services'
 
 @Component({
   components: {
@@ -143,7 +166,7 @@ import StateMixin from '@/mixins/state'
     AppSaveConfigAndRestartBtn
   }
 })
-export default class AppBar extends Mixins(StateMixin) {
+export default class AppBar extends Mixins(StateMixin, ServicesMixin) {
   menu = false
   userPasswordDialogOpen = false
   pendingChangesDialogOpen = false
@@ -184,6 +207,10 @@ export default class AppBar extends Mixins(StateMixin) {
     return (this.$store.state.config.layoutMode)
   }
 
+  get shutdownOnAppBar (): boolean {
+    return (this.$store.state.config.uiSettings.general.shutdownOnAppBar)
+  }
+
   handleExitLayout () {
     this.$store.commit('config/setLayoutMode', false)
   }
@@ -197,6 +224,19 @@ export default class AppBar extends Mixins(StateMixin) {
         container2: layout.layouts.dashboard.container2
       }
     })
+  }
+
+  handleHostShutdown () {
+    this.$confirm(
+      this.$tc('app.general.simple_form.msg.confirm_shutdown_host'),
+      { title: this.$tc('app.general.label.confirm'), color: 'card-heading', icon: '$error' }
+    )
+      .then(res => {
+        if (res) {
+          this.$emit('click')
+          this.hostShutdown()
+        }
+      })
   }
 
   saveConfigAndRestart (force = false) {

--- a/src/components/settings/GeneralSettings.vue
+++ b/src/components/settings/GeneralSettings.vue
@@ -84,6 +84,19 @@
       <v-divider />
 
       <app-setting
+        :title="$t('app.setting.label.shutdownOnAppBar')"
+      >
+        <v-switch
+          v-model="shutdownOnAppBar"
+          hide-details
+          class="mb-5"
+          @click.native.stop
+        />
+      </app-setting>
+
+      <v-divider />
+
+      <app-setting
         :title="$t('app.setting.label.confirm_on_power_device_change')"
       >
         <v-switch
@@ -189,6 +202,18 @@ export default class GeneralSettings extends Mixins(StateMixin) {
   set confirmOnEstop (value: boolean) {
     this.$store.dispatch('config/saveByPath', {
       path: 'uiSettings.general.confirmOnEstop',
+      value,
+      server: true
+    })
+  }
+
+  get shutdownOnAppBar () {
+    return this.$store.state.config.uiSettings.general.shutdownOnAppBar
+  }
+
+  set shutdownOnAppBar (value: boolean) {
+    this.$store.dispatch('config/saveByPath', {
+      path: 'uiSettings.general.shutdownOnAppBar',
       value,
       server: true
     })

--- a/src/locales/de.yaml
+++ b/src/locales/de.yaml
@@ -433,6 +433,7 @@ app:
       show_barometric_pressure: Luftdruck anzeigen
       show_rate_of_change: Temperatur-Änderungsrate anzeigen
       show_relative_humidity: Relative Luftfeuchtigkeit anzeigen
+      shutdownOnAppBar: Schaltfläche zum Herunterfahren auf der Kopfleiste anzeigen
       starts_with: Beginnt mit
       theme_preset: Community-Voreinstellung
       thermal_preset_gcode: GCode

--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -447,6 +447,7 @@ app:
       show_code_lens: Show CodeLens
       show_rate_of_change: Show temperature rate of change
       show_relative_humidity: Show relative humidity
+      shutdownOnAppBar: Show Shutdown Icon on Top Bar
       starts_with: Starts with
       theme_preset: Community preset
       thermal_preset_gcode: GCode

--- a/src/store/config/index.ts
+++ b/src/store/config/index.ts
@@ -65,7 +65,8 @@ export const defaultState = (): ConfigState => {
         showRelativeHumidity: true,
         showBarometricPressure: true,
         flipConsoleLayout: false,
-        cameraFullscreenAction: 'embed'
+        cameraFullscreenAction: 'embed',
+        shutdownOnAppBar: true
       },
       theme: {
         isDark: true,

--- a/src/store/config/types.ts
+++ b/src/store/config/types.ts
@@ -58,6 +58,7 @@ export interface GeneralConfig {
   showBarometricPressure: boolean;
   flipConsoleLayout: boolean;
   cameraFullscreenAction: CameraFullscreenAction;
+  shutdownOnAppBar: boolean;
 }
 
 export type CameraFullscreenAction = 'embed' | 'rawstream';


### PR DESCRIPTION
Closes: #729 

- Shutdown icon on AppBar/TopBar
- Entry in the settings to (de)activate

Here you can see it in action:

https://user-images.githubusercontent.com/44060099/177038146-131b4d90-e044-4868-8f4e-533ad995fa6f.mov

