### PR TITLE
fix: use default color for power icon in top navigation

### DIFF
--- a/src/components/layout/AppBar.vue
+++ b/src/components/layout/AppBar.vue
@@ -85,7 +85,7 @@
               v-on="on"
               @click="handlePowerToggle()"
             >
-              <v-icon color="primary">
+              <v-icon>
                 {{ topNavPowerDeviceOn ? '$powerOn' : '$powerOff' }}
               </v-icon>
             </app-btn>
@@ -199,6 +199,10 @@ export default class AppBar extends Mixins(StateMixin, ServicesMixin) {
     return this.$store.getters['printer/getSaveConfigPending']
   }
 
+  get devicePowerComponentEnabled () {
+    return this.$store.getters['server/componentSupport']('power')
+  }
+
   get theme () {
     return this.$store.getters['config/getTheme']
   }
@@ -225,7 +229,7 @@ export default class AppBar extends Mixins(StateMixin, ServicesMixin) {
 
   get topNavPowerToggleDisabled (): boolean {
     const device = this.topNavPowerDevice
-    return (!device) || (this.printerPrinting && device.locked_while_printing) || ['init', 'error'].includes(device.status)
+    return (!device) || (this.printerPrinting && device.locked_while_printing) || ['init', 'error'].includes(device.status) || (!this.devicePowerComponentEnabled)
   }
 
   handleExitLayout () {


### PR DESCRIPTION
The default icon color matches the rest of the buttons, so I think it makes sense to use that instead of the theme one.

I've also added a check for the "power" component, as this is also checked in the SystemCommand.vue, and without it a Klipper `RESTART` incorrectly keeps the button enabled (but on the side menu it is hidden)

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>