### PR TITLE
feat: preheat printer chamber if value provided

### DIFF
--- a/src/components/widgets/filesystem/FileSystem.vue
+++ b/src/components/widgets/filesystem/FileSystem.vue
@@ -863,6 +863,9 @@ export default class FileSystem extends Mixins(StateMixin, FilesMixin, ServicesM
       if (file.first_layer_bed_temp > 0) {
         this.sendGcode(`M140 S${file.first_layer_bed_temp}`)
       }
+      if (file.chamber_temp && file.chamber_temp > 0) {
+        this.sendGcode(`M141 S${file.chamber_temp}`)
+      }
     }
   }
 

--- a/src/store/files/types.ts
+++ b/src/store/files/types.ts
@@ -49,6 +49,7 @@ export interface KlipperFile {
 }
 
 export interface KlipperFileMeta {
+  chamber_temp?: number;
   estimated_time?: number;
   filament_total?: number;
   filament_weight_total?: number;


### PR DESCRIPTION
Moonraker now has the ability to send the [chamber temperature](https://github.com/Arksine/moonraker/pull/480) as part of the gcode files metadata, so this PR will ensure we send an `M141` command (reference [here](https://marlinfw.org/docs/gcode/M141.html)) if the value is present.

Users that actually want to take advantage of this new feature will need to:

- indicate on their slicer of choice what temperature to set the chamber to.
- create a user macro in Klipper for `M141` (there is no default, so must be created for this to work)

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>