### PR TITLE
fix: Enable vue-echarts auto-resizing

### DIFF
--- a/src/components/ui/AppChart.vue
+++ b/src/components/ui/AppChart.vue
@@ -12,6 +12,7 @@
         :update-options="{ notMerge: true }"
         :init-options="{ renderer: 'svg' }"
         :events="events"
+        autoresize
       />
     </div>
   </div>

--- a/src/components/widgets/bedmesh/BedMeshChart.vue
+++ b/src/components/widgets/bedmesh/BedMeshChart.vue
@@ -8,6 +8,7 @@
       :option="opts"
       :update-options="{ notMerge: false }"
       :init-options="{ renderer: 'canvas' }"
+      autoresize
     />
 
     <!-- <pre>legends: {{ opts.legend }}</pre> -->

--- a/src/components/widgets/thermals/ThermalChart.vue
+++ b/src/components/widgets/thermals/ThermalChart.vue
@@ -9,6 +9,7 @@
       :option="options"
       :update-options="{ notMerge: true }"
       :init-options="{ renderer: 'svg' }"
+      autoresize
       @legendselectchanged="handleLegendSelectChange"
     />
   </div>


### PR DESCRIPTION
Fixes the issue where the (thermals and others) chart wouldn't be sized properly after resizing the window or switching from the settings page to the dashboard.

Before
![image](https://user-images.githubusercontent.com/25269274/182450937-762311b4-a17f-445a-91c0-ad66046e72b0.png)

After
![image](https://user-images.githubusercontent.com/25269274/182450872-3a02984d-061e-49bc-9a29-52590ac8ddd1.png)
