### PR TITLE
fix: add default authentication source to new users

### DIFF
--- a/src/store/auth/mutations.ts
+++ b/src/store/auth/mutations.ts
@@ -32,7 +32,7 @@ export const mutations: MutationTree<AuthState> = {
   },
 
   setAddUser (state, user) {
-    state.users.push(user)
+    state.users.push({ source: 'moonraker', ...user })
   },
 
   setRemoveUser (state, user) {


### PR DESCRIPTION
Adds a fallback `source` attribute to newly created users, making them always match their typedef.

Fixes the following bug:
![image](https://user-images.githubusercontent.com/25269274/177840939-fbe990e0-6ae1-4db5-9c16-2d70df62c855.png)
