### PR TITLE
fix: ensures containers exist

### DIFF
--- a/src/store/layout/mutations.ts
+++ b/src/store/layout/mutations.ts
@@ -24,15 +24,15 @@ export const mutations: MutationTree<LayoutState> = {
 
       for (const layout of migratableLayouts) {
         const defaultComponents = defaultState.layouts[layout]
-        const existingComponents = Object.values(defaultComponents).flat().map(card => card.id)
-        const componentsInDB = Object.values(payload.layouts[layout]).flat().map(card => card.id)
+        const defaultComponentIds = Object.values(defaultComponents).flat().map(card => card.id)
+        const currentComponentIds = Object.values(payload.layouts[layout]).flat().map(card => card.id)
 
         for (const [container, defaultContainerComponents] of Object.entries(defaultComponents)) {
           const currentContainerComponents = payload.layouts[layout][container] || []
 
           payload.layouts[layout][container] = [
-            ...currentContainerComponents.filter(component => existingComponents.includes(component.id)),
-            ...defaultContainerComponents.filter(component => !componentsInDB.includes(component.id))
+            ...currentContainerComponents.filter(component => defaultComponentIds.includes(component.id)),
+            ...defaultContainerComponents.filter(component => !currentComponentIds.includes(component.id))
           ]
         }
       }

--- a/src/store/layout/mutations.ts
+++ b/src/store/layout/mutations.ts
@@ -27,23 +27,13 @@ export const mutations: MutationTree<LayoutState> = {
         const existingComponents = Object.values(defaultComponents).flat().map(card => card.id)
         const componentsInDB = Object.values(payload.layouts[layout]).flat().map(card => card.id)
 
-        // add missing components
-        for (const [container, components] of Object.entries(defaultComponents)) {
-          for (const component of components) {
-            if (!componentsInDB.includes(component.id)) {
-              payload.layouts[layout][container].push(component)
-            }
-          }
-        }
+        for (const [container, defaultContainerComponents] of Object.entries(defaultComponents)) {
+          const currentContainerComponents = payload.layouts[layout][container] || []
 
-        // remove outdated components
-        for (const [container, components] of Object.entries(payload.layouts[layout])) {
-          for (const component of components) {
-            if (!existingComponents.includes(component.id)) {
-              const payloadContainer = payload.layouts[layout][container]
-              payloadContainer.splice(payloadContainer.indexOf(component), 1)
-            }
-          }
+          payload.layouts[layout][container] = [
+            ...currentContainerComponents.filter(component => existingComponents.includes(component.id)),
+            ...defaultContainerComponents.filter(component => !componentsInDB.includes(component.id))
+          ]
         }
       }
 


### PR DESCRIPTION
While testing, I've found a bug that I believe to have been introduced with the changes of #793.

Repro steps:

- start with fresh (non-existing) moonraker database
- open Fluidd
- collapse Thermals card
- refresh page (F5)
- observe browser developer console

![image](https://user-images.githubusercontent.com/85504/185970316-bd3972b2-9452-4ac5-8676-101998105369.png)

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>