### PR TITLE
fix: mitigates console warning

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -215,15 +215,21 @@ export default class App extends Mixins(StateMixin) {
       this.flashMessage.open = true
     })
 
-    const legacyFavIcons = document.querySelectorAll("link[rel*='icon'][type='image/png']")
-
-    legacyFavIcons.forEach(item => {
+    const clearNodes = (item: Element) => {
       const parentElement = item.parentElement
 
       if (parentElement) {
         parentElement.removeChild(item)
       }
-    })
+    }
+
+    const legacyFavIcons = document.querySelectorAll("link[rel*='icon'][type='image/png']")
+
+    legacyFavIcons.forEach(clearNodes)
+
+    const legacyThemeColor = document.querySelectorAll("meta[name='theme-color']")
+
+    legacyThemeColor.forEach(clearNodes)
   }
 
   handleToolsDrawerChange () {

--- a/src/App.vue
+++ b/src/App.vue
@@ -215,21 +215,22 @@ export default class App extends Mixins(StateMixin) {
       this.flashMessage.open = true
     })
 
-    const clearNodes = (item: Element) => {
-      const parentElement = item.parentElement
+    const legacyElementsSelectors = [
+      "link[rel*='icon'][type='image/png']",
+      "meta[name='theme-color']"
+    ]
 
-      if (parentElement) {
-        parentElement.removeChild(item)
-      }
+    for (const legacyElementsSelector of legacyElementsSelectors) {
+      const legacyElements = document.querySelectorAll(legacyElementsSelector)
+
+      legacyElements.forEach(item => {
+        const parentElement = item.parentElement
+
+        if (parentElement) {
+          parentElement.removeChild(item)
+        }
+      })
     }
-
-    const legacyFavIcons = document.querySelectorAll("link[rel*='icon'][type='image/png']")
-
-    legacyFavIcons.forEach(clearNodes)
-
-    const legacyThemeColor = document.querySelectorAll("meta[name='theme-color']")
-
-    legacyThemeColor.forEach(clearNodes)
   }
 
   handleToolsDrawerChange () {

--- a/vue.config.js
+++ b/vue.config.js
@@ -19,7 +19,7 @@ module.exports = defineConfig({
     }
   },
   pwa: {
-    themeColor: '',
+    themeColor: '#2196F3',
     msTileColor: '#000000',
     appleMobileWebAppCache: 'yes',
     manifestOptions: {


### PR DESCRIPTION
Mitigates the following warning:

![image](https://user-images.githubusercontent.com/85504/181535352-a11b1939-0a08-418c-9697-b7b77a920a9c.png)

From my tests with Edge and Chrome on Windows 11, it seems to work fine with the value back in!

This is a follow up on this discussion: https://github.com/fluidd-core/fluidd/pull/774#discussion_r932142733

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>