### PR TITLE
feat: adds new Bed Screws Adjust helper dialog

### DIFF
--- a/src/components/common/BedScrewsAdjustDialog.vue
+++ b/src/components/common/BedScrewsAdjustDialog.vue
@@ -1,0 +1,162 @@
+<template>
+  <v-dialog
+    :value="value"
+    :max-width="450"
+    scrollable
+    @input="$emit('input', $event)"
+  >
+    <v-form @submit.prevent="sendAccept">
+      <v-card>
+        <v-card-title class="card-heading py-2">
+          <span class="focus--text">{{ $t('app.tool.title.bed_screws_adjust') }}</span>
+        </v-card-title>
+
+        <v-divider />
+
+        <v-card-text>
+          <v-row>
+            <v-col>
+              <v-text-field
+                :label="$t('app.general.label.screw_name')"
+                outlined
+                hide-details
+                dense
+                disabled
+                :value="currentScrewName"
+              />
+            </v-col>
+          </v-row>
+          <v-row>
+            <v-col>
+              <v-text-field
+                :label="$t('app.general.label.screw_index')"
+                outlined
+                hide-details
+                dense
+                disabled
+                :value="$t('app.general.label.partial_of_total', {partial: currentScrewIndex + 1, total: bedScrews.length})"
+              />
+            </v-col>
+          </v-row>
+          <v-row>
+            <v-col>
+              <v-text-field
+                :label="$t('app.general.label.accepted_screws')"
+                outlined
+                hide-details
+                dense
+                disabled
+                :value="$t('app.general.label.partial_of_total', {partial: acceptedScrews, total: bedScrews.length})"
+              />
+            </v-col>
+          </v-row>
+          <v-row>
+            <v-col class="text-subtitle-1 text-center">
+              <span v-html="$t('app.general.msg.bed_screws_adjust')" />
+            </v-col>
+          </v-row>
+
+          <v-progress-linear
+            :value="acceptedScrews / bedScrews.length * 100"
+            class="mt-2"
+          />
+        </v-card-text>
+
+        <v-card-actions>
+          <v-spacer />
+
+          <app-btn
+            color="warning"
+            text
+            type="button"
+            @click="sendAbort"
+          >
+            {{ $t('app.general.btn.abort') }}
+          </app-btn>
+
+          <app-btn
+            :loading="hasWait($waits.onBedScrewsAdjust)"
+            color="primary"
+            text
+            type="button"
+            @click="sendAdjusted"
+          >
+            {{ $t('app.general.btn.adjusted') }}
+          </app-btn>
+
+          <app-btn
+            :loading="hasWait($waits.onBedScrewsAdjust)"
+            color="primary"
+            :elevation="2"
+            type="submit"
+          >
+            {{ $t('app.general.btn.accept') }}
+          </app-btn>
+        </v-card-actions>
+      </v-card>
+    </v-form>
+  </v-dialog>
+</template>
+
+<script lang="ts">
+import { Component, Mixins, Prop, Watch } from 'vue-property-decorator'
+import StateMixin from '@/mixins/state'
+import ToolheadMixin from '@/mixins/toolhead'
+import { startCase } from 'lodash-es'
+
+@Component({})
+export default class BedScrewsAdjustDialog extends Mixins(StateMixin, ToolheadMixin) {
+  @Prop({ type: Boolean, default: false })
+  public value!: boolean
+
+  get bedScrews () {
+    return this.$store.getters['printer/getBedScrews']
+  }
+
+  get bedScrewsAdjust () {
+    return this.$store.state.printer.printer.bed_screws
+  }
+
+  get currentState () {
+    return this.bedScrewsAdjust.state || ' '
+  }
+
+  get currentScrewIndex () {
+    return this.bedScrewsAdjust.current_screw
+  }
+
+  get currentScrewName () {
+    return startCase(this.bedScrews[this.currentScrewIndex].name || this.$t('app.general.label.screw_number', { index: this.currentScrewIndex + 1 }))
+  }
+
+  get currentScrewPosition () {
+    const [x, y] = this.bedScrews[this.currentScrewIndex][this.currentState]
+
+    return `${x}, ${y}`
+  }
+
+  get acceptedScrews () {
+    return this.bedScrewsAdjust.accepted_screws
+  }
+
+  @Watch('isBedScrewsAdjustActive')
+  onBedScrewsAdjustActive (value: boolean) {
+    if (!value) {
+      this.$emit('input', false)
+    }
+  }
+
+  sendAbort () {
+    this.sendGcode('ABORT', this.$waits.onBedScrewsAdjust)
+    this.$emit('input', false)
+  }
+
+  sendAdjusted () {
+    this.sendGcode('ADJUSTED', this.$waits.onBedScrewsAdjust)
+  }
+
+  sendAccept () {
+    this.sendGcode('ACCEPT', this.$waits.onBedScrewsAdjust)
+  }
+}
+</script>

--- a/src/components/common/ManualProbeDialog.vue
+++ b/src/components/common/ManualProbeDialog.vue
@@ -8,7 +8,7 @@
     <v-form @submit.prevent="sendAccept">
       <v-card>
         <v-card-title class="card-heading py-2">
-          <span class="focus--text">{{ $t('app.tool.tooltip.manual_probe') }}</span>
+          <span class="focus--text">{{ $t('app.tool.title.manual_probe') }}</span>
         </v-card-title>
 
         <v-divider />

--- a/src/components/settings/ToolheadSettings.vue
+++ b/src/components/settings/ToolheadSettings.vue
@@ -177,6 +177,19 @@
 
       <v-divider />
 
+      <app-setting
+        :title="$t('app.setting.label.show_bed_screws_adjust_dialog_automatically')"
+        :sub-title="$t('app.setting.tooltip.show_bed_screws_adjust_dialog_automatically')"
+      >
+        <v-switch
+          v-model="showBedScrewsAdjustDialogAutomatically"
+          hide-details
+          class="mt-0 mb-4"
+        />
+      </app-setting>
+
+      <v-divider />
+
       <template v-if="printerSupportsForceMove">
         <app-setting :title="$t('app.setting.label.force_move_toggle_warning')">
           <v-switch
@@ -377,6 +390,18 @@ export default class ToolHeadSettings extends Vue {
   set showManualProbeDialogAutomatically (value: boolean) {
     this.$store.dispatch('config/saveByPath', {
       path: 'uiSettings.general.showManualProbeDialogAutomatically',
+      value,
+      server: true
+    })
+  }
+
+  get showBedScrewsAdjustDialogAutomatically () {
+    return this.$store.state.config.uiSettings.general.showBedScrewsAdjustDialogAutomatically
+  }
+
+  set showBedScrewsAdjustDialogAutomatically (value: boolean) {
+    this.$store.dispatch('config/saveByPath', {
+      path: 'uiSettings.general.showBedScrewsAdjustDialogAutomatically',
       value,
       server: true
     })

--- a/src/components/widgets/toolhead/ToolheadCard.vue
+++ b/src/components/widgets/toolhead/ToolheadCard.vue
@@ -67,7 +67,7 @@
           :disabled="!klippyReady || printerPrinting"
           small
           class="ml-1"
-          @click="sendGcode('BED_SCREWS_ADJUST', waits.onBedScrewsAdjust)"
+          @click="bedScrewsAdjust"
         >
           {{ $t('app.tool.tooltip.bed_screws_adjust') }}
         </app-btn>
@@ -113,6 +113,11 @@
       v-if="manualProbeDialogOpen"
       v-model="manualProbeDialogOpen"
     />
+
+    <bed-screws-adjust-dialog
+      v-if="bedScrewsAdjustDialogOpen"
+      v-model="bedScrewsAdjustDialogOpen"
+    />
   </collapsable-card>
 </template>
 
@@ -122,16 +127,19 @@ import StateMixin from '@/mixins/state'
 import ToolheadMixin from '@/mixins/toolhead'
 import Toolhead from '@/components/widgets/toolhead/Toolhead.vue'
 import ManualProbeDialog from '@/components/common/ManualProbeDialog.vue'
+import BedScrewsAdjustDialog from '@/components/common/BedScrewsAdjustDialog.vue'
 
 @Component({
   components: {
     Toolhead,
-    ManualProbeDialog
+    ManualProbeDialog,
+    BedScrewsAdjustDialog
   }
 })
 export default class ToolheadCard extends Mixins(StateMixin, ToolheadMixin) {
   forceMove = false
   manualProbeDialogOpen = false
+  bedScrewsAdjustDialogOpen = false
 
   @Prop({ type: Boolean, default: false })
   public menuCollapsed!: boolean
@@ -164,11 +172,31 @@ export default class ToolheadCard extends Mixins(StateMixin, ToolheadMixin) {
     return this.$store.state.config.uiSettings.general.showManualProbeDialogAutomatically
   }
 
+  get showBedScrewsAdjustDialogAutomatically () {
+    return this.$store.state.config.uiSettings.general.showBedScrewsAdjustDialogAutomatically
+  }
+
   @Watch('isManualProbeActive')
   onIsManualProbeActive (value: boolean) {
     if (value && this.showManualProbeDialogAutomatically &&
       this.klippyReady && !this.printerPrinting) {
       this.manualProbeDialogOpen = true
+    }
+  }
+
+  @Watch('isBedScrewsAdjustActive')
+  onIsBedScrewsAdjustActive (value: boolean) {
+    if (value && this.showBedScrewsAdjustDialogAutomatically &&
+      this.klippyReady && !this.printerPrinting) {
+      this.bedScrewsAdjustDialogOpen = true
+    }
+  }
+
+  bedScrewsAdjust () {
+    if (this.isBedScrewsAdjustActive) {
+      this.bedScrewsAdjustDialogOpen = true
+    } else {
+      this.sendGcode('BED_SCREWS_ADJUST', this.waits.onBedScrewsAdjust)
     }
   }
 

--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -134,6 +134,7 @@ app:
       add_file: Add File
       add_printer: Add printer
       adjust_layout: Adjust dashboard layout
+      adjusted: Adjusted
       all: All
       auth_unsure: Unsure why you're seeing this?
       calibrate: Calibrate
@@ -197,6 +198,7 @@ app:
     label:
       accel_to_decel: Accel to Decel
       acceleration: Acceleration
+      accepted_screws: Accepted screws
       actual_time: Actual
       add_camera: Add Camera
       add_filter: Add Filter
@@ -243,6 +245,7 @@ app:
       'on': 'On'
       'off': 'Off'
       password: Password
+      partial_of_total: '%{partial} of %{total}'
       power: Power
       pressure_advance: Pressure Advance
       printers: Printers
@@ -251,6 +254,9 @@ app:
       retract_length: Retract Length
       retract_speed: Retract Speed
       save_as: Save As
+      screw_index: Screw index
+      screw_name: Screw name
+      screw_number: Screw %{index}
       services: Services
       slicer: Slicer
       smooth_time: Smooth Time
@@ -284,6 +290,8 @@ app:
     msg:
       password_changed: Password changed
       wrong_password: Oops, something went wrong. Is your password correct?
+      bed_screws_adjust: >-
+        Click <b>Adjusted</b> if a significant adjustment is necessary on the current screw; otherwise, click <b>Accept</b> to continue.
     simple_form:
       error:
         arrayofnums: Only numbers
@@ -470,6 +478,7 @@ app:
       date_time_format: Date and Time format
       force_move_toggle_warning: Require confirm when activating FORCE_MOVE
       show_manual_probe_dialog_automatically: Show Manual Probe dialog automatically
+      show_bed_screws_adjust_dialog_automatically: Show Bed Screws Adjust dialog automatically
     timer_options:
       duration: Duration only
       filament: Filament Estimation
@@ -489,6 +498,7 @@ app:
     tooltip:
       gcode_coords: Use GCode position instead of toolhead position on dashboard
       show_manual_probe_dialog_automatically: Automatically shows helper dialog if running a Manual Probe tool
+      show_bed_screws_adjust_dialog_automatically: Automatically shows helper dialog if running BED_SCREWS_ADJUST tool
   socket:
     msg:
       connecting: Connecting to moonraker...
@@ -526,6 +536,9 @@ app:
       home_x: X
       home_y: 'Y'
       home_all: All
+    title:
+      bed_screws_adjust: Bed Screws Adjust
+      manual_probe: Manual Probe
     tooltip:
       absolute_positioning: Absolute Positioning
       extruder_disabled: extruder disabled, below min_extrude_temp (%{min}<small>°C</small>)

--- a/src/mixins/toolhead.ts
+++ b/src/mixins/toolhead.ts
@@ -41,4 +41,8 @@ export default class ToolheadMixin extends Vue {
   get isManualProbeActive () {
     return this.$store.getters['printer/getIsManualProbeActive']
   }
+
+  get isBedScrewsAdjustActive () {
+    return this.$store.getters['printer/getIsBedScrewsAdjustActive']
+  }
 }

--- a/src/store/config/index.ts
+++ b/src/store/config/index.ts
@@ -69,6 +69,7 @@ export const defaultState = (): ConfigState => {
         cameraFullscreenAction: 'embed',
         topNavPowerToggle: null,
         showManualProbeDialogAutomatically: true,
+        showBedScrewsAdjustDialogAutomatically: true,
         forceMoveToggleWarning: true
       },
       theme: {

--- a/src/store/config/types.ts
+++ b/src/store/config/types.ts
@@ -61,6 +61,7 @@ export interface GeneralConfig {
   cameraFullscreenAction: CameraFullscreenAction;
   topNavPowerToggle: null | string;
   showManualProbeDialogAutomatically: boolean;
+  showBedScrewsAdjustDialogAutomatically: boolean;
   forceMoveToggleWarning: boolean;
 }
 

--- a/src/store/printer/getters.ts
+++ b/src/store/printer/getters.ts
@@ -577,6 +577,27 @@ export const getters: GetterTree<PrinterState, RootState> = {
     return sensors
   },
 
+  getBedScrews: (_, getters) => {
+    const config = getters.getPrinterSettings('bed_screws')
+    const screws = []
+
+    for (let index = 1; index <= 99; index++) {
+      const adjust = config[`screw${index}`]
+
+      if (!adjust) {
+        break
+      }
+
+      screws.push({
+        adjust,
+        fine: config[`screw${index}_fine_adjust`],
+        name: config[`screw${index}_name`]
+      })
+    }
+
+    return screws
+  },
+
   /**
    * Return a required setting from the printer.config object.
    */
@@ -672,5 +693,9 @@ export const getters: GetterTree<PrinterState, RootState> = {
 
   getIsManualProbeActive: (state) => {
     return state.printer.manual_probe?.is_active || false
+  },
+
+  getIsBedScrewsAdjustActive: (state) => {
+    return state.printer.bed_screws?.is_active || false
   }
 }

--- a/src/store/printer/index.ts
+++ b/src/store/printer/index.ts
@@ -110,6 +110,12 @@ export const defaultState = (): PrinterState => {
         z_position_lower: null,
         z_position_upper: null
       },
+      bed_screws: {
+        is_active: false,
+        state: null,
+        current_screw: 0,
+        accepted_screws: 0
+      },
       fan: {
         speed: 0
       },


### PR DESCRIPTION
UX probably can and should be improved, this is the best I could come up with...

![image](https://user-images.githubusercontent.com/85504/181805021-a5413d0f-f430-43fe-a025-d8594aa7ae91.png)

The progress just above the buttons represents the `accepted screws / total screws`

Fixes #792 

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>