### PR TITLE
fix: show current layer in Gcode preview by default

### DIFF
--- a/src/store/gcodePreview/index.ts
+++ b/src/store/gcodePreview/index.ts
@@ -16,7 +16,7 @@ export const defaultState = (): GcodePreviewState => {
     parserWorker: null,
 
     viewer: {
-      showCurrentLayer: false,
+      showCurrentLayer: true,
       showNextLayer: false,
       showPreviousLayer: false,
       showMoves: true,


### PR DESCRIPTION
Fixes #780

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>