### PR TITLE
fix: corrects moonraker docs link for "include" section

### DIFF
--- a/src/components/widgets/filesystem/setupMonaco.ts
+++ b/src/components/widgets/filesystem/setupMonaco.ts
@@ -24,6 +24,15 @@ const getDocsSection = (service: CodeLensSupportedService, sectionName: string) 
       if (/^extruder[0-9]+$/.test(sectionName)) {
         return 'extruder'
       }
+
+      break
+
+    case 'moonraker':
+      if (sectionName.startsWith('include')) {
+        return 'include-directives'
+      }
+
+      break
   }
 
   return sectionName


### PR DESCRIPTION
I just realized that moonraker also allows for `[include ...]` sections, but the codelens link docs was incorrectly pointing to [#include](https://moonraker.readthedocs.io/en/latest/configuration/#include) when it should be [#include-directives](https://moonraker.readthedocs.io/en/latest/configuration/#include-directives)

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>