### PR TITLE
feat: adds new Manual Probe helper dialog

### DIFF
--- a/src/components/common/ManualProbeDialog.vue
+++ b/src/components/common/ManualProbeDialog.vue
@@ -1,0 +1,242 @@
+<template>
+  <v-dialog
+    :value="value"
+    :max-width="450"
+    scrollable
+    @input="$emit('input', $event)"
+  >
+    <v-form @submit.prevent="sendAccept">
+      <v-card>
+        <v-card-title class="card-heading py-2">
+          <span class="focus--text">{{ $t('app.tool.tooltip.manual_probe') }}</span>
+        </v-card-title>
+
+        <v-divider />
+
+        <v-card-text>
+          <v-row>
+            <v-col>
+              <v-text-field
+                label="Z Min"
+                outlined
+                hide-details
+                dense
+                disabled
+                :value="zPositionLower"
+              />
+            </v-col>
+            <v-col>
+              <v-text-field
+                label="Z"
+                outlined
+                hide-details
+                dense
+                disabled
+                :value="zPosition"
+              />
+            </v-col>
+            <v-col>
+              <v-text-field
+                label="Z Max"
+                outlined
+                hide-details
+                dense
+                disabled
+                :value="zPositionUpper"
+              />
+            </v-col>
+          </v-row>
+
+          <v-row class="bysect-row">
+            <v-col
+              cols="3"
+              offset="1"
+            >
+              <app-btn-group>
+                <app-btn
+                  :disabled="!klippyReady || printerPrinting || manualProbe.z_position_lower === null"
+                  color="primary"
+                  @click="sendTestZ('--')"
+                >
+                  --
+                </app-btn>
+                <app-btn
+                  :disabled="!klippyReady || printerPrinting || manualProbe.z_position_lower === null"
+                  color="primary"
+                  @click="sendTestZ('-')"
+                >
+                  -
+                </app-btn>
+              </app-btn-group>
+            </v-col>
+            <v-col
+              cols="3"
+              offset="4"
+            >
+              <app-btn-group>
+                <app-btn
+                  :disabled="!klippyReady || printerPrinting || manualProbe.z_position_upper === null"
+                  color="primary"
+                  @click="sendTestZ('+')"
+                >
+                  +
+                </app-btn>
+                <app-btn
+                  :disabled="!klippyReady || printerPrinting || manualProbe.z_position_upper === null"
+                  color="primary"
+                  @click="sendTestZ('++')"
+                >
+                  ++
+                </app-btn>
+              </app-btn-group>
+            </v-col>
+          </v-row>
+
+          <v-row
+            v-for="offset in offsets"
+            :key="offset"
+            class="offset-row"
+          >
+            <v-col
+              cols="3"
+              offset="1"
+            >
+              <app-btn
+                :disabled="!klippyReady || printerPrinting"
+                color="primary"
+                @click="sendTestZ(`-${offset}`)"
+              >
+                <v-icon>
+                  $minus
+                </v-icon>
+              </app-btn>
+            </v-col>
+            <v-col cols="4">
+              <div
+                class="v-btn v-size--default btncolor"
+              >
+                {{ offset }}
+              </div>
+            </v-col>
+            <v-col cols="3">
+              <app-btn
+                :disabled="!klippyReady || printerPrinting"
+                color="primary"
+                @click="sendTestZ(`+${offset}`)"
+              >
+                <v-icon>
+                  $plus
+                </v-icon>
+              </app-btn>
+            </v-col>
+          </v-row>
+        </v-card-text>
+
+        <v-card-actions>
+          <v-spacer />
+
+          <app-btn
+            color="warning"
+            text
+            type="button"
+            @click="sendAbort"
+          >
+            {{ $t('app.general.btn.abort') }}
+          </app-btn>
+
+          <app-btn
+            :loading="hasWait($waits.onManualProbe)"
+            color="primary"
+            :elevation="2"
+            type="submit"
+          >
+            {{ $t('app.general.btn.accept') }}
+          </app-btn>
+        </v-card-actions>
+      </v-card>
+    </v-form>
+  </v-dialog>
+</template>
+
+<script lang="ts">
+import { Component, Mixins, Prop, Watch } from 'vue-property-decorator'
+import StateMixin from '@/mixins/state'
+import ToolheadMixin from '@/mixins/toolhead'
+
+@Component({})
+export default class ManualProbeDialog extends Mixins(StateMixin, ToolheadMixin) {
+  @Prop({ type: Boolean, default: false })
+  public value!: boolean
+
+  get offsets () {
+    return [
+      1,
+      0.1,
+      ...this.$store.state.config.uiSettings.general.zAdjustDistances
+    ]
+  }
+
+  get manualProbe () {
+    return this.$store.state.printer.printer.manual_probe
+  }
+
+  get zPositionLower () {
+    return this.manualProbe.z_position_lower?.toFixed(3) || ' '
+  }
+
+  get zPosition () {
+    return this.manualProbe.z_position?.toFixed(3) || ' '
+  }
+
+  get zPositionUpper () {
+    return this.manualProbe.z_position_upper?.toFixed(3) || ' '
+  }
+
+  @Watch('isManualProbeActive')
+  onIsManualProbeActive (value: boolean) {
+    if (!value) {
+      this.$emit('input', false)
+    }
+  }
+
+  sendTestZ (zValue: string) {
+    this.sendGcode(`TESTZ Z=${zValue}`)
+  }
+
+  sendAbort () {
+    this.sendGcode('ABORT', this.$waits.onManualProbe)
+    this.$emit('input', false)
+  }
+
+  sendAccept () {
+    this.sendGcode('ACCEPT', this.$waits.onManualProbe)
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+  .bysect-row > .col {
+    padding: 4px 1px;
+
+    & .v-btn {
+      min-width: 40px;
+      flex-grow: 1;
+    }
+  }
+
+  .offset-row > .col {
+    padding: 4px 1px;
+
+    & > * {
+      border-radius: 0;
+      width: 100%;
+    }
+
+    &:first-child > * {
+      border-radius: $border-radius-root 0 0 $border-radius-root;
+    }
+    &:last-child > * {
+      border-radius: 0 $border-radius-root $border-radius-root 0;
+    }
+  }
+</style>

--- a/src/components/common/ManualProbeDialog.vue
+++ b/src/components/common/ManualProbeDialog.vue
@@ -54,14 +54,14 @@
             >
               <app-btn-group>
                 <app-btn
-                  :disabled="!klippyReady || printerPrinting || manualProbe.z_position_lower === null"
+                  :disabled="!klippyReady || printerPrinting"
                   color="primary"
                   @click="sendTestZ('--')"
                 >
                   --
                 </app-btn>
                 <app-btn
-                  :disabled="!klippyReady || printerPrinting || manualProbe.z_position_lower === null"
+                  :disabled="!klippyReady || printerPrinting"
                   color="primary"
                   @click="sendTestZ('-')"
                 >
@@ -75,14 +75,14 @@
             >
               <app-btn-group>
                 <app-btn
-                  :disabled="!klippyReady || printerPrinting || manualProbe.z_position_upper === null"
+                  :disabled="!klippyReady || printerPrinting"
                   color="primary"
                   @click="sendTestZ('+')"
                 >
                   +
                 </app-btn>
                 <app-btn
-                  :disabled="!klippyReady || printerPrinting || manualProbe.z_position_upper === null"
+                  :disabled="!klippyReady || printerPrinting"
                   color="primary"
                   @click="sendTestZ('++')"
                 >

--- a/src/components/settings/ToolheadSettings.vue
+++ b/src/components/settings/ToolheadSettings.vue
@@ -164,6 +164,19 @@
 
       <v-divider />
 
+      <app-setting
+        :title="$t('app.setting.label.show_manual_probe_dialog_automatically')"
+        :sub-title="$t('app.setting.tooltip.show_manual_probe_dialog_automatically')"
+      >
+        <v-switch
+          v-model="showManualProbeDialogAutomatically"
+          hide-details
+          class="mt-0 mb-4"
+        />
+      </app-setting>
+
+      <v-divider />
+
       <template v-if="printerSupportsForceMove">
         <app-setting :title="$t('app.setting.label.force_move_toggle_warning')">
           <v-switch
@@ -355,6 +368,18 @@ export default class ToolHeadSettings extends Vue {
 
   get printerSupportsForceMove () {
     return this.$store.getters['printer/getPrinterSettings']('force_move.enable_force_move') ?? false
+  }
+
+  get showManualProbeDialogAutomatically () {
+    return this.$store.state.config.uiSettings.general.showManualProbeDialogAutomatically
+  }
+
+  set showManualProbeDialogAutomatically (value: boolean) {
+    this.$store.dispatch('config/saveByPath', {
+      path: 'uiSettings.general.showManualProbeDialogAutomatically',
+      value,
+      server: true
+    })
   }
 
   get forceMoveToggleWarning () {

--- a/src/components/ui/AppBtnCollapseGroup.vue
+++ b/src/components/ui/AppBtnCollapseGroup.vue
@@ -1,7 +1,7 @@
-<template>
+<template v-if="hasDefaultSlot">
   <!-- not collapsed -->
   <div
-    v-if="!isCollapsed && hasDefaultSlot"
+    v-if="!isCollapsed"
     class="d-inline-block"
   >
     <slot />
@@ -9,7 +9,7 @@
 
   <!-- collapsed to hamburger -->
   <v-menu
-    v-else-if="isCollapsed && hasDefaultSlot"
+    v-else
     transition="slide-y-transition"
     left
     offset-y

--- a/src/components/ui/AppBtnGroup.vue
+++ b/src/components/ui/AppBtnGroup.vue
@@ -1,22 +1,63 @@
 <template>
-  <v-item-group class="app-btn-group">
+  <v-item-group
+    class="app-btn-group"
+    :class="{
+      'app-btn-group-vertical': vertical
+    }"
+  >
     <slot />
   </v-item-group>
 </template>
 
-<style lang="scss">
-@import '~vuetify/src/styles/styles.sass';
-.app-btn-group {
-  .v-btn {
-    &:not(:last-child) {
-      margin-right: 2px;
+<script lang="ts">
+import { Component, Vue, Prop } from 'vue-property-decorator'
+
+@Component({})
+export default class AppBtnGroup extends Vue {
+  @Prop({ type: Boolean, default: false })
+  public vertical!: boolean
+}
+</script>
+
+<style lang="scss" scoped>
+  .app-btn-group {
+    display: flex;
+
+    &:not(.app-btn-group-vertical) {
+      & > :deep(.v-btn) {
+        border-radius: 0;
+
+        &:not(:last-child) {
+          margin-right: 2px;
+        }
+
+        &:first-child {
+          border-radius: $border-radius-root 0 0 $border-radius-root;
+        }
+        &:last-child {
+          border-radius: 0 $border-radius-root $border-radius-root 0;
+        }
+      }
     }
-    &:first-child {
-      border-radius: $border-radius-root 0 0 $border-radius-root;
-    }
-    &:last-child {
-      border-radius: 0 $border-radius-root $border-radius-root 0;
+
+    &.app-btn-group-vertical {
+      flex-direction: column;
+
+      & > :deep(.v-btn) {
+        border-radius: 0;
+        align-self: center;
+
+        &:not(:last-child) {
+          margin-bottom: 2px;
+        }
+
+        &:first-child {
+          border-radius: $border-radius-root $border-radius-root 0 0;
+        }
+        &:last-child {
+          border-radius: 0 0 $border-radius-root $border-radius-root;
+        }
+      }
     }
   }
-}
 </style>

--- a/src/components/widgets/toolhead/ToolheadCard.vue
+++ b/src/components/widgets/toolhead/ToolheadCard.vue
@@ -31,6 +31,16 @@
     <template #menu>
       <app-btn-collapse-group :collapsed="menuCollapsed">
         <app-btn
+          v-if="isManualProbeActive"
+          :elevation="2"
+          :disabled="!klippyReady || printerPrinting"
+          small
+          class="ml-1"
+          @click="manualProbeDialogOpen = true"
+        >
+          {{ $t('app.tool.tooltip.manual_probe') }}
+        </app-btn>
+        <app-btn
           v-if="printerSupportsForceMove"
           :elevation="2"
           :disabled="!klippyReady || printerPrinting"
@@ -98,22 +108,30 @@
     </template>
 
     <toolhead :force-move="forceMove" />
+
+    <manual-probe-dialog
+      v-if="manualProbeDialogOpen"
+      v-model="manualProbeDialogOpen"
+    />
   </collapsable-card>
 </template>
 
 <script lang="ts">
-import { Component, Mixins, Prop } from 'vue-property-decorator'
+import { Component, Mixins, Prop, Watch } from 'vue-property-decorator'
 import StateMixin from '@/mixins/state'
 import ToolheadMixin from '@/mixins/toolhead'
 import Toolhead from '@/components/widgets/toolhead/Toolhead.vue'
+import ManualProbeDialog from '@/components/common/ManualProbeDialog.vue'
 
 @Component({
   components: {
-    Toolhead
+    Toolhead,
+    ManualProbeDialog
   }
 })
 export default class ToolheadCard extends Mixins(StateMixin, ToolheadMixin) {
   forceMove = false
+  manualProbeDialogOpen = false
 
   @Prop({ type: Boolean, default: false })
   public menuCollapsed!: boolean
@@ -140,6 +158,18 @@ export default class ToolheadCard extends Mixins(StateMixin, ToolheadMixin) {
 
   get printerSupportsForceMove () {
     return this.printerSettings.force_move?.enable_force_move ?? false
+  }
+
+  get showManualProbeDialogAutomatically () {
+    return this.$store.state.config.uiSettings.general.showManualProbeDialogAutomatically
+  }
+
+  @Watch('isManualProbeActive')
+  onIsManualProbeActive (value: boolean) {
+    if (value && this.showManualProbeDialogAutomatically &&
+      this.klippyReady && !this.printerPrinting) {
+      this.manualProbeDialogOpen = true
+    }
   }
 
   async toggleForceMove () {

--- a/src/globals.ts
+++ b/src/globals.ts
@@ -359,5 +359,6 @@ export const Waits = Object.freeze({
   onExtruderChange: 'onExtruderChange',
   onLoadLanguage: 'onLoadLanguage',
   onFileSystem: 'onFileSystem',
-  onTimelapseSaveFrame: 'onTimelapseSaveFrame'
+  onTimelapseSaveFrame: 'onTimelapseSaveFrame',
+  onManualProbe: 'onManualProbe'
 })

--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -127,6 +127,8 @@ app:
         your system. Are you sure?
   general:
     btn:
+      abort: Abort
+      accept: Accept
       add: Add
       add_dir: Add Directory
       add_file: Add File
@@ -467,6 +469,7 @@ app:
       z_adjust_values: Z Adjust values
       date_time_format: Date and Time format
       force_move_toggle_warning: Require confirm when activating force_move
+      show_manual_probe_dialog_automatically: Show Manual Probe dialog automatically
     timer_options:
       duration: Duration only
       filament: Filament Estimation
@@ -485,6 +488,7 @@ app:
       tool: Tool
     tooltip:
       gcode_coords: Use GCode position instead of toolhead position on dashboard
+      show_manual_probe_dialog_automatically: Automatically shows helper dialog if running a Manual Probe tool
   socket:
     msg:
       connecting: Connecting to moonraker...
@@ -527,6 +531,7 @@ app:
       extruder_disabled: extruder disabled, below min_extrude_temp (%{min}<small>°C</small>)
       home_xy: Home XY
       home_z: Home Z
+      manual_probe: Manual Probe
       motors_off: MOTORS OFF
       z_tilt_adjust: Z_Tilt_Adjust
       quad_gantry_level: QGL

--- a/src/mixins/toolhead.ts
+++ b/src/mixins/toolhead.ts
@@ -37,4 +37,8 @@ export default class ToolheadMixin extends Vue {
   get hasHomingOverride (): boolean {
     return this.$store.getters['printer/getHasHomingOverride']
   }
+
+  get isManualProbeActive () {
+    return this.$store.getters['printer/getIsManualProbeActive']
+  }
 }

--- a/src/store/config/index.ts
+++ b/src/store/config/index.ts
@@ -68,6 +68,7 @@ export const defaultState = (): ConfigState => {
         flipConsoleLayout: false,
         cameraFullscreenAction: 'embed',
         topNavPowerToggle: null,
+        showManualProbeDialogAutomatically: true,
         forceMoveToggleWarning: true
       },
       theme: {

--- a/src/store/config/types.ts
+++ b/src/store/config/types.ts
@@ -60,6 +60,7 @@ export interface GeneralConfig {
   flipConsoleLayout: boolean;
   cameraFullscreenAction: CameraFullscreenAction;
   topNavPowerToggle: null | string;
+  showManualProbeDialogAutomatically: boolean;
   forceMoveToggleWarning: boolean;
 }
 

--- a/src/store/printer/getters.ts
+++ b/src/store/printer/getters.ts
@@ -668,5 +668,9 @@ export const getters: GetterTree<PrinterState, RootState> = {
     } else {
       return false
     }
+  },
+
+  getIsManualProbeActive: (state) => {
+    return state.printer?.manual_probe?.is_active || false
   }
 }

--- a/src/store/printer/index.ts
+++ b/src/store/printer/index.ts
@@ -104,6 +104,12 @@ export const defaultState = (): PrinterState => {
         homing_origin: [],
         speed: 0
       },
+      manual_probe: {
+        is_active: false,
+        z_position: null,
+        z_position_lower: null,
+        z_position_upper: null
+      },
       fan: {
         speed: 0
       },


### PR DESCRIPTION
Will show buttons for all the "Z Adjust values" from settings + `1` and `0.1` in case they are not there as this might need more broad changes.

There's a new "Show Manual Probe dialog automatically" setting that will automatically open the dialog if we are on the Dashboard or Tune page and a Manual Probe command is initiated.

Dialog:

![image](https://user-images.githubusercontent.com/85504/180613453-d2a0b66a-b3ef-49f5-9364-f50c27b59854.png)

Button added to dashboard page (only visible when a Manual Probe command is running):

![image](https://user-images.githubusercontent.com/85504/180613490-95b57fd0-aa3d-4429-8a47-75d4a325da22.png)

Button added to tune page (only visible when a Manual Probe command is running):

![image](https://user-images.githubusercontent.com/85504/180613525-f551afa5-ff1e-4c55-bf5d-653118a04c10.png)

Fixes #761
Fixes #782

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>