### PR TITLE
feat: add optional Chamber Temp column to jobs

### DIFF
--- a/src/components/widgets/filesystem/FileSystem.vue
+++ b/src/components/widgets/filesystem/FileSystem.vue
@@ -340,6 +340,7 @@ export default class FileSystem extends Mixins(StateMixin, FilesMixin, ServicesM
         { text: this.$t('app.general.table.header.total_duration'), value: 'history.total_duration', configurable: true },
         { text: this.$t('app.general.table.header.first_layer_bed_temp'), value: 'first_layer_bed_temp', configurable: true },
         { text: this.$t('app.general.table.header.first_layer_extr_temp'), value: 'first_layer_extr_temp', configurable: true },
+        { text: this.$t('app.general.table.header.chamber_temp'), value: 'chamber_temp', configurable: true },
         {
           text: this.$t('app.general.table.header.last_printed'),
           value: 'print_start_time',

--- a/src/components/widgets/filesystem/FileSystemBrowser.vue
+++ b/src/components/widgets/filesystem/FileSystemBrowser.vue
@@ -212,6 +212,16 @@
           <file-row-item
             v-if="root === 'gcodes'"
             :headers="headers"
+            item-value="chamber_temp"
+          >
+            <span v-if="item.chamber_temp !== undefined">
+              {{ item.chamber_temp }}<small>°C</small>
+            </span>
+          </file-row-item>
+
+          <file-row-item
+            v-if="root === 'gcodes'"
+            :headers="headers"
             item-value="print_start_time"
           >
             <span v-if="item.print_start_time !== undefined && item.print_start_time !== null">

--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -326,6 +326,7 @@ app:
     table:
       header:
         actions: Actions
+        chamber_temp: Chamber temp
         end_time: Ended
         estimated_time: Estimated time
         filament: Filament

--- a/src/store/config/index.ts
+++ b/src/store/config/index.ts
@@ -96,6 +96,7 @@ export const defaultState = (): ConfigState => {
         gcodes_dashboard: [
           { value: 'first_layer_extr_temp', visible: false },
           { value: 'first_layer_bed_temp', visible: false },
+          { value: 'chamber_temp', visible: false },
           { value: 'history.total_duration', visible: false },
           { value: 'history.print_duration', visible: false },
           { value: 'estimated_time', visible: false },
@@ -113,6 +114,7 @@ export const defaultState = (): ConfigState => {
           { value: 'history.filament_used', visible: false },
           { value: 'slicer_version', visible: false },
           { value: 'history.print_duration', visible: false },
+          { value: 'chamber_temp', visible: false },
           { value: 'first_layer_extr_temp', visible: false },
           { value: 'first_layer_bed_temp', visible: false }
         ],


### PR DESCRIPTION
Adds new optional Chamber Temp column (defaults to hidden) to the "gcodes" root.

![image](https://user-images.githubusercontent.com/85504/184921908-95e18fc4-c246-40bf-9b30-0fe78cebc15e.png)

![image](https://user-images.githubusercontent.com/85504/184921962-aff33331-a0ad-44d0-ba17-17da275060da.png)


Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>