### PR TITLE
chore: mark all @Props as readonly

### DIFF
--- a/src/components/common/AddInstanceDialog.vue
+++ b/src/components/common/AddInstanceDialog.vue
@@ -106,7 +106,7 @@ import consola from 'consola'
 @Component({})
 export default class AddInstanceDialog extends Mixins(StateMixin) {
   @Prop({ type: Boolean, required: true })
-  public value!: boolean
+  readonly value!: boolean
 
   @Ref('form')
   readonly form!: VForm

--- a/src/components/common/BedScrewsAdjustDialog.vue
+++ b/src/components/common/BedScrewsAdjustDialog.vue
@@ -107,7 +107,7 @@ import { startCase } from 'lodash-es'
 @Component({})
 export default class BedScrewsAdjustDialog extends Mixins(StateMixin, ToolheadMixin) {
   @Prop({ type: Boolean, default: false })
-  public value!: boolean
+  readonly value!: boolean
 
   get bedScrews () {
     return this.$store.getters['printer/getBedScrews']

--- a/src/components/common/CollapsableCard.vue
+++ b/src/components/common/CollapsableCard.vue
@@ -109,19 +109,19 @@ export default class CollapsableCard extends Vue {
    * Title
    */
   @Prop({ type: String, required: true })
-  public title!: string
+  readonly title!: string
 
   /**
    * Card color.
    */
   @Prop({ type: String })
-  public color!: string
+  readonly color!: string
 
   /**
    * Sub title.
    */
   @Prop({ type: String, required: false })
-  public subTitle!: string
+  readonly subTitle!: string
 
   /**
    * Required to bind to a layout.
@@ -132,7 +132,7 @@ export default class CollapsableCard extends Vue {
    * duplicate id's across containers for any given layout.
    */
   @Prop({ type: String })
-  public layoutPath!: string
+  readonly layoutPath!: string
 
   /**
    * If lazy, we use a v-show for card display.
@@ -143,69 +143,69 @@ export default class CollapsableCard extends Vue {
    * visible.
    */
   @Prop({ type: Boolean, default: true })
-  public lazy!: boolean
+  readonly lazy!: boolean
 
   /**
    * The icon to use in the title.
    */
   @Prop({ type: String, required: false })
-  public icon!: string
+  readonly icon!: string
 
   /**
    * The icon color to use in the title.
    */
   @Prop({ type: String, required: false })
-  public iconColor!: string
+  readonly iconColor!: string
 
   /**
    * Loading state.
    */
   @Prop({ type: Boolean, default: false })
-  public loading!: boolean
+  readonly loading!: boolean
 
   /**
    * Enables dragging of the card. Also causes the card
    * to react to layoutMode state.
    */
   @Prop({ type: Boolean, default: false })
-  public draggable!: boolean
+  readonly draggable!: boolean
 
   /**
    * Whether this card is collapsable or not.
    */
   @Prop({ type: Boolean, default: true })
-  public collapsable!: boolean
+  readonly collapsable!: boolean
 
   /**
    * Rounded
    */
   @Prop({ type: String, default: 'md' })
-  public rounded!: string
+  readonly rounded!: string
 
   /**
    * Optionally set a defined height.
    */
   @Prop({ type: [Number, String], required: false })
-  public height!: number | string
+  readonly height!: number | string
 
   /**
    * Breakpoint at which to condense the menu buttons to a hamburger.
    * xs, sm, md, lg, xl.
    */
   @Prop({ type: String, default: 'lg' })
-  public menuBreakpoint!: string
+  readonly menuBreakpoint!: string
 
   /**
    * Define any optional classes for the card itself.
    */
   @Prop({ type: String })
-  public cardClasses!: string
+  readonly cardClasses!: string
 
   /**
    * Define any optional classes for the card content itself.
    */
   @Prop({ type: String })
-  public contentClasses!: string
+  readonly contentClasses!: string
 
   /**
    * Base classes.

--- a/src/components/common/FlashMessage.vue
+++ b/src/components/common/FlashMessage.vue
@@ -29,16 +29,16 @@ import { Component, Prop } from 'vue-property-decorator'
 @Component({})
 export default class FlashMessage extends Vue {
   @Prop({ type: Boolean })
-  public value!: boolean
+  readonly value!: boolean
 
   @Prop({ type: String, default: 'dark' })
-  public type!: string
+  readonly type!: string
 
   @Prop({ type: String, default: 'Saved!' })
-  public text!: string
+  readonly text!: string
 
   @Prop({ type: Number, default: 1500 })
-  public timeout!: number
+  readonly timeout!: number
 
   get open () {
     return this.$props.value

--- a/src/components/common/ManualProbeDialog.vue
+++ b/src/components/common/ManualProbeDialog.vue
@@ -166,7 +166,7 @@ import ToolheadMixin from '@/mixins/toolhead'
 @Component({})
 export default class ManualProbeDialog extends Mixins(StateMixin, ToolheadMixin) {
   @Prop({ type: Boolean, default: false })
-  public value!: boolean
+  readonly value!: boolean
 
   get offsets () {
     return [

--- a/src/components/layout/AppNavDrawer.vue
+++ b/src/components/layout/AppNavDrawer.vue
@@ -115,7 +115,7 @@ import StateMixin from '@/mixins/state'
 @Component({})
 export default class AppNavDrawer extends Mixins(StateMixin) {
   @Prop({ type: Boolean, default: true })
-  public value!: boolean
+  readonly value!: boolean
 
   get theme () {
     return this.$store.getters['config/getTheme']

--- a/src/components/layout/AppSaveConfigAndRestartBtn.vue
+++ b/src/components/layout/AppSaveConfigAndRestartBtn.vue
@@ -42,10 +42,10 @@ import { Component, Prop, Vue } from 'vue-property-decorator'
 @Component({})
 export default class AppSaveConfigAndRestartBtn extends Vue {
   @Prop({ type: Boolean, default: false })
-  public disabled!: boolean
+  readonly disabled!: boolean
 
   @Prop({ type: Boolean, default: false })
-  public loading!: boolean
+  readonly loading!: boolean
 
   get isExpanded () {
     return this.$vuetify.breakpoint.mdAndUp

--- a/src/components/layout/AppToolsDrawer.vue
+++ b/src/components/layout/AppToolsDrawer.vue
@@ -35,7 +35,7 @@ import StateMixin from '@/mixins/state'
 @Component({})
 export default class AppToolsDrawer extends Mixins(StateMixin) {
   @Prop({ type: Boolean, default: false })
-  public value!: boolean
+  readonly value!: boolean
 
   get supportsHistory () {
     return this.$store.getters['server/componentSupport']('history')

--- a/src/components/settings/PendingChangesDialog.vue
+++ b/src/components/settings/PendingChangesDialog.vue
@@ -52,7 +52,7 @@ import { Component, Vue, Prop } from 'vue-property-decorator'
 @Component({})
 export default class PendingChangesDialog extends Vue {
   @Prop({ type: Boolean, required: true })
-  public value!: boolean
+  readonly value!: boolean
 
   get saveConfigPendingItems () {
     const saveConfigPendingItems = this.$store.getters['printer/getSaveConfigPendingItems']

--- a/src/components/settings/VersionInformationDialog.vue
+++ b/src/components/settings/VersionInformationDialog.vue
@@ -121,10 +121,10 @@ import { Component, Vue, Prop } from 'vue-property-decorator'
 @Component({})
 export default class VersionInformationDialog extends Vue {
   @Prop({ type: Boolean, required: true })
-  public value!: boolean
+  readonly value!: boolean
 
   @Prop({ type: Object })
-  public component!: HashVersion | ArtifactVersion | OSPackage
+  readonly component!: HashVersion | ArtifactVersion | OSPackage
 
   // For HashVersions or ArtifacVersions, show the commit history.
   // For type system, show the packages available to update.

--- a/src/components/settings/VersionStatus.vue
+++ b/src/components/settings/VersionStatus.vue
@@ -77,18 +77,18 @@ import { Component, Prop } from 'vue-property-decorator'
 @Component({})
 export default class VersionStatus extends Vue {
   @Prop({ type: Boolean, default: false })
-  public hasUpdate!: boolean
+  readonly hasUpdate!: boolean
 
   @Prop({ type: Boolean, default: false })
-  public disabled!: boolean
+  readonly disabled!: boolean
 
   @Prop({ type: Boolean, default: false })
-  public loading!: boolean
+  readonly loading!: boolean
 
   @Prop({ type: Boolean, default: false })
-  public dirty!: boolean
+  readonly dirty!: boolean
 
   @Prop({ type: Boolean, default: true })
-  public valid!: boolean
+  readonly valid!: boolean
 }
 </script>

--- a/src/components/settings/auth/ApiKeyDialog.vue
+++ b/src/components/settings/auth/ApiKeyDialog.vue
@@ -73,7 +73,7 @@ import { Component, Vue, Prop } from 'vue-property-decorator'
 @Component({})
 export default class ApiKeyDialog extends Vue {
   @Prop({ type: Boolean, required: true })
-  public value!: boolean
+  readonly value!: boolean
 
   get apiKey () {
     return this.$store.getters['auth/getApiKey']

--- a/src/components/settings/auth/UserConfigDialog.vue
+++ b/src/components/settings/auth/UserConfigDialog.vue
@@ -75,10 +75,10 @@ import { AppUser } from '@/store/auth/types'
 @Component({})
 export default class UserConfigDialog extends Vue {
   @Prop({ type: Boolean, required: true })
-  public value!: boolean
+  readonly value!: boolean
 
   @Prop({ type: Object, required: true })
-  public user!: AppUser
+  readonly user!: AppUser
 
   valid = false
 

--- a/src/components/settings/auth/UserPasswordDialog.vue
+++ b/src/components/settings/auth/UserPasswordDialog.vue
@@ -103,7 +103,7 @@ import { VForm } from '@/types'
 @Component({})
 export default class UserPasswordDialog extends Vue {
   @Prop({ type: Boolean, default: false })
-  public value!: boolean
+  readonly value!: boolean
 
   @Ref('form')
   readonly form!: VForm

--- a/src/components/settings/cameras/CameraConfigDialog.vue
+++ b/src/components/settings/cameras/CameraConfigDialog.vue
@@ -199,10 +199,10 @@ import { CameraConfig } from '@/store/cameras/types'
 @Component({})
 export default class CameraConfigDialog extends Vue {
   @Prop({ type: Boolean, required: true })
-  public value!: boolean
+  readonly value!: boolean
 
   @Prop({ type: Object, required: true })
-  public camera!: CameraConfig
+  readonly camera!: CameraConfig
 
   cameraUrlRules = [
     (v: string) => !!v || 'Required'

--- a/src/components/settings/console/ConsoleFilterDialog.vue
+++ b/src/components/settings/console/ConsoleFilterDialog.vue
@@ -107,13 +107,13 @@ import { ConsoleFilter, ConsoleFilterType } from '@/store/console/types'
 @Component({})
 export default class ConsoleFilterDialog extends Vue {
   @Prop({ type: Boolean, required: true })
-  public value!: boolean
+  readonly value!: boolean
 
   @Prop({ type: Object, required: true })
-  public rules!: any
+  readonly rules!: any
 
   @Prop({ type: Object, required: true })
-  public filter!: ConsoleFilter
+  readonly filter!: ConsoleFilter
 
   valid = true
 

--- a/src/components/settings/macros/MacroCategoryDialog.vue
+++ b/src/components/settings/macros/MacroCategoryDialog.vue
@@ -57,19 +57,19 @@ import { Component, Vue, Prop } from 'vue-property-decorator'
 @Component({})
 export default class MacroCategoryDialog extends Vue {
   @Prop({ type: Boolean, required: true })
-  public value!: boolean
+  readonly value!: boolean
 
   @Prop({ type: String, required: true })
-  public title!: string
+  readonly title!: string
 
   @Prop({ type: String, required: true })
-  public label!: string
+  readonly label!: string
 
   @Prop({ type: Array, required: false })
-  public rules!: []
+  readonly rules!: []
 
   @Prop({ type: String, required: true })
-  public name!: string
+  readonly name!: string
 
   newName = ''
   valid = true

--- a/src/components/settings/macros/MacroSettingsDialog.vue
+++ b/src/components/settings/macros/MacroSettingsDialog.vue
@@ -145,10 +145,10 @@ import { Component, Vue, Prop, Watch } from 'vue-property-decorator'
 @Component({})
 export default class MacroMoveDialog extends Vue {
   @Prop({ type: Boolean, required: true })
-  public value!: boolean
+  readonly value!: boolean
 
   @Prop({ type: Object, required: true })
-  public macro!: Macro
+  readonly macro!: Macro
 
   assign = null
   valid = false

--- a/src/components/settings/presets/PresetDialog.vue
+++ b/src/components/settings/presets/PresetDialog.vue
@@ -122,10 +122,10 @@ import { Fan, Heater } from '@/store/printer/types'
 @Component({})
 export default class TemperaturePresetDialog extends Vue {
   @Prop({ type: Boolean, required: true })
-  public value!: boolean
+  readonly value!: boolean
 
   @Prop({ type: Object, required: true })
-  public preset!: TemperaturePreset
+  readonly preset!: TemperaturePreset
 
   valid = false
 

--- a/src/components/ui/AppBtnCollapse.vue
+++ b/src/components/ui/AppBtnCollapse.vue
@@ -41,13 +41,13 @@ import { Component, Vue, Prop } from 'vue-property-decorator'
 @Component({})
 export default class AppBtnCollapse extends Vue {
   @Prop({ type: Boolean, default: false })
-  public collapsed!: boolean
+  readonly collapsed!: boolean
 
   @Prop({ type: Boolean, default: true })
-  public enabled!: boolean
+  readonly enabled!: boolean
 
   @Prop({ type: Boolean, default: false })
-  public inLayout!: boolean
+  readonly inLayout!: boolean
 
   // emitChange (value: boolean) {
   //   this.$emit('input', value)

--- a/src/components/ui/AppBtnCollapseGroup.vue
+++ b/src/components/ui/AppBtnCollapseGroup.vue
@@ -43,10 +43,10 @@ import { Component, Vue, Prop } from 'vue-property-decorator'
 @Component({})
 export default class AppBtnCollapseGroup extends Vue {
   @Prop({ type: Boolean, default: false })
-  public collapsed!: boolean
+  readonly collapsed!: boolean
 
   @Prop({ type: String, default: '$menu' })
-  public menuIcon!: string
+  readonly menuIcon!: string
 
   get isCollapsed () {
     if (this.collapsed) return true

--- a/src/components/ui/AppBtnGroup.vue
+++ b/src/components/ui/AppBtnGroup.vue
@@ -15,7 +15,7 @@ import { Component, Vue, Prop } from 'vue-property-decorator'
 @Component({})
 export default class AppBtnGroup extends Vue {
   @Prop({ type: Boolean, default: false })
-  public vertical!: boolean
+  readonly vertical!: boolean
 }
 </script>
 

--- a/src/components/ui/AppBtnToolheadMove.vue
+++ b/src/components/ui/AppBtnToolheadMove.vue
@@ -33,25 +33,25 @@ import { Component, Vue, Prop } from 'vue-property-decorator'
 @Component({})
 export default class AppBtnToolheadMove extends Vue {
   @Prop({ type: String, required: true })
-  public icon!: string
+  readonly icon!: string
 
   @Prop()
-  public disabled!: boolean
+  readonly disabled!: boolean
 
   @Prop({ type: String, default: 'btncolor' })
-  public color!: string
+  readonly color!: string
 
   @Prop({ type: Boolean, default: false })
-  public loading!: boolean
+  readonly loading!: boolean
 
   @Prop({ type: String, default: '' })
-  public badge!: string
+  readonly badge!: string
 
   @Prop({ type: String, default: '' })
-  public tooltip!: string
+  readonly tooltip!: string
 
   @Prop({ type: Boolean, default: false })
-  public smallIcon!: boolean
+  readonly smallIcon!: boolean
 
   get hasDefaultSlot () {
     return !!this.$slots.default || !!this.$scopedSlots.default

--- a/src/components/ui/AppChart.vue
+++ b/src/components/ui/AppChart.vue
@@ -26,16 +26,16 @@ import { merge } from 'lodash-es'
 @Component({})
 export default class AppChart extends Vue {
   @Prop({ type: Array, required: true })
-  public data!: any
+  readonly data!: any
 
   @Prop({ type: Object, default: {} })
-  public options!: any
+  readonly options!: any
 
   @Prop({ type: String, default: '100%' })
-  public height!: string
+  readonly height!: string
 
   @Prop({ type: Array, default: () => [] })
-  public events!: any
+  readonly events!: any
 
   @Ref('chart')
   readonly chart!: ECharts

--- a/src/components/ui/AppCodeView.vue
+++ b/src/components/ui/AppCodeView.vue
@@ -46,7 +46,7 @@ import { Component, Vue, Prop } from 'vue-property-decorator'
 })
 export default class AppCodeView extends Vue {
   @Prop({ type: String, required: true })
-  public value!: string
+  readonly value!: string
 
   copied = false
 

--- a/src/components/ui/AppColorPicker.vue
+++ b/src/components/ui/AppColorPicker.vue
@@ -155,19 +155,19 @@ interface PointerPosition {
 export default class AppColorPicker extends Vue {
   // Expected color input. Can be a hex, rgbw etc.
   @Prop({ type: String, required: true })
-  public primary!: string
+  readonly primary!: string
 
   @Prop({ type: String, required: false })
-  public white!: string
+  readonly white!: string
 
   @Prop({ type: String, default: '' })
-  public title!: string
+  readonly title!: string
 
   @Prop({ type: Boolean, default: false })
-  public dot!: boolean
+  readonly dot!: boolean
 
   @Prop({ type: String, default: 'RGB' })
-  public supportedChannels!: string
+  readonly supportedChannels!: string
 
   menu = false
 

--- a/src/components/ui/AppColumnPicker.vue
+++ b/src/components/ui/AppColumnPicker.vue
@@ -60,13 +60,13 @@ import { AppTableHeader } from '@/types'
 @Component({})
 export default class AppColumnPicker extends Mixins(StateMixin) {
   @Prop({ type: String, required: true })
-  public keyName!: string
+  readonly keyName!: string
 
   @Prop({ type: Array, required: true })
-  public headers!: AppTableHeader[]
+  readonly headers!: AppTableHeader[]
 
   @Prop({ type: Boolean, default: false })
-  public disabled!: boolean
+  readonly disabled!: boolean
 
   value: any[] = []
 

--- a/src/components/ui/AppInlineHelp.vue
+++ b/src/components/ui/AppInlineHelp.vue
@@ -33,24 +33,24 @@ import { Component, Vue, Prop } from 'vue-property-decorator'
 @Component({})
 export default class AppInlineHelp extends Vue {
   @Prop({ type: String, required: false })
-  public tooltip!: string
+  readonly tooltip!: string
 
   @Prop({ type: String, default: 'primary' })
-  public type!: string
+  readonly type!: string
 
   @Prop({ type: Boolean, default: false })
-  public top!: boolean
+  readonly top!: boolean
 
   @Prop({ type: Boolean, default: false })
-  public bottom!: boolean
+  readonly bottom!: boolean
 
   @Prop({ type: Boolean, default: false })
-  public left!: boolean
+  readonly left!: boolean
 
   @Prop({ type: Boolean, default: false })
-  public right!: boolean
+  readonly right!: boolean
 
   @Prop({ type: Boolean, default: false })
-  public small!: boolean
+  readonly small!: boolean
 }
 </script>

--- a/src/components/ui/AppIroColorPicker.vue
+++ b/src/components/ui/AppIroColorPicker.vue
@@ -56,10 +56,10 @@ import { ColorPickerProps, IroColorPicker } from '@jaames/iro/dist/ColorPicker'
 })
 export default class AppColorPicker extends Vue {
   @Prop({ type: [Object, String], default: '#ffffff' })
-  public color!: IroColor
+  readonly color!: IroColor
 
   @Prop({ type: Object, default: () => ({}) })
-  public options!: ColorPickerProps
+  readonly options!: ColorPickerProps
 
   @Ref('picker')
   readonly picker!: HTMLElement

--- a/src/components/ui/AppMacroBtn.vue
+++ b/src/components/ui/AppMacroBtn.vue
@@ -97,10 +97,10 @@ import gcodeMacroParams from '@/util/gcode-macro-params'
 @Component({})
 export default class AppMacroBtn extends Mixins(StateMixin) {
   @Prop({ type: Object, required: true })
-  public macro!: Macro
+  readonly macro!: Macro
 
   @Prop({ type: Boolean, default: false })
-  public enableParams!: boolean
+  readonly enableParams!: boolean
 
   params: { [index: string]: { value: string | number; reset: string | number }} = {}
 

--- a/src/components/ui/AppNamedInput.vue
+++ b/src/components/ui/AppNamedInput.vue
@@ -55,28 +55,28 @@ import StateMixin from '@/mixins/state'
 @Component({})
 export default class AppNamedInput extends Mixins(StateMixin) {
   @Prop({ type: [String, Number], required: true })
-  public value!: string | number
+  readonly value!: string | number
 
   @Prop({ type: String, required: true })
-  public label!: string
+  readonly label!: string
 
   @Prop({ type: [String, Number], required: false })
-  public resetValue!: string | number
+  readonly resetValue!: string | number
 
   @Prop({ type: Boolean, default: false })
-  public readonly!: boolean
+  readonly readonly!: boolean
 
   @Prop({ type: Boolean, default: false })
-  public disabled!: boolean
+  readonly disabled!: boolean
 
   @Prop({ type: Boolean, default: false })
-  public loading!: boolean
+  readonly loading!: boolean
 
   @Prop({ type: String })
-  public suffix!: string
+  readonly suffix!: string
 
   @Prop({ type: Array, default: () => { return [] } })
-  public rules!: []
+  readonly rules!: []
 
   handleChange (value: string | number) {
     if (this.value !== value) this.$emit('change', value)

--- a/src/components/ui/AppNavItem.vue
+++ b/src/components/ui/AppNavItem.vue
@@ -55,16 +55,16 @@ import StateMixin from '@/mixins/state'
 @Component({})
 export default class AppNavItem extends Mixins(StateMixin) {
   @Prop({ type: String })
-  public title!: string
+  readonly title!: string
 
   @Prop({ type: String })
-  public to!: string
+  readonly to!: string
 
   @Prop({ type: Boolean, default: false })
-  public exact!: boolean
+  readonly exact!: boolean
 
   @Prop({ type: String })
-  public icon!: string
+  readonly icon!: string
 
   get isMobile () {
     return this.$vuetify.breakpoint.mobile

--- a/src/components/ui/AppQrCode.vue
+++ b/src/components/ui/AppQrCode.vue
@@ -17,10 +17,10 @@ import QrcodeVue from 'qrcode.vue'
 })
 export default class AppQrCode extends Vue {
   @Prop({ type: String, default: '' })
-  public value!: string
+  readonly value!: string
 
   @Prop({ type: Number, default: 260 })
-  public size!: number
+  readonly size!: number
 }
 </script>
 

--- a/src/components/ui/AppSetting.vue
+++ b/src/components/ui/AppSetting.vue
@@ -44,19 +44,19 @@ import { Component, Vue, Prop } from 'vue-property-decorator'
 @Component({})
 export default class AppSetting extends Vue {
   @Prop({ type: String, default: '' })
-  public title!: string
+  readonly title!: string
 
   @Prop({ type: String })
-  public subTitle!: string
+  readonly subTitle!: string
 
   @Prop({ type: String })
-  public help!: string
+  readonly help!: string
 
   @Prop({ type: String })
-  public accentColor!: string
+  readonly accentColor!: string
 
   @Prop({ type: Number, default: 6 })
-  public rCols!: number
+  readonly rCols!: number
 
   get cols () {
     return [12 - this.rCols, this.rCols]

--- a/src/components/ui/AppSlider.vue
+++ b/src/components/ui/AppSlider.vue
@@ -99,43 +99,43 @@ import StateMixin from '@/mixins/state'
 @Component({})
 export default class AppSlider extends Mixins(StateMixin) {
   @Prop({ type: Number, required: true })
-  public value!: number
+  readonly value!: number
 
   @Prop({ type: Number, required: false })
-  public resetValue!: number
+  readonly resetValue!: number
 
   @Prop({ type: String, required: true })
-  public label!: string
+  readonly label!: string
 
   @Prop({ type: Array, default: () => { return [] } })
-  public rules!: []
+  readonly rules!: []
 
   @Prop({ type: Boolean, default: false })
-  public disabled!: boolean
+  readonly disabled!: boolean
 
   @Prop({ type: Boolean, default: false })
-  public locked!: boolean
+  readonly locked!: boolean
 
   @Prop({ type: Boolean, default: false })
-  public loading!: boolean
+  readonly loading!: boolean
 
   @Prop({ type: Number, default: 0 })
-  public min!: number
+  readonly min!: number
 
   @Prop({ type: Number, default: 100 })
-  public max!: number
+  readonly max!: number
 
   @Prop({ type: Boolean, default: false })
-  public overridable!: boolean
+  readonly overridable!: boolean
 
   @Prop({ type: Number, default: 1 })
-  public step!: number
+  readonly step!: number
 
   @Prop({ type: String })
-  public suffix!: string
+  readonly suffix!: string
 
   @Prop({ type: Boolean, default: false })
-  public fullWidth!: boolean
+  readonly fullWidth!: boolean
 
   valid = true
   lockState = false

--- a/src/components/ui/AppSwitch.vue
+++ b/src/components/ui/AppSwitch.vue
@@ -26,13 +26,13 @@ import StateMixin from '@/mixins/state'
 @Component({})
 export default class AppSwitch extends Mixins(StateMixin) {
   @Prop({ type: Boolean, required: true })
-  public value!: boolean
+  readonly value!: boolean
 
   @Prop({ type: String, required: true })
-  public label!: string
+  readonly label!: string
 
   @Prop({ type: Boolean, required: false, default: false })
-  public disabled!: boolean
+  readonly disabled!: boolean
 
   @Watch('value')
   onValueChange (val: boolean) {

--- a/src/components/widgets/bedmesh/BedMeshCard.vue
+++ b/src/components/widgets/bedmesh/BedMeshCard.vue
@@ -49,7 +49,7 @@ import ToolheadMixin from '@/mixins/toolhead'
 })
 export default class BedMeshCard extends Mixins(StateMixin, ToolheadMixin) {
   @Prop({ type: Boolean, default: false })
-  public fullScreen!: boolean
+  readonly fullScreen!: boolean
 
   get options () {
     const map_scale = this.scale / 2

--- a/src/components/widgets/bedmesh/BedMeshChart.vue
+++ b/src/components/widgets/bedmesh/BedMeshChart.vue
@@ -25,13 +25,13 @@ import { merge } from 'lodash-es'
 @Component({})
 export default class EChartsBedMesh extends Vue {
   @Prop({ type: Array, required: true, default: {} })
-  public data!: []
+  readonly data!: []
 
   @Prop({ type: Object, default: {} })
-  public options!: any
+  readonly options!: any
 
   @Prop({ type: String, default: '100%' })
-  public height!: string
+  readonly height!: string
 
   @Ref('chart')
   readonly chart!: ECharts

--- a/src/components/widgets/bedmesh/SaveMeshDialog.vue
+++ b/src/components/widgets/bedmesh/SaveMeshDialog.vue
@@ -73,10 +73,10 @@ import ToolheadMixin from '@/mixins/toolhead'
 @Component({})
 export default class SaveMeshDialog extends Mixins(StateMixin, ToolheadMixin) {
   @Prop({ type: Boolean, default: false })
-  public value!: string
+  readonly value!: string
 
   @Prop({ type: String })
-  public existingName!: string
+  readonly existingName!: string
 
   mounted () {
     this.name = 'default'

--- a/src/components/widgets/camera/CameraCard.vue
+++ b/src/components/widgets/camera/CameraCard.vue
@@ -54,7 +54,7 @@ import StateMixin from '@/mixins/state'
 })
 export default class CameraCard extends Mixins(StateMixin) {
   @Prop({ type: Boolean, default: true })
-  public enabled!: boolean
+  readonly enabled!: boolean
 
   dialogState: any = {
     open: false,

--- a/src/components/widgets/camera/CameraDialog.vue
+++ b/src/components/widgets/camera/CameraDialog.vue
@@ -22,10 +22,10 @@ import { CameraConfig } from '@/store/cameras/types'
 })
 export default class CameraDialog extends Vue {
   @Prop({ type: Boolean, required: true })
-  public value!: boolean
+  readonly value!: boolean
 
   @Prop({ type: Object, required: true })
-  public camera!: CameraConfig
+  readonly camera!: CameraConfig
 }
 </script>
 

--- a/src/components/widgets/camera/CameraItem.vue
+++ b/src/components/widgets/camera/CameraItem.vue
@@ -68,10 +68,10 @@ import { CameraFullscreenAction } from '@/store/config/types'
 @Component({})
 export default class CameraItem extends Vue {
   @Prop({ type: Object, required: true })
-  public camera!: CameraConfig
+  readonly camera!: CameraConfig
 
   @Prop({ type: Boolean, required: false, default: false })
-  public fullscreen!: boolean
+  readonly fullscreen!: boolean
 
   @Ref('camera_image')
   readonly cameraImage!: HTMLElement

--- a/src/components/widgets/console/Console.vue
+++ b/src/components/widgets/console/Console.vue
@@ -66,16 +66,16 @@ import { DinamicScroller } from 'vue-virtual-scroller'
 })
 export default class Console extends Mixins(StateMixin) {
   @Prop({ type: Array, default: [] })
-  public items!: []
+  readonly items!: []
 
   @Prop({ type: String, default: 'id' })
-  public keyField!: string
+  readonly keyField!: string
 
   @Prop({ type: Number, default: 250 })
-  public height!: number
+  readonly height!: number
 
   @Prop({ type: Boolean, default: false })
-  public readonly!: boolean
+  readonly readonly!: boolean
 
   @Ref('scroller')
   readonly dynamicScroller!: DinamicScroller

--- a/src/components/widgets/console/ConsoleCard.vue
+++ b/src/components/widgets/console/ConsoleCard.vue
@@ -136,10 +136,10 @@ export default class ConsoleCard extends Mixins(StateMixin) {
   }
 
   @Prop({ type: Boolean, default: true })
-  public enabled!: boolean
+  readonly enabled!: boolean
 
   @Prop({ type: Boolean, default: false })
-  public fullScreen!: boolean
+  readonly fullScreen!: boolean
 
   @Ref('console')
   readonly console!: Console

--- a/src/components/widgets/console/ConsoleCommand.vue
+++ b/src/components/widgets/console/ConsoleCommand.vue
@@ -45,13 +45,13 @@ import { VInput } from '@/types'
 @Component({})
 export default class ConsoleCommand extends Vue {
   @Prop({ type: String })
-  public value!: string
+  readonly value!: string
 
   @Ref('input')
   readonly input!: VInput
 
   @Prop({ type: Boolean, default: false })
-  public disabled!: boolean
+  readonly disabled!: boolean
 
   @Watch('value')
   onValueChange (val: string) {

--- a/src/components/widgets/console/ConsoleItem.vue
+++ b/src/components/widgets/console/ConsoleItem.vue
@@ -22,7 +22,7 @@ import { ConsoleEntry } from '@/store/console/types'
 @Component({})
 export default class ConsoleItem extends Vue {
   @Prop({ type: Object, default: {} })
-  public value!: ConsoleEntry
+  readonly value!: ConsoleEntry
 
   get knownCommands () {
     const availableCommands = this.$store.getters['console/getAllGcodeCommands']

--- a/src/components/widgets/exclude-objects/ExcludeObjectsDialog.vue
+++ b/src/components/widgets/exclude-objects/ExcludeObjectsDialog.vue
@@ -64,7 +64,7 @@ import StateMixin from '@/mixins/state'
 @Component({})
 export default class ExcludeObjectDialog extends Mixins(StateMixin) {
   @Prop({ type: Boolean, default: false })
-  public value!: boolean
+  readonly value!: boolean
 
   get parts () {
     return this.$store.getters['parts/getParts']

--- a/src/components/widgets/filesystem/FileEditor.vue
+++ b/src/components/widgets/filesystem/FileEditor.vue
@@ -23,16 +23,16 @@ let monaco: typeof Monaco // dynamically imported
 @Component({})
 export default class FileEditor extends Vue {
   @Prop({ type: String, required: true })
-  public value!: string
+  readonly value!: string
 
   @Prop({ type: String, required: true })
-  public filename!: string
+  readonly filename!: string
 
   @Prop({ type: Boolean, default: false })
-  public readonly!: boolean
+  readonly readonly!: boolean
 
   @Prop({ type: Boolean, default: true })
-  public codeLens!: boolean
+  readonly codeLens!: boolean
 
   @Ref('monaco-editor')
   readonly monacoEditor!: HTMLElement

--- a/src/components/widgets/filesystem/FileEditorDialog.vue
+++ b/src/components/widgets/filesystem/FileEditorDialog.vue
@@ -132,22 +132,22 @@ import isMobile from '@/util/is-mobile'
 })
 export default class FileEditorDialog extends Mixins(StateMixin) {
   @Prop({ type: Boolean, required: true })
-  public value!: boolean
+  readonly value!: boolean
 
   @Prop({ type: String, required: true })
-  public root!: string
+  readonly root!: string
 
   @Prop({ type: String, required: true })
-  public filename!: string
+  readonly filename!: string
 
   @Prop({ type: String, required: true })
-  public contents!: string
+  readonly contents!: string
 
   @Prop({ type: Boolean, default: false })
-  public loading!: boolean
+  readonly loading!: boolean
 
   @Prop({ type: Boolean, default: false })
-  public readonly!: boolean
+  readonly readonly!: boolean
 
   @Ref('editor')
   readonly editor?: FileEditor

--- a/src/components/widgets/filesystem/FileEditorTextOnly.vue
+++ b/src/components/widgets/filesystem/FileEditorTextOnly.vue
@@ -15,10 +15,10 @@ import { Vue, Component, Prop } from 'vue-property-decorator'
 @Component({})
 export default class FileEditorText extends Vue {
   @Prop({ type: String, required: true })
-  public value!: string
+  readonly value!: string
 
   @Prop({ type: Boolean, default: false })
-  public readonly!: boolean
+  readonly readonly!: boolean
 
   emitChange (value: string | undefined) {
     this.$emit('change', value)

--- a/src/components/widgets/filesystem/FileNameDialog.vue
+++ b/src/components/widgets/filesystem/FileNameDialog.vue
@@ -57,19 +57,19 @@ import StateMixin from '@/mixins/state'
 @Component({})
 export default class FileNameDialog extends Mixins(StateMixin) {
   @Prop({ type: Boolean, required: true })
-  public value!: boolean
+  readonly value!: boolean
 
   @Prop({ type: String, required: true })
-  public title!: string
+  readonly title!: string
 
   @Prop({ type: String, required: true })
-  public label!: string
+  readonly label!: string
 
   @Prop({ type: Array, required: false })
-  public rules!: []
+  readonly rules!: []
 
   @Prop({ type: String, required: true })
-  public name!: string
+  readonly name!: string
 
   newName = ''
   valid = false

--- a/src/components/widgets/filesystem/FilePreviewDialog.vue
+++ b/src/components/widgets/filesystem/FilePreviewDialog.vue
@@ -74,16 +74,16 @@ import { FilePreviewState } from '@/store/files/types'
 @Component({})
 export default class FilePreviewDialog extends Mixins(StateMixin) {
   @Prop({ type: Boolean, default: false })
-  public value!: boolean
+  readonly value!: boolean
 
   @Prop({ type: Object })
-  public file?: FilePreviewState
+  readonly file?: FilePreviewState
 
   @Prop({ type: Boolean, default: false })
-  public downloadable!: boolean
+  readonly downloadable!: boolean
 
   @Prop({ type: Boolean, default: false })
-  public removable!: boolean
+  readonly removable!: boolean
 
   get icon () {
     if (this.isVideo) {

--- a/src/components/widgets/filesystem/FileRowItem.vue
+++ b/src/components/widgets/filesystem/FileRowItem.vue
@@ -16,22 +16,22 @@ import { Component, Vue, Prop } from 'vue-property-decorator'
 @Component({})
 export default class FileRowItem extends Vue {
   @Prop({ type: String, required: false })
-  public itemValue!: string
+  readonly itemValue!: string
 
   /**
    * Optionally pass a key to define how we lookup this header item.
    */
   @Prop({ type: String, required: false })
-  public itemKey!: string
+  readonly itemKey!: string
 
   @Prop({ type: Array, required: false })
-  public headers!: AppTableHeader[]
+  readonly headers!: AppTableHeader[]
 
   @Prop({ type: Boolean, default: true })
-  public nowrap!: boolean
+  readonly nowrap!: boolean
 
   @Prop({ type: Boolean, default: false })
-  public right!: boolean
+  readonly right!: boolean
 
   /**
    * Self check if it should appear or not based on the headers

--- a/src/components/widgets/filesystem/FileSystem.vue
+++ b/src/components/widgets/filesystem/FileSystem.vue
@@ -178,30 +178,30 @@ import { AppTableHeader } from '@/types'
 export default class FileSystem extends Mixins(StateMixin, FilesMixin, ServicesMixin) {
   // Can be a list of roots, or a single root.
   @Prop({ type: [String, Array], required: true })
-  public roots!: string | string[]
+  readonly roots!: string | string[]
 
   @Prop({ type: String, required: false })
-  public name!: string
+  readonly name!: string
 
   // If dense, hide the meta and reduce the overall size.
   @Prop({ type: Boolean, default: false })
-  public dense!: boolean
+  readonly dense!: boolean
 
   // Constrain height
   @Prop({ type: [Number, String] })
-  public height!: number | string
+  readonly height!: number | string
 
   // Constrain height
   @Prop({ type: [Number, String] })
-  public maxHeight!: number | string
+  readonly maxHeight!: number | string
 
   // Allow bulk-actions
   @Prop({ type: Boolean, default: false })
-  public bulkActions!: boolean
+  readonly bulkActions!: boolean
 
   // Override behavior (thumbnails, click/view actions) for timelapse browser
   @Prop({ type: Boolean, default: false })
-  public timelapseBrowser!: boolean
+  readonly timelapseBrowser!: boolean
 
   // Ready. True once the available roots have loaded from moonraker.
   ready = false

--- a/src/components/widgets/filesystem/FileSystemBrowser.vue
+++ b/src/components/widgets/filesystem/FileSystemBrowser.vue
@@ -260,38 +260,38 @@ import FileRowItem from './FileRowItem.vue'
 })
 export default class FileSystemBrowser extends Mixins(FilesMixin) {
   @Prop({ type: String, required: true })
-  public root!: string
+  readonly root!: string
 
   @Prop({ type: Array, required: true })
-  public files!: FileBrowserEntry[]
+  readonly files!: FileBrowserEntry[]
 
   @Prop({ type: Boolean, default: false })
-  public dense!: boolean
+  readonly dense!: boolean
 
   @Prop({ type: Boolean, default: false })
-  public loading!: boolean
+  readonly loading!: boolean
 
   // Currently defined list of headers.
   @Prop({ type: Array, required: true })
-  public headers!: AppTableHeader[]
+  readonly headers!: AppTableHeader[]
 
   @Prop({ type: String, required: false })
-  public search!: string
+  readonly search!: string
 
   @Prop({ type: Boolean, required: true })
-  public dragState!: boolean
+  readonly dragState!: boolean
 
   @Prop({ type: Boolean, default: false })
-  public disabled!: boolean
+  readonly disabled!: boolean
 
   @Prop({ type: Boolean, default: false })
-  public bulkActions!: boolean
+  readonly bulkActions!: boolean
 
   @Prop({ type: Boolean, default: false })
-  public largeThumbnails!: boolean
+  readonly largeThumbnails!: boolean
 
   @Prop({ type: Array, required: true })
-  public selected!: (FileBrowserEntry | AppFileWithMeta)[]
+  readonly selected!: (FileBrowserEntry | AppFileWithMeta)[]
 
   dragItem: FileBrowserEntry | AppFileWithMeta | null = null
   ghost: HTMLDivElement | undefined = undefined

--- a/src/components/widgets/filesystem/FileSystemBulkActions.vue
+++ b/src/components/widgets/filesystem/FileSystemBulkActions.vue
@@ -64,6 +64,6 @@ import FileSystemFilterMenu from './FileSystemFilterMenu.vue'
 export default class FileSystemBulkActions extends Mixins(StatesMixin) {
   // The current path
   @Prop({ type: String, required: false })
-  public path!: string
+  readonly path!: string
 }
 </script>

--- a/src/components/widgets/filesystem/FileSystemContextMenu.vue
+++ b/src/components/widgets/filesystem/FileSystemContextMenu.vue
@@ -130,19 +130,19 @@ import { AppDirectory, AppFile, AppFileWithMeta } from '@/store/files/types'
 @Component({})
 export default class FileSystemContextMenu extends Mixins(StateMixin, FilesMixin) {
   @Prop({ type: String, required: true })
-  public root!: string
+  readonly root!: string
 
   @Prop({ type: Boolean, default: false })
-  public open!: boolean
+  readonly open!: boolean
 
   @Prop({ type: Object, required: true })
-  public file!: AppDirectory | AppFile | AppFileWithMeta
+  readonly file!: AppDirectory | AppFile | AppFileWithMeta
 
   @Prop({ type: Number, required: true })
-  public positionX!: number
+  readonly positionX!: number
 
   @Prop({ type: Number, required: true })
-  public positionY!: number
+  readonly positionY!: number
 
   get rootProperties () {
     return this.$store.getters['files/getRootProperties'](this.root)

--- a/src/components/widgets/filesystem/FileSystemDownloadDialog.vue
+++ b/src/components/widgets/filesystem/FileSystemDownloadDialog.vue
@@ -63,9 +63,9 @@ import { FileDownload } from '@/store/files/types'
 @Component({})
 export default class FileSystemDownloadDialog extends Mixins(StateMixin) {
   @Prop({ type: Boolean, default: false })
-  public value!: boolean
+  readonly value!: boolean
 
   @Prop({ type: Object })
-  public file!: FileDownload
+  readonly file!: FileDownload
 }
 </script>

--- a/src/components/widgets/filesystem/FileSystemDragOverlay.vue
+++ b/src/components/widgets/filesystem/FileSystemDragOverlay.vue
@@ -34,7 +34,7 @@ import StateMixin from '@/mixins/state'
 @Component({})
 export default class FileSystemDragOverlay extends Mixins(StateMixin) {
   @Prop({ type: Boolean, default: false })
-  public value!: boolean
+  readonly value!: boolean
 }
 </script>
 

--- a/src/components/widgets/filesystem/FileSystemFilterMenu.vue
+++ b/src/components/widgets/filesystem/FileSystemFilterMenu.vue
@@ -76,10 +76,10 @@ interface FileFilter {
 @Component({})
 export default class FileSystemFilterMenu extends Vue {
   @Prop({ type: String, required: true })
-  public root!: FileRoot
+  readonly root!: FileRoot
 
   @Prop({ type: Boolean, default: false })
-  public disabled!: boolean
+  readonly disabled!: boolean
 
   availableFilters: FileFilter[] = [
     {

--- a/src/components/widgets/filesystem/FileSystemMenu.vue
+++ b/src/components/widgets/filesystem/FileSystemMenu.vue
@@ -101,11 +101,11 @@ import { Component, Vue, Prop, Ref } from 'vue-property-decorator'
 @Component({})
 export default class FileSystemMenu extends Vue {
   @Prop({ type: String, required: true })
-  public root!: string
+  readonly root!: string
 
   // If the controls are disabled or not.
   @Prop({ type: Boolean, default: false })
-  public disabled!: boolean
+  readonly disabled!: boolean
 
   @Ref('uploadFile')
   readonly uploadFile!: HTMLInputElement

--- a/src/components/widgets/filesystem/FileSystemToolbar.vue
+++ b/src/components/widgets/filesystem/FileSystemToolbar.vue
@@ -137,33 +137,33 @@ import { AppTableHeader } from '@/types'
 export default class FileSystemToolbar extends Mixins(StatesMixin) {
   // The currently active root.
   @Prop({ type: String, required: true })
-  public root!: string
+  readonly root!: string
 
   @Prop({ type: String, required: false })
-  public name!: string
+  readonly name!: string
 
   // Can be a list of roots, or a single root.
   @Prop({ type: Array, required: false })
-  public roots!: string[]
+  readonly roots!: string[]
 
   // Currently defined list of headers.
   @Prop({ type: Array, required: false })
-  public headers!: AppTableHeader[]
+  readonly headers!: AppTableHeader[]
 
   // The current path
   @Prop({ type: String, required: false })
-  public path!: string
+  readonly path!: string
 
   // If the controls are disabled or not.
   @Prop({ type: Boolean, default: false })
-  public disabled!: boolean
+  readonly disabled!: boolean
 
   // If the fs is loading or not.
   @Prop({ type: Boolean, default: false })
-  public loading!: boolean
+  readonly loading!: boolean
 
   @Prop({ type: String, default: '' })
-  public search!: string
+  readonly search!: string
 
   textSearch = ''
 

--- a/src/components/widgets/filesystem/FileSystemUploadDialog.vue
+++ b/src/components/widgets/filesystem/FileSystemUploadDialog.vue
@@ -98,9 +98,9 @@ import { FilesUpload } from '@/store/files/types'
 @Component({})
 export default class FileSystemUploadDialog extends Mixins(StateMixin) {
   @Prop({ type: Boolean, default: false })
-  public value!: boolean
+  readonly value!: boolean
 
   @Prop({ type: Array })
-  public files!: FilesUpload[]
+  readonly files!: FilesUpload[]
 }
 </script>

--- a/src/components/widgets/gcode-preview/GcodePreview.vue
+++ b/src/components/widgets/gcode-preview/GcodePreview.vue
@@ -217,19 +217,19 @@ import ExcludeObjects from '@/components/widgets/exclude-objects/ExcludeObjects.
 })
 export default class GcodePreview extends Mixins(StateMixin) {
   @Prop({ type: Boolean, default: true })
-  public disabled!: boolean
+  readonly disabled!: boolean
 
   @Prop({ type: String })
-  public width!: string
+  readonly width!: string
 
   @Prop({ type: String })
-  public height!: string
+  readonly height!: string
 
   @Prop({ type: Number, default: Infinity })
-  public progress!: number
+  readonly progress!: number
 
   @Prop({ type: Number, default: 0 })
-  public layer!: LayerNr
+  readonly layer!: LayerNr
 
   @Ref('svg')
   readonly svg!: SVGElement

--- a/src/components/widgets/gcode-preview/GcodePreviewCard.vue
+++ b/src/components/widgets/gcode-preview/GcodePreviewCard.vue
@@ -172,10 +172,10 @@ import ExcludeObjectsDialog from '@/components/widgets/exclude-objects/ExcludeOb
 })
 export default class GcodePreviewCard extends Mixins(StateMixin, FilesMixin) {
   @Prop({ type: Boolean, default: true })
-  public enabled!: boolean
+  readonly enabled!: boolean
 
   @Prop({ type: Boolean, default: false })
-  public menuCollapsed!: boolean
+  readonly menuCollapsed!: boolean
 
   currentLayer = 0
   moveProgress = 0

--- a/src/components/widgets/gcode-preview/GcodePreviewControlCheckbox.vue
+++ b/src/components/widgets/gcode-preview/GcodePreviewControlCheckbox.vue
@@ -14,13 +14,13 @@ import StateMixin from '@/mixins/state'
 @Component({})
 export default class GcodePreviewControlCheckbox extends Mixins(StateMixin) {
   @Prop({ type: String, required: true })
-  public name!: string
+  readonly name!: string
 
   @Prop({ type: String, required: true })
-  public label!: string
+  readonly label!: string
 
   @Prop({ type: Boolean, default: false })
-  public disabled!: boolean
+  readonly disabled!: boolean
 
   get property () {
     return this.$store.getters['gcodePreview/getViewerOption'](this.name)

--- a/src/components/widgets/gcode-preview/GcodePreviewControls.vue
+++ b/src/components/widgets/gcode-preview/GcodePreviewControls.vue
@@ -55,7 +55,7 @@ import FilesMixin from '@/mixins/files'
 })
 export default class GcodePreviewControls extends Mixins(StateMixin, FilesMixin) {
   @Prop({ type: Boolean, default: false })
-  public disabled!: boolean
+  readonly disabled!: boolean
 
   get canFollowProgress () {
     const file = this.$store.getters['gcodePreview/getFile']

--- a/src/components/widgets/gcode-preview/GcodePreviewParserProgressDialog.vue
+++ b/src/components/widgets/gcode-preview/GcodePreviewParserProgressDialog.vue
@@ -61,13 +61,13 @@ import { AppFile } from '@/store/files/types'
 @Component({})
 export default class GcodePreviewParserProgressDialog extends Mixins(StateMixin) {
   @Prop({ type: Boolean, default: false })
-  public value!: boolean
+  readonly value!: boolean
 
   @Prop({ type: Number })
-  public progress!: number
+  readonly progress!: number
 
   @Prop({ type: Object })
-  public file!: AppFile
+  readonly file!: AppFile
 
   get percent () {
     return Math.floor((this.progress / this.file.size) * 100)

--- a/src/components/widgets/history/JobHistoryItemStatus.vue
+++ b/src/components/widgets/history/JobHistoryItemStatus.vue
@@ -25,7 +25,7 @@ import { HistoryItem, HistoryItemStatus } from '@/store/history/types'
 @Component({})
 export default class JobHistoryItemStatus extends Mixins(FilesMixin) {
   @Prop({ type: Object, required: true })
-  public job!: HistoryItem
+  readonly job!: HistoryItem
 
   // get status () {
   //   if (this.job.status === HistoryItemStatus.Completed) return HistoryItemStatus.Completed

--- a/src/components/widgets/history/PrintHistoryCard.vue
+++ b/src/components/widgets/history/PrintHistoryCard.vue
@@ -50,7 +50,7 @@ import { SocketActions } from '@/api/socketActions'
 })
 export default class PrinterHistoryCard extends Vue {
   @Prop({ type: Boolean, default: false })
-  public menuCollapsed!: boolean
+  readonly menuCollapsed!: boolean
 
   handleRemoveAll () {
     this.$confirm(

--- a/src/components/widgets/jobs/JobsCard.vue
+++ b/src/components/widgets/jobs/JobsCard.vue
@@ -38,7 +38,7 @@ import StateMixin from '@/mixins/state'
 })
 export default class JobsCard extends Mixins(StateMixin) {
   @Prop({ type: Boolean, default: true })
-  public enabled!: boolean
+  readonly enabled!: boolean
 
   get inLayout (): boolean {
     return (this.$store.state.config.layoutMode)

--- a/src/components/widgets/limits/PrinterLimitsCard.vue
+++ b/src/components/widgets/limits/PrinterLimitsCard.vue
@@ -21,7 +21,7 @@ import StateMixin from '@/mixins/state'
 })
 export default class PrinterLimitsCard extends Mixins(StateMixin) {
   @Prop({ type: Boolean, default: true })
-  public enabled!: boolean
+  readonly enabled!: boolean
 
   get inLayout (): boolean {
     return (this.$store.state.config.layoutMode)

--- a/src/components/widgets/macros/MacrosCard.vue
+++ b/src/components/widgets/macros/MacrosCard.vue
@@ -21,7 +21,7 @@ import StateMixin from '@/mixins/state'
 })
 export default class MacrosCard extends Mixins(StateMixin) {
   @Prop({ type: Boolean, default: true })
-  public enabled!: boolean
+  readonly enabled!: boolean
 
   get inLayout (): boolean {
     return (this.$store.state.config.layoutMode)

--- a/src/components/widgets/outputs/OutputFan.vue
+++ b/src/components/widgets/outputs/OutputFan.vue
@@ -45,7 +45,7 @@ import { Waits } from '@/globals'
 @Component({})
 export default class OutputFan extends Mixins(StateMixin) {
   @Prop({ type: Object, required: true })
-  public fan!: Fan
+  readonly fan!: Fan
 
   get prettyValue () {
     return (this.value === 0)

--- a/src/components/widgets/outputs/OutputItem.vue
+++ b/src/components/widgets/outputs/OutputItem.vue
@@ -36,7 +36,7 @@ import { Fan, Led, OutputPin as IOutputPin } from '@/store/printer/types'
 })
 export default class Outputs extends Vue {
   @Prop({ type: Object, required: true })
-  public item!: Fan | Led | IOutputPin
+  readonly item!: Fan | Led | IOutputPin
 
   get fanTypes () {
     return [

--- a/src/components/widgets/outputs/OutputLed.vue
+++ b/src/components/widgets/outputs/OutputLed.vue
@@ -34,7 +34,7 @@ type Channel = 'r' | 'g' | 'b' | 'w'
 @Component({})
 export default class OutputLed extends Mixins(StateMixin) {
   @Prop({ type: Object, required: true })
-  public led!: Led
+  readonly led!: Led
 
   channelLookup: Record<Channel, string> = { r: 'RED', g: 'GREEN', b: 'BLUE', w: 'WHITE' }
 

--- a/src/components/widgets/outputs/OutputPin.vue
+++ b/src/components/widgets/outputs/OutputPin.vue
@@ -34,7 +34,7 @@ import { OutputPin as IOutputPin } from '@/store/printer/types'
 @Component({})
 export default class OutputPin extends Mixins(StateMixin) {
   @Prop({ type: Object, required: true })
-  public pin!: IOutputPin
+  readonly pin!: IOutputPin
 
   setValue (pin: IOutputPin, target: number) {
     if (!pin.pwm) {

--- a/src/components/widgets/outputs/OutputsCard.vue
+++ b/src/components/widgets/outputs/OutputsCard.vue
@@ -22,7 +22,7 @@ import Outputs from '@/components/widgets/outputs/Outputs.vue'
 })
 export default class OutputsCard extends Mixins(StateMixin) {
   @Prop({ type: Boolean, default: true })
-  public enabled!: boolean
+  readonly enabled!: boolean
 
   get inLayout (): boolean {
     return (this.$store.state.config.layoutMode)

--- a/src/components/widgets/retract/RetractCard.vue
+++ b/src/components/widgets/retract/RetractCard.vue
@@ -21,7 +21,7 @@ import StateMixin from '@/mixins/state'
 })
 export default class RetractCard extends Mixins(StateMixin) {
   @Prop({ type: Boolean, default: true })
-  public enabled!: boolean
+  readonly enabled!: boolean
 
   get inLayout (): boolean {
     return (this.$store.state.config.layoutMode)

--- a/src/components/widgets/stats/PrinterStatsCard.vue
+++ b/src/components/widgets/stats/PrinterStatsCard.vue
@@ -143,7 +143,7 @@ import { SocketActions } from '@/api/socketActions'
 })
 export default class PrinterStatsCard extends Vue {
   @Prop({ type: Boolean, default: false })
-  public menuCollapsed!: boolean
+  readonly menuCollapsed!: boolean
 
   get rollup () {
     return this.$store.getters['history/getRollUp']

--- a/src/components/widgets/status/StatusLabel.vue
+++ b/src/components/widgets/status/StatusLabel.vue
@@ -20,10 +20,10 @@ import StateMixin from '@/mixins/state'
 @Component({})
 export default class AppSwitch extends Mixins(StateMixin) {
   @Prop({ type: String, required: true })
-  public label!: string
+  readonly label!: string
 
   @Prop({ type: [String, Number], default: '70px' })
-  public labelWidth!: string | number
+  readonly labelWidth!: string | number
 }
 </script>
 

--- a/src/components/widgets/system/McuCard.vue
+++ b/src/components/widgets/system/McuCard.vue
@@ -52,7 +52,7 @@ import { Component, Prop, Vue } from 'vue-property-decorator'
 })
 export default class PrinterStatsCard extends Vue {
   @Prop({ type: Object, required: true })
-  public mcu!: MCU
+  readonly mcu!: MCU
 
   mcuConstantsDialogOpen = false
 

--- a/src/components/widgets/system/McuConstantsDialog.vue
+++ b/src/components/widgets/system/McuConstantsDialog.vue
@@ -35,10 +35,10 @@ import { Component, Prop, Vue } from 'vue-property-decorator'
 @Component({})
 export default class McuConstantsDialog extends Vue {
   @Prop({ type: Boolean, default: false })
-  public value!: boolean
+  readonly value!: boolean
 
   @Prop({ type: Object, required: true })
-  public mcu!: MCU
+  readonly mcu!: MCU
 
   get constants () {
     return Object.entries(this.mcu.mcu_constants)

--- a/src/components/widgets/system/McuLoadChart.vue
+++ b/src/components/widgets/system/McuLoadChart.vue
@@ -37,7 +37,7 @@ export default class McuLoadChart extends Vue {
   ready = false
 
   @Prop({ type: String, required: true })
-  public mcu!: string
+  readonly mcu!: string
 
   get chartData () {
     return this.$store.state.charts[this.mcu] || []

--- a/src/components/widgets/thermals/InputTemperature.vue
+++ b/src/components/widgets/thermals/InputTemperature.vue
@@ -29,16 +29,16 @@ import StateMixin from '@/mixins/state'
 @Component({})
 export default class InputTemperature extends Mixins(StateMixin) {
   @Prop({ type: Number, required: true })
-  public value!: number
+  readonly value!: number
 
   @Prop({ type: Number, default: null })
-  public max!: number
+  readonly max!: number
 
   @Prop({ type: Number, default: null })
-  public min!: number
+  readonly min!: number
 
   @Prop({ type: Boolean, default: false })
-  public loading!: boolean
+  readonly loading!: boolean
 
   @Watch('value')
   onValueChange (val: number) {

--- a/src/components/widgets/thermals/TemperatureCard.vue
+++ b/src/components/widgets/thermals/TemperatureCard.vue
@@ -99,10 +99,10 @@ import { TemperaturePreset } from '@/store/config/types'
 })
 export default class TemperatureCard extends Mixins(StateMixin) {
   @Prop({ type: Boolean, default: true })
-  public enabled!: boolean
+  readonly enabled!: boolean
 
   @Prop({ type: Boolean, default: false })
-  public menuCollapsed!: boolean
+  readonly menuCollapsed!: boolean
 
   @Ref('thermalchart')
   readonly thermalChart!: ThermalChart

--- a/src/components/widgets/thermals/ThermalChart.vue
+++ b/src/components/widgets/thermals/ThermalChart.vue
@@ -23,7 +23,7 @@ import getKlipperType from '@/util/get-klipper-type'
 @Component({})
 export default class ThermalChart extends Vue {
   @Prop({ type: String, default: '100%' })
-  public height!: string
+  readonly height!: string
 
   @Ref('chart')
   readonly chart!: ECharts

--- a/src/components/widgets/timelapse/TimelapseRenderSettingsDialog.vue
+++ b/src/components/widgets/timelapse/TimelapseRenderSettingsDialog.vue
@@ -204,10 +204,10 @@ import { VInput } from '@/types'
 })
 export default class TimelapseRenderSettingsDialog extends Mixins(StateMixin) {
   @Prop({ type: Boolean, required: true })
-  public value!: boolean
+  readonly value!: boolean
 
   @Prop({ type: Boolean, required: true })
-  public renderable!: boolean
+  readonly renderable!: boolean
 
   @Ref('outputFramerateElement')
   readonly outputFramerateElement!: VInput

--- a/src/components/widgets/toolhead/Toolhead.vue
+++ b/src/components/widgets/toolhead/Toolhead.vue
@@ -51,7 +51,7 @@ import PressureAdvanceAdjust from '@/components/widgets/toolhead/PressureAdvance
 })
 export default class Toolhead extends Mixins(StateMixin) {
   @Prop({ type: Boolean, default: false })
-  public forceMove!: boolean
+  readonly forceMove!: boolean
 
   get multipleExtruders () {
     return this.$store.getters['printer/getExtruders'].length > 1

--- a/src/components/widgets/toolhead/ToolheadCard.vue
+++ b/src/components/widgets/toolhead/ToolheadCard.vue
@@ -142,7 +142,7 @@ export default class ToolheadCard extends Mixins(StateMixin, ToolheadMixin) {
   bedScrewsAdjustDialogOpen = false
 
   @Prop({ type: Boolean, default: false })
-  public menuCollapsed!: boolean
+  readonly menuCollapsed!: boolean
 
   get printerSettings () {
     return this.$store.getters['printer/getPrinterSettings']()

--- a/src/components/widgets/toolhead/ToolheadMoves.vue
+++ b/src/components/widgets/toolhead/ToolheadMoves.vue
@@ -195,7 +195,7 @@ export default class ToolheadMoves extends Mixins(StateMixin, ToolheadMixin) {
   fab = false
 
   @Prop({ type: Boolean, default: false })
-  public forceMove!: boolean
+  readonly forceMove!: boolean
 
   get kinematics () {
     return this.$store.getters['printer/getPrinterSettings']('printer.kinematics') || ''

--- a/src/components/widgets/toolhead/ToolheadPosition.vue
+++ b/src/components/widgets/toolhead/ToolheadPosition.vue
@@ -137,7 +137,7 @@ import ToolheadMixin from '@/mixins/toolhead'
 @Component({})
 export default class ToolheadPosition extends Mixins(StateMixin, ToolheadMixin) {
   @Prop({ type: Boolean, default: false })
-  public forceMove!: boolean
+  readonly forceMove!: boolean
 
   get gcodePosition () {
     return this.$store.state.printer.printer.gcode_move.gcode_position


### PR DESCRIPTION
While checking the example docs on [vue-property-decorator @Prop](https://www.npmjs.com/package/vue-property-decorator#propoptions-propoptions--constructor--constructor---decorator), I noticed that the properties are all marked with `readonly`

So I did a quick test on Vue to change the value of a @Prop variable, and Vue complained!

![image](https://user-images.githubusercontent.com/85504/184167366-38da5fc7-6446-4dc5-aa43-fae8b6b652e8.png)

So marking these with typescript `readonly` is not only safe as in fact, recommended!

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>