### PR TITLE
fix: no collapsed console in fullscreen mode

### DIFF
--- a/src/components/common/CollapsableCard.vue
+++ b/src/components/common/CollapsableCard.vue
@@ -287,6 +287,9 @@ export default class CollapsableCard extends Vue {
    * If the layout isn't defined, then this should always be disabled.
    */
   get isCollapsed (): boolean {
+    if (!this.collapsable) {
+      return false
+    }
     return (this.layout) ? this.layout.collapsed : false
   }
 


### PR DESCRIPTION
Hi,
I am sure that this is a bug. For this reason I have added a small fix that checks whether the component is collapsable or not. If it is not collapsable, it must be in fullscreen mode and returns false (isCollapsed --> false). 

Here is a video to demonstrate it:

https://user-images.githubusercontent.com/44060099/177038733-a3963482-23e9-479d-8d9b-91db2b927d14.mov

And also for the fix:

https://user-images.githubusercontent.com/44060099/177038853-52b6a480-34d3-4bc4-b629-acdc9405d746.mov

Signed-off-by: Kerim Bilgic <bastelklug@pfusch.eu>