### PR TITLE
fix: hide sub-navigation if socket not connected

### DIFF
--- a/src/components/layout/AppNavDrawer.vue
+++ b/src/components/layout/AppNavDrawer.vue
@@ -2,8 +2,8 @@
   <v-navigation-drawer
     :value="value"
     :color="theme.currentTheme.drawer"
-    :mini-variant="!hasSubNavigation"
-    :floating="!hasSubNavigation"
+    :mini-variant="!(hasSubNavigation && authenticated && socketConnected)"
+    :floating="!(hasSubNavigation && authenticated && socketConnected)"
     clipped
     app
     @input="emitChange"
@@ -99,7 +99,10 @@
         </div>
       </v-navigation-drawer>
 
-      <router-view name="navigation" />
+      <router-view
+        v-if="hasSubNavigation && authenticated && socketConnected"
+        name="navigation"
+      />
     </v-row>
   </v-navigation-drawer>
 </template>

--- a/src/components/layout/AppNavDrawer.vue
+++ b/src/components/layout/AppNavDrawer.vue
@@ -2,8 +2,8 @@
   <v-navigation-drawer
     :value="value"
     :color="theme.currentTheme.drawer"
-    :mini-variant="!(hasSubNavigation && authenticated && socketConnected)"
-    :floating="!(hasSubNavigation && authenticated && socketConnected)"
+    :mini-variant="!showSubNavigation"
+    :floating="!showSubNavigation"
     clipped
     app
     @input="emitChange"
@@ -100,7 +100,7 @@
       </v-navigation-drawer>
 
       <router-view
-        v-if="hasSubNavigation && authenticated && socketConnected"
+        v-if="showSubNavigation"
         name="navigation"
       />
     </v-row>
@@ -135,6 +135,10 @@ export default class AppNavDrawer extends Mixins(StateMixin) {
 
   get hasSubNavigation () {
     return this.$route.meta?.hasSubNavigation ?? false
+  }
+
+  get showSubNavigation () {
+    return this.hasSubNavigation && this.socketConnected && this.authenticated
   }
 
   get isMobile () {


### PR DESCRIPTION
When we are on Settings page and moonraker restarts (or socket gets closed) we get the "reconnect" buttons, but sub-navigation is still visible.

Before:

![image](https://user-images.githubusercontent.com/85504/181311699-303960fa-1ffa-4acd-808c-0e23557d83dc.png)

After:

![image](https://user-images.githubusercontent.com/85504/181311607-7231944c-d16a-4376-b820-7af46c74a771.png)

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>