### PR TITLE
fix: Check Bed_Mesh Support

### DIFF
--- a/src/components/widgets/bedmesh/BedMeshCard.vue
+++ b/src/components/widgets/bedmesh/BedMeshCard.vue
@@ -1,5 +1,6 @@
 <template>
   <collapsable-card
+    v-if="supportsBedMesh && klippyReady"
     :title="$t('app.general.title.bedmesh')"
     :lazy="false"
     icon="$bedMesh"
@@ -164,6 +165,10 @@ export default class BedMeshCard extends Mixins(StateMixin, ToolheadMixin) {
   // The current processed mesh data, if any.
   get mesh () {
     return this.$store.getters['mesh/getCurrentMeshData']
+  }
+
+  get supportsBedMesh () {
+    return this.$store.getters['mesh/getSupportsBedMesh']
   }
 
   get isMobile () {

--- a/src/components/widgets/bedmesh/BedMeshCard.vue
+++ b/src/components/widgets/bedmesh/BedMeshCard.vue
@@ -1,6 +1,5 @@
 <template>
   <collapsable-card
-    v-if="supportsBedMesh && klippyReady"
     :title="$t('app.general.title.bedmesh')"
     :lazy="false"
     icon="$bedMesh"
@@ -165,10 +164,6 @@ export default class BedMeshCard extends Mixins(StateMixin, ToolheadMixin) {
   // The current processed mesh data, if any.
   get mesh () {
     return this.$store.getters['mesh/getCurrentMeshData']
-  }
-
-  get supportsBedMesh () {
-    return this.$store.getters['mesh/getSupportsBedMesh']
   }
 
   get isMobile () {

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -108,6 +108,10 @@ export default class Dashboard extends Mixins(StateMixin) {
     return 'firmware_retraction' in this.$store.getters['printer/getPrinterSettings']()
   }
 
+  get supportsBedMesh () {
+    return this.$store.getters['mesh/getSupportsBedMesh']
+  }
+
   get macros () {
     return this.$store.getters['macros/getVisibleMacros']
   }
@@ -176,6 +180,7 @@ export default class Dashboard extends Mixins(StateMixin) {
     if (item.id === 'macros-card' && (this.macros.length <= 0 && this.uncategorizedMacros.length <= 0)) return true
     if (item.id === 'printer-status-card' && !this.klippyReady) return true
     if (item.id === 'retract-card' && !this.firmwareRetractionEnabled) return true
+    if (item.id === 'bed-mesh-card' && !this.supportsBedMesh) return true
 
     // Otherwise return the opposite of whatever the enabled state is.
     return !item.enabled


### PR DESCRIPTION
Only shows the bed_mesh card if bed_mesh is available and klipper is ready (important for the dashboard card).

Signed-off-by: Kerim Bilgic <bastelklug@pfusch.eu>