### PR TITLE
fix: OutputLed working with all types of LEDs

### DIFF
--- a/src/components/widgets/outputs/OutputLed.vue
+++ b/src/components/widgets/outputs/OutputLed.vue
@@ -29,35 +29,65 @@ import { IroColor } from '@irojs/iro-core'
 import StateMixin from '@/mixins/state'
 import { Led } from '@/store/printer/types'
 
-interface RgbwColor {
-  r: number;
-  g: number;
-  b: number;
-  w: number;
-}
+type Channel = 'r' | 'g' | 'b' | 'w'
 
 @Component({})
 export default class OutputLed extends Mixins(StateMixin) {
   @Prop({ type: Object, required: true })
   public led!: Led
 
-  channelLookup: {[key: string]: string} = { r: 'RED', g: 'GREEN', b: 'BLUE', w: 'WHITE' }
+  channelLookup: Record<Channel, string> = { r: 'RED', g: 'GREEN', b: 'BLUE', w: 'WHITE' }
 
-  get supportedChannels () {
-    return this.led.config.color_order[0]
+  get supportedChannels (): string {
+    const { type, config } = this.led
+
+    if ('color_order' in config) {
+      return config.color_order[0]
+    }
+
+    switch (type) {
+      case 'dotstar':
+        return 'RGB'
+
+      case 'led':
+      {
+        const channels = []
+
+        if ('red_pin' in config) channels.push('R')
+        if ('green_pin' in config) channels.push('G')
+        if ('blue_pin' in config) channels.push('B')
+        if ('white_pin' in config) channels.push('W')
+
+        return channels.join('')
+      }
+    }
+
+    return 'RBGW'
+  }
+
+  get currentColor () {
+    return this.convertFromNumberArray(this.led.color_data[0])
   }
 
   get primaryColor () {
-    const vals = this.convertTo(this.led.color_data[0])
-    const c = new IroColor(vals)
-    return c.hexString
+    const color = new IroColor(this.currentColor)
+
+    return color.hexString
   }
 
   get whiteColor () {
-    const vals = this.convertTo(this.led.color_data[0])
-    if (!vals.w) return undefined
-    const c = new IroColor({ r: vals.w, g: vals.w, b: vals.w })
-    return c.hexString
+    if (!this.supportedChannels.includes('W')) {
+      return undefined
+    }
+
+    const currentColor = this.currentColor
+    const color = new IroColor({
+      r: currentColor.w,
+      g: currentColor.w,
+      b: currentColor.w
+    })
+
+    return color.hexString
   }
 
   get isMobile () {
@@ -65,38 +95,28 @@ export default class OutputLed extends Mixins(StateMixin) {
   }
 
   handleColorChange (value: { channel: string; color: IroColor }) {
-    // Will return an update to either the primary or white channel.
-    // Gather the existing values..
-    const channels = this.supportedChannels.toLowerCase()
-    let currentVals = Object.fromEntries(this.led.color_data[0].map((value: number, idx: number) => [channels[idx], value]))
-    const newVals = this.convertFrom(value.color.rgb)
+    const selectedColor = value.color.rgb
 
-    if (value.channel === 'primary') {
-      // RGB picker update
-      currentVals = { ...currentVals, ...newVals }
-    } else {
-      // White channel update
-      currentVals.w = newVals.r
+    const newColor: Record<Channel, number> = {
+      ...this.currentColor,
+      ...(value.channel === 'primary' ? selectedColor : { w: selectedColor.r })
     }
 
-    this.sendGcode(`SET_LED LED=${this.led.name} ${Object.entries(currentVals).map(([key, val]) => `${this.channelLookup[key]}=${val}`).join(' ')}`)
+    const supportedChannels = this.supportedChannels.toLowerCase().split('') as Channel[]
+    const colorsString = supportedChannels.map(channel => `${this.channelLookup[channel]}=${Math.round(newColor[channel] * 1000 / 255) / 1000}`).join(' ')
+
+    this.sendGcode(`SET_LED LED=${this.led.name} ${colorsString}`)
   }
 
-  convertTo (o: any): RgbwColor {
-    const r: any = {}
-    const channels = this.supportedChannels.toLowerCase()
-    Object.keys(o).forEach((key) => {
-      r[channels[key]] = Math.round(o[key] * 255)
-    })
-    return r
-  }
+  convertFromNumberArray (colorData: number[]) : Record<Channel, number> {
+    const [r, g, b, w] = colorData.map(value => value * 255)
 
-  convertFrom (o: any): RgbwColor {
-    const r: any = {}
-    Object.keys(o).forEach((key) => {
-      r[key] = Number.parseFloat((o[key] / 255).toPrecision(2))
-    })
-    return r
+    return {
+      r,
+      g,
+      b,
+      w
+    }
   }
 }
 </script>


### PR DESCRIPTION
A couple of issues with this one, but I've now tested in Simulavr with `[led]`, `[neopixel]` and `[dotstar]` (containing 1 or more channels, with and without White channel), and I believe it will work for these and the other types of LEDs too!

> **Dev note:** though on some of these LED types we can specify a `color_order`, that does NOT change the output order of `color_data` - it is ALWAYS `[R, G, B, W]`)
> 
> ![image](https://user-images.githubusercontent.com/85504/178964798-56a0d0df-8475-4c2d-95fa-321984a39332.png)
> 
> Klipper also does not complain if we call `SET_LED` with all params, so I've decided to keep that in for now

Fixes #765

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>