### PR TITLE
fix: adds ACCEL parameter to FORCE_MOVE commands

### DIFF
--- a/src/components/widgets/toolhead/ToolheadMoves.vue
+++ b/src/components/widgets/toolhead/ToolheadMoves.vue
@@ -249,7 +249,10 @@ export default class ToolheadMoves extends Mixins(StateMixin, ToolheadMixin) {
       : distance
 
     if (this.forceMove) {
-      this.sendGcode(`FORCE_MOVE STEPPER=stepper_${axis} DISTANCE=${distance} VELOCITY=${rate}`)
+      const accel = (axis.toLowerCase() === 'z')
+        ? this.$store.getters['printer/getPrinterSettings']('printer.max_z_accel')
+        : this.$store.state.printer.printer.toolhead.max_accel
+      this.sendGcode(`FORCE_MOVE STEPPER=stepper_${axis} DISTANCE=${distance} VELOCITY=${rate} ACCEL=${accel}`)
     } else {
       this.sendGcode(`G91
       G1 ${axis}${distance} F${rate * 60}

--- a/src/components/widgets/toolhead/ToolheadPosition.vue
+++ b/src/components/widgets/toolhead/ToolheadPosition.vue
@@ -185,7 +185,10 @@ export default class ToolheadPosition extends Mixins(StateMixin, ToolheadMixin) 
         ? this.$store.state.config.uiSettings.general.defaultToolheadZSpeed
         : this.$store.state.config.uiSettings.general.defaultToolheadXYSpeed
       if (this.forceMove) {
-        this.sendGcode(`FORCE_MOVE STEPPER=stepper_${axis.toLowerCase()} DISTANCE=${pos} VELOCITY=${rate}`)
+        const accel = (axis.toLowerCase() === 'z')
+          ? this.$store.getters['printer/getPrinterSettings']('printer.max_z_accel')
+          : this.$store.state.printer.printer.toolhead.max_accel
+        this.sendGcode(`FORCE_MOVE STEPPER=stepper_${axis.toLowerCase()} DISTANCE=${pos} VELOCITY=${rate} ACCEL=${accel}`)
       } else {
         this.sendGcode(`G90
         G1 ${axis}${pos} F${rate * 60}`)


### PR DESCRIPTION
Send `ACCEL` parameter with `FORCE_MOVE` commands.

For X and Y it will use the currently set acceleration, for Z it will take the `max_z_accel` from the printer configuration

Fixes #814

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>