### PR TITLE
fix: width constraint at root container level

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -38,8 +38,11 @@
       <!-- <pre>authenticated {{ authenticated }}, socketConnected {{ socketConnected }}, apiConnected {{ apiConnected }}</pre> -->
       <v-container
         fluid
-        :class="{ 'fill-height': $route.meta.fillHeight }"
-        class="pa-2 pa-sm-4"
+        :class="{
+          'fill-height': $route.meta && $route.meta.fillHeight,
+          [['single', 'double', 'triple', 'quad'][columnCount - 1]]: true
+        }"
+        class="constrained-width pa-2 pa-sm-4"
       >
         <v-row
           v-if="
@@ -115,6 +118,10 @@ export default class App extends Mixins(StateMixin) {
 
   get inLayout (): boolean {
     return (this.$store.state.config.layoutMode)
+  }
+
+  get columnCount () {
+    return this.$store.state.config.containerColumnCount
   }
 
   get loading () {

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -147,4 +147,9 @@ const router = new VueRouter({
   }
 })
 
+router.beforeEach((to, from, next) => {
+  store.commit('config/setContainerColumnCount', 2)
+  next()
+})
+
 export default router

--- a/src/store/config/index.ts
+++ b/src/store/config/index.ts
@@ -11,6 +11,7 @@ export const defaultState = (): ConfigState => {
     apiUrl: '',
     socketUrl: '',
     layoutMode: false,
+    containerColumnCount: 2,
     hostConfig: {
       endpoints: [],
       blacklist: [],

--- a/src/store/config/mutations.ts
+++ b/src/store/config/mutations.ts
@@ -161,6 +161,10 @@ export const mutations: MutationTree<ConfigState> = {
     state.layoutMode = payload
   },
 
+  setContainerColumnCount (state, payload: number) {
+    state.containerColumnCount = payload
+  },
+
   /**
    * Toggle a tables header state based on its name and key.
    */

--- a/src/store/config/types.ts
+++ b/src/store/config/types.ts
@@ -7,6 +7,7 @@ export interface ConfigState {
   apiUrl: string;
   socketUrl: string;
   layoutMode: boolean;
+  containerColumnCount: number;
   instances: InstanceConfig[];
   uiSettings: UiSettings;
   hostConfig: HostConfig;

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -1,47 +1,39 @@
 <template>
-  <v-layout justify-center>
-    <v-row
-      :dense="$vuetify.breakpoint.smAndDown"
-      :class="{
-        [['single', 'double', 'triple', 'quad'][columnCount - 1]]: true
-      }"
-      class="constrained-width"
-    >
-      <template v-for="(container, containerIndex) in containers">
-        <v-col
-          v-if="inLayout || hasCards(container)"
-          :key="`container${containerIndex}`"
-          cols="12"
-          md="6"
-          :lg="columnSpan"
-          :class="{ 'drag': inLayout }"
+  <v-row :dense="$vuetify.breakpoint.smAndDown">
+    <template v-for="(container, containerIndex) in containers">
+      <v-col
+        v-if="inLayout || hasCards(container)"
+        :key="`container${containerIndex}`"
+        cols="12"
+        md="6"
+        :lg="columnSpan"
+        :class="{ 'drag': inLayout }"
+      >
+        <draggable
+          v-model="containers[containerIndex]"
+          class="list-group"
+          v-bind="dragOptions"
+          @start.stop="drag = true"
+          @end.stop="handleStopDrag"
         >
-          <draggable
-            v-model="containers[containerIndex]"
-            class="list-group"
-            v-bind="dragOptions"
-            @start.stop="drag = true"
-            @end.stop="handleStopDrag"
+          <transition-group
+            type="transition"
+            :name="!drag ? 'flip-list' : null"
           >
-            <transition-group
-              type="transition"
-              :name="!drag ? 'flip-list' : null"
-            >
-              <template v-for="c in container">
-                <component
-                  :is="c.id"
-                  v-if="(c.enabled && !filtered(c)) || inLayout"
-                  :key="c.id"
-                  :menu-collapsed="menuCollapsed"
-                  class="mb-2 mb-sm-4"
-                />
-              </template>
-            </transition-group>
-          </draggable>
-        </v-col>
-      </template>
-    </v-row>
-  </v-layout>
+            <template v-for="c in container">
+              <component
+                :is="c.id"
+                v-if="(c.enabled && !filtered(c)) || inLayout"
+                :key="c.id"
+                :menu-collapsed="menuCollapsed"
+                class="mb-2 mb-sm-4"
+              />
+            </template>
+          </transition-group>
+        </draggable>
+      </v-col>
+    </template>
+  </v-row>
 </template>
 
 <script lang="ts">
@@ -102,6 +94,11 @@ export default class Dashboard extends Mixins(StateMixin) {
     if (this.inLayout) return 4
 
     return this.containers.reduce((count, container) => +this.hasCards(container) + count, 0)
+  }
+
+  @Watch('columnCount')
+  onColumnCount (value: number) {
+    this.$store.commit('config/setContainerColumnCount', value)
   }
 
   get columnSpan () {


### PR DESCRIPTION
Moves "width constraint" code back to root container as the changes from #820 caused a misalignment when other elements are visible.

## Before

![image](https://user-images.githubusercontent.com/85504/184357432-9eb845df-5a63-4ad4-8a2f-f6d649d92e97.png)

## After

![image](https://user-images.githubusercontent.com/85504/184357492-61aba93c-9e21-4877-952b-08a2ceea56ba.png)

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>