### PR TITLE
fix: delta viewbox regression

### DIFF
--- a/src/components/widgets/gcode-preview/GcodePreview.vue
+++ b/src/components/widgets/gcode-preview/GcodePreview.vue
@@ -416,6 +416,10 @@ export default class GcodePreview extends Mixins(StateMixin) {
       y
     } = this.viewBox
 
+    if (this.isDelta) {
+      return `${x.min} ${y.min} ${x.max} ${y.max}`
+    }
+
     return `${x.min} ${y.min} ${x.max - x.min} ${y.max - y.min}`
   }
 


### PR DESCRIPTION
Delta gcode preview has a bug caused by the changes on #816 

Before #816:

![image](https://user-images.githubusercontent.com/85504/183942641-f0cf2be0-2df9-4a88-b0a3-d987910b0b1d.png)

Current:

![image](https://user-images.githubusercontent.com/85504/183942531-6452629f-d5c6-43c1-b8ab-81dc04ef4305.png)

With the changes on this PR:

![image](https://user-images.githubusercontent.com/85504/183942359-309493df-75a1-4cc4-a78a-f32978ef5c1e.png)


Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>