### PR TITLE
fix: edge case where containers order is incorrect

### DIFF
--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -131,7 +131,15 @@ export default class Dashboard extends Mixins(StateMixin) {
 
   @Watch('layout')
   onLayoutChange () {
-    const containers = Object.values(this.layout) as Array<LayoutConfig[]>
+    const containers: Array<LayoutConfig[]> = []
+
+    for (let index = 1; index <= 4; index++) {
+      const container = this.layout[`container${index}`]
+
+      if (container?.length > 0) {
+        containers.push(container)
+      }
+    }
 
     while (containers.length < 4) {
       containers.push([])


### PR DESCRIPTION
Fixes edge case caused by usage of `Object.values`, where containers are retrieved in non-ascending order.

This is because `Object.values` will iterate the object properties by creation order, not alphabetical, so there is the possibility that "container2" could be returned before "container1".

I've noticed that this was happening with the following repro steps:

- start with a new Moonraker database (or delete existing one)
- open Fluidd
- collapse one of the cards on the right column (for example, the temperatures one)
- refresh the page and observe (columns will be switched left and right)

This PR fixes the issue observed with the above steps.

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>