### PR TITLE
feat: Extended G-Code viewer auto-actions

### DIFF
--- a/src/components/settings/GcodePreviewSettings.vue
+++ b/src/components/settings/GcodePreviewSettings.vue
@@ -108,6 +108,28 @@
 
       <v-divider />
 
+      <app-setting :title="$t('app.setting.label.auto_load_on_print_start')">
+        <v-switch
+          v-model="autoLoadOnPrintStart"
+          hide-details
+          class="mb-5"
+          @click.native.stop
+        />
+      </app-setting>
+
+      <v-divider />
+
+      <app-setting :title="$t('app.setting.label.auto_follow_on_file_load')">
+        <v-switch
+          v-model="autoFollowOnFileLoad"
+          hide-details
+          class="mb-5"
+          @click.native.stop
+        />
+      </app-setting>
+
+      <v-divider />
+
       <app-setting :title="$t('app.setting.label.reset')">
         <app-btn
           outlined
@@ -226,6 +248,30 @@ export default class GcodePreviewSettings extends Vue {
   set groupLowerLayers (value: boolean) {
     this.$store.dispatch('config/saveByPath', {
       path: 'uiSettings.gcodePreview.groupLowerLayers',
+      value,
+      server: true
+    })
+  }
+
+  get autoLoadOnPrintStart () {
+    return this.$store.state.config.uiSettings.gcodePreview.autoLoadOnPrintStart
+  }
+
+  set autoLoadOnPrintStart (value: boolean) {
+    this.$store.dispatch('config/saveByPath', {
+      path: 'uiSettings.gcodePreview.autoLoadOnPrintStart',
+      value,
+      server: true
+    })
+  }
+
+  get autoFollowOnFileLoad () {
+    return this.$store.state.config.uiSettings.gcodePreview.autoFollowOnFileLoad
+  }
+
+  set autoFollowOnFileLoad (value: boolean) {
+    this.$store.dispatch('config/saveByPath', {
+      path: 'uiSettings.gcodePreview.autoFollowOnFileLoad',
       value,
       server: true
     })

--- a/src/components/widgets/gcode-preview/GcodePreviewCard.vue
+++ b/src/components/widgets/gcode-preview/GcodePreviewCard.vue
@@ -221,6 +221,13 @@ export default class GcodePreviewCard extends Mixins(StateMixin, FilesMixin) {
     }
   }
 
+  @Watch('printerFile')
+  onPrintFileChanged () {
+    if (this.autoLoadOnPrintStart && this.printerFile) {
+      this.loadCurrent()
+    }
+  }
+
   get file (): AppFile | undefined {
     return this.$store.getters['gcodePreview/getFile']
   }
@@ -304,7 +311,7 @@ export default class GcodePreviewCard extends Mixins(StateMixin, FilesMixin) {
   }
 
   async loadCurrent () {
-    const file = this.$store.state.printer.printer.current_file as AppFile
+    const file = this.printerFile as AppFile
     this.getGcode(file)
       .then(response => response?.data)
       .then((gcode: AxiosResponse) => {
@@ -338,6 +345,10 @@ export default class GcodePreviewCard extends Mixins(StateMixin, FilesMixin) {
     }
 
     return true
+  }
+
+  get autoLoadOnPrintStart () {
+    return this.$store.state.config.uiSettings.gcodePreview.autoLoadOnPrintStart
   }
 }
 </script>

--- a/src/locales/de.yaml
+++ b/src/locales/de.yaml
@@ -391,6 +391,8 @@ app:
       all_off: Alle aus
       all_on: Alle an
       auto_edit_extensions: Erweiterungen, die automatisch im Bearbeitungsmodus geöffnet werden
+      auto_follow_on_file_load: Fortschritt beim Laden einer Datei automatisch folgen
+      auto_load_on_print_start: Datei bei Druckstart automatisch laden
       camera_flip_x: Horizontal spiegeln
       camera_flip_y: Vertikal spiegeln
       camera_rotate_by: Rotieren um

--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -400,6 +400,8 @@ app:
       all_off: All off
       all_on: All on
       auto_edit_extensions: Extensions to automatically open in edit mode
+      auto_follow_on_file_load: Automatically follow progress on file load
+      auto_load_on_print_start: Automatically load file on print start
       camera_flip_x: Flip horizontally
       camera_flip_y: Flip vertically
       camera_fullscreen_action:

--- a/src/store/config/index.ts
+++ b/src/store/config/index.ts
@@ -121,6 +121,8 @@ export const defaultState = (): ConfigState => {
         drawBackground: true,
         showAnimations: true,
         groupLowerLayers: false,
+        autoLoadOnPrintStart: true,
+        autoFollowOnFileLoad: true,
         flip: {
           horizontal: false,
           vertical: true

--- a/src/store/config/types.ts
+++ b/src/store/config/types.ts
@@ -154,6 +154,8 @@ export interface GcodePreviewConfig {
   drawBackground: boolean;
   showAnimations: boolean;
   groupLowerLayers: boolean;
+  autoLoadOnPrintStart: boolean;
+  autoFollowOnFileLoad: boolean;
   flip: {
     horizontal: boolean;
     vertical: boolean;

--- a/src/store/gcodePreview/actions.ts
+++ b/src/store/gcodePreview/actions.ts
@@ -23,7 +23,7 @@ export const actions: ActionTree<GcodePreviewState, RootState> = {
     }
   },
 
-  async loadGcode ({ commit, getters, state }, payload: { file: AppFile; gcode: string }) {
+  async loadGcode ({ commit, getters, state, rootState }, payload: { file: AppFile; gcode: string }) {
     const worker = await spawn(new Worker(new URL('@/workers/parseGcode.worker.ts', import.meta.url) as any))
 
     commit('setParserWorker', worker)
@@ -46,6 +46,10 @@ export const actions: ActionTree<GcodePreviewState, RootState> = {
     commit('setMoves', [])
 
     commit('setFile', payload.file)
+    if (rootState.config?.uiSettings.gcodePreview.autoFollowOnFileLoad) {
+      // check if loaded file equals printed file is handled downstream
+      commit('setViewerState', { followProgress: true })
+    }
 
     try {
       commit('setMoves', await Promise.race([abort, worker.parse(payload.gcode)]))


### PR DESCRIPTION
Provides the following two new features:
* An option to automatically load the print file on print start
* An option to automatically follow progress on file load

I'm not 100% sure about the UX when auto-loading a file (the two popups seem annoying); maybe that can be moved to the background?

Closes #730