### PR TITLE
feat: toolhead diagnostics

### DIFF
--- a/src/components/layout/AppNavDrawer.vue
+++ b/src/components/layout/AppNavDrawer.vue
@@ -77,6 +77,14 @@
           </app-nav-item>
 
           <app-nav-item
+            v-if="diagnosticsEnabled"
+            icon="$chart"
+            to="/diagnostics"
+          >
+            {{ $t('app.general.title.diagnostics') }}
+          </app-nav-item>
+
+          <app-nav-item
             icon="$codeJson"
             to="/configure"
           >
@@ -124,6 +132,10 @@ export default class AppNavDrawer extends Mixins(StateMixin) {
 
   get supportsTimelapse () {
     return this.$store.getters['server/componentSupport']('timelapse')
+  }
+
+  get diagnosticsEnabled () {
+    return this.$store.state.config.uiSettings.general.enableDiagnostics
   }
 
   get supportsVersions () {

--- a/src/components/settings/ToolheadSettings.vue
+++ b/src/components/settings/ToolheadSettings.vue
@@ -176,6 +176,16 @@
         <v-divider />
       </template>
 
+      <app-setting :title="$t('app.setting.label.enable_diagnostics')">
+        <v-switch
+          v-model="enableDiagnostics"
+          hide-details
+          class="mt-0 mb-4"
+        />
+      </app-setting>
+
+      <v-divider />
+
       <app-setting :title="$t('app.setting.label.reset')">
         <app-btn
           outlined
@@ -364,6 +374,18 @@ export default class ToolHeadSettings extends Vue {
   set forceMoveToggleWarning (value: boolean) {
     this.$store.dispatch('config/saveByPath', {
       path: 'uiSettings.general.forceMoveToggleWarning',
+      value,
+      server: true
+    })
+  }
+
+  get enableDiagnostics () {
+    return this.$store.state.config.uiSettings.general.enableDiagnostics
+  }
+
+  set enableDiagnostics (value: boolean) {
+    this.$store.dispatch('config/saveByPath', {
+      path: 'uiSettings.general.enableDiagnostics',
       value,
       server: true
     })

--- a/src/locales/de.yaml
+++ b/src/locales/de.yaml
@@ -333,6 +333,7 @@ app:
       config_files: Konfigurationsdateien
       configure: Konfiguration
       console: Konsole
+      diagnostics: Diagnostik
       endstops: Endschalter
       fans_outputs: Lüfter & Ausgänge
       gcode_preview: Gcode-Vorschau
@@ -415,6 +416,7 @@ app:
       default_toolhead_z_speed: Standard Druckkopfgeschwindigkeit für Z
       draw_background: Hintergrund anzeigen
       enable: Aktivieren
+      enable_diagnostics: Diagnostik-Aufzeichnung aktivieren
       enable_notifications: Aktiviere Benachrichtigung
       expression: Ausdruck
       extrusion_line_width: Extrusionslinien-Dicke

--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -342,6 +342,7 @@ app:
       config_files: Configuration Files
       configure: Configuration
       console: Console
+      diagnostics: Diagnostics
       endstops: Endstops
       fans_outputs: Fans & Outputs
       gcode_preview: Gcode Preview
@@ -430,6 +431,7 @@ app:
       default_toolhead_z_speed: Default toolhead Z speed
       draw_background: Draw Background
       enable: Enable
+      enable_diagnostics: Enable diagnostics logging
       enable_notifications: Enable notifications
       expression: Expression
       extrusion_line_width: Extrusion Line Width

--- a/src/plugins/socketClient.ts
+++ b/src/plugins/socketClient.ts
@@ -159,15 +159,15 @@ export class WebSocketClient {
                 // ...However, status notifications come through thick and fast,
                 // so we cache these and send them through every second.
 
+                const timestamp = eventtime ? eventtime * 1000 : Date.now()
+
                 // If any of these properties exist, bypass the cache and send immediately
                 for (const key of ['motion_report']) {
                   if (this.store && key in params) {
-                    this.store.dispatch('printer/onFastNotifyStatusUpdate', { key, payload: params[key] }, { root: true })
+                    this.store.dispatch('printer/onFastNotifyStatusUpdate', { key, timestamp, payload: params[key] }, { root: true })
                     delete params[key]
                   }
                 }
-
-                const timestamp = eventtime ? eventtime * 1000 : Date.now()
 
                 this.cache = (!this.cache)
                   ? { timestamp, params }

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -18,6 +18,7 @@ import NotFound from '@/views/NotFound.vue'
 import Login from '@/views/Login.vue'
 import Icons from '@/views/Icons.vue'
 import store from '@/store'
+import Diagnostics from '@/views/Diagnostics.vue'
 
 Vue.use(VueRouter)
 
@@ -55,6 +56,12 @@ const routes: Array<RouteConfig> = [
     path: '/tune',
     name: 'Tune',
     component: Tune,
+    beforeEnter: ifAuthenticated
+  },
+  {
+    path: '/diagnostics',
+    name: 'Diagnostics',
+    component: Diagnostics,
     beforeEnter: ifAuthenticated
   },
   {

--- a/src/store/config/index.ts
+++ b/src/store/config/index.ts
@@ -68,7 +68,8 @@ export const defaultState = (): ConfigState => {
         flipConsoleLayout: false,
         cameraFullscreenAction: 'embed',
         topNavPowerToggle: null,
-        forceMoveToggleWarning: true
+        forceMoveToggleWarning: true,
+        enableDiagnostics: false
       },
       theme: {
         isDark: true,

--- a/src/store/config/types.ts
+++ b/src/store/config/types.ts
@@ -61,6 +61,7 @@ export interface GeneralConfig {
   cameraFullscreenAction: CameraFullscreenAction;
   topNavPowerToggle: null | string;
   forceMoveToggleWarning: boolean;
+  enableDiagnostics: boolean;
 }
 
 export type CameraFullscreenAction = 'embed' | 'rawstream';

--- a/src/views/Diagnostics.vue
+++ b/src/views/Diagnostics.vue
@@ -1,0 +1,78 @@
+<template>
+  <v-row>
+    <v-col cols="6">
+      <collapsable-card
+        icon="$printer3dNozzle"
+        :title="$t('app.general.label.flow')"
+      >
+        <app-chart
+          :data="flowData"
+          :options="flowOptions"
+          height="300px"
+        />
+      </collapsable-card>
+    </v-col>
+    <v-col cols="6">
+      <collapsable-card
+        icon="$motion"
+        :title="$t('app.general.label.speed')"
+      >
+        <app-chart
+          :data="velocityData"
+          :options="velocityOptions"
+          height="300px"
+        />
+      </collapsable-card>
+    </v-col>
+  </v-row>
+</template>
+
+<script lang="ts">
+import { Component, Mixins } from 'vue-property-decorator'
+import StateMixin from '@/mixins/state'
+import AppChart from '@/components/ui/AppChart.vue'
+import CollapsableCard from '@/components/common/CollapsableCard.vue'
+
+@Component({
+  components: { CollapsableCard, AppChart }
+})
+export default class Diagnostics extends Mixins(StateMixin) {
+  ready = false
+  metadata = {
+    extrusion_rate: { suffix: 'mm³/s', name: this.$t('app.general.label.flow') },
+    velocity: { suffix: 'mm/s', name: this.$t('velocity') }
+  } as {[type: string]: {suffix: string, name: string}}
+
+  get flowData () { return this.$store.state.charts.extrusion_rate || [] }
+  get flowOptions () { return this.options('extrusion_rate') }
+
+  get velocityData () { return this.$store.state.charts.velocity || [] }
+  get velocityOptions () { return this.options('velocity') }
+
+  options (type: string) {
+    const o = {
+      ...this.$store.getters['charts/getBaseChartOptions']({
+        [type]: this.metadata[type].suffix
+      }),
+      series: this.series(type),
+      dataZoom: [{
+        type: 'inside',
+        zoomOnMouseWheel: 'shift'
+      }]
+    }
+
+    o.yAxis.max = o.yAxis.min = undefined
+    o.yAxis.axisLabel = { formatter: `{value} ${this.metadata[type].suffix}`, show: true }
+    console.log(o)
+
+    return o
+  }
+
+  series (type: string) {
+    return this.$store.getters['charts/getBaseSeries']({
+      name: this.metadata[type].name,
+      encode: { x: 'date', y: type }
+    })
+  }
+}
+</script>


### PR DESCRIPTION
Toolhead diagnostics charts using Klipper's `motion_report` (recording flow rate and speeds for now)
Maybe other diagnostic statistics would be useful here too, not sure which additional ones to log..

Disabled by default to save browser processing power:
![image](https://user-images.githubusercontent.com/25269274/180618796-3a77939b-1630-429e-a6c3-964c04eaa6cf.png)
![image](https://user-images.githubusercontent.com/25269274/180619220-c8890d79-c0f3-4006-a6dc-7a78c21899eb.png)

Closes #454