### PR TITLE
fix: disable FORCE_MOVE toggle when printing / not ready

### DIFF
--- a/src/components/widgets/toolhead/ToolheadCard.vue
+++ b/src/components/widgets/toolhead/ToolheadCard.vue
@@ -33,6 +33,7 @@
         <app-btn
           v-if="printerSupportsForceMove"
           :elevation="2"
+          :disabled="!klippyReady || printerPrinting"
           small
           class="ml-1"
           :color="forceMove ? 'error' : undefined"


### PR DESCRIPTION
Adds the same conditional disabling to the FORCE_MOVE toggle that the other toolhead card header buttons use

Before
![image](https://user-images.githubusercontent.com/25269274/179351375-f6ef38c1-49e8-4164-aaba-02a06525e6e2.png)

After
![image](https://user-images.githubusercontent.com/25269274/179351366-d904c5a1-c55d-4b95-b2c4-891ab8b7026a.png)