### PR TITLE
fix: Correct SVG transformations in GCode Preview

### DIFF
--- a/src/components/widgets/gcode-preview/GcodePreview.vue
+++ b/src/components/widgets/gcode-preview/GcodePreview.vue
@@ -324,8 +324,8 @@ export default class GcodePreview extends Mixins(StateMixin) {
     }
 
     const transform = [
-      this.flipX ? -(x.max - x.min) : 0,
-      this.flipY ? -(y.max - y.min) : 0
+      this.flipX ? -(x.max + x.min) : 0,
+      this.flipY ? -(y.max + y.min) : 0
     ]
 
     return `scale(${scale.join()}) translate(${transform.join()})`
@@ -416,7 +416,7 @@ export default class GcodePreview extends Mixins(StateMixin) {
       y
     } = this.viewBox
 
-    return `${x.min} ${y.min} ${x.max} ${y.max}`
+    return `${x.min} ${y.min} ${x.max - x.min} ${y.max - y.min}`
   }
 
   get defaultLayerPaths (): LayerPaths {


### PR DESCRIPTION
If a printer is not configured to have a (0,0) (xmin, ymin) coordinate, the GCode preview currently does not show up like in the picture below. For example, my printer's x goes from -113 to +113 and y from -74 to +74.

<img width="200" alt="image" src="https://user-images.githubusercontent.com/18223213/183264334-a487d8e3-c282-4434-8f5b-c38134ca045d.png">

I fixed two issues with the SVG generation:
- The final 2 parameters of [`viewBox`](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/viewBox) are the width & height of the image, not the +x and +y values.
- When flipping the image, the min & max coordinates should be added instead of subtracted. Imagine the print bed has minimum x 100 and maximum x 200. When flipped across the origin, it's going to end up far away and need to be translated 300px back.

Now, the preview shows up:
<img width="200" alt="image" src="https://user-images.githubusercontent.com/18223213/183264480-85899a08-f306-4237-aa97-b526d484ef82.png">

Signed-off-by: Ryan Adolf ryanadolf123@gmail.com