### PR TITLE
feat: Increase resolution of speed and flow sliders to single decimal…

### DIFF
--- a/src/components/widgets/toolhead/SpeedAndFlowAdjust.vue
+++ b/src/components/widgets/toolhead/SpeedAndFlowAdjust.vue
@@ -14,6 +14,7 @@
         :locked="(!klippyReady || isMobile)"
         :min="1"
         :max="200"
+        :step="0.1"
         @change="handleSetSpeed"
       />
     </v-col>
@@ -31,6 +32,7 @@
         :locked="(!klippyReady || isMobile)"
         :min="1"
         :max="200"
+        :step="0.1"
         @change="handleSetFlow"
       />
     </v-col>


### PR DESCRIPTION
… point

Usually no decimal value is fine for tuning but in some cases it may not be enough.
Klipper already supports flow and speed adjustment to a few decimal points but such
resolution is kinda pointless. 1 decimal point is more then enough for most users.

Acceleration values and corner speeds support the same as they are float as well but
these sliders were left untouched as they truly do not need decimal resolution (You can't see
the difference in prints).

Signed-off-by: Martin Botka <martin.botka@somainline.org>