### PR TITLE
feat: Enabling default list of endpoints via config

### DIFF
--- a/public/config.json
+++ b/public/config.json
@@ -3,6 +3,8 @@
     "fluidd.xyz",
     "fluidd.net"
   ],
+  "endpoints": [
+  ],
   "hosted": false,
   "themePresets": [
     {

--- a/server/config.json
+++ b/server/config.json
@@ -3,7 +3,7 @@
     "fluidd.xyz",
     "fluidd.net"
   ],
-  "endpoints":[
+  "endpoints": [
   ],
   "hosted": true,
   "themePresets": [

--- a/server/config.json
+++ b/server/config.json
@@ -3,6 +3,8 @@
     "fluidd.xyz",
     "fluidd.net"
   ],
+  "endpoints":[
+  ],
   "hosted": true,
   "themePresets": [
     {

--- a/src/init.ts
+++ b/src/init.ts
@@ -54,13 +54,10 @@ const getApiConfig = async (hostConfig: HostConfig): Promise<ApiConfig | Instanc
   // If endpoints are defined in the hostConfig file,
   // we want to load these on initial application launch
   if (hostConfig && 'endpoints' in hostConfig && hostConfig.endpoints.length) {
-    console.log({ before: hostConfig.endpoints })
     endpoints.push(
       ...hostConfig.endpoints
         .map(sanitizeEndpoint)
         .filter((endpoint): endpoint is string => !!endpoint))
-
-    console.log({ after: endpoints })
   }
 
   // Add the browsers url to our endpoints list, unless black listed.

--- a/src/init.ts
+++ b/src/init.ts
@@ -45,22 +45,22 @@ const getApiConfig = async (hostConfig: HostConfig): Promise<ApiConfig | Instanc
 
   // If local storage not set, then ping the browser url.
   const endpoints: string[] = []
-  let blacklist: string[] = []
+  const blacklist: string[] = []
 
   if (hostConfig && 'blacklist' in hostConfig && hostConfig.blacklist.length) {
-    blacklist = hostConfig.blacklist
+    blacklist.push(...hostConfig.blacklist)
   }
 
   // If endpoints are defined in the hostConfig file,
   // we want to load these on initial application launch
   if (hostConfig && 'endpoints' in hostConfig && hostConfig.endpoints.length) {
-    hostConfig.endpoints.map(async endpoint => {
-      const temp = sanitizeEndpoint(endpoint)
-      if (temp) {
-        endpoints.push(temp)
-      }
-    }
-    )
+    console.log({ before: hostConfig.endpoints })
+    endpoints.push(
+      ...hostConfig.endpoints
+        .map(sanitizeEndpoint)
+        .filter((endpoint): endpoint is string => !!endpoint))
+
+    console.log({ after: endpoints })
   }
 
   // Add the browsers url to our endpoints list, unless black listed.
@@ -69,8 +69,8 @@ const getApiConfig = async (hostConfig: HostConfig): Promise<ApiConfig | Instanc
     endpoints.push(`${document.location.protocol}//${document.location.host}`)
 
     // Add the moonraker endpoints...
-    let port = '7125'
-    if (document.location.protocol === 'https:') port = '7130'
+    const port = document.location.protocol === 'https:' ? '7130' : '7125'
+
     endpoints.push(`${document.location.protocol}//${document.location.hostname}:${port}`)
   }
 

--- a/src/init.ts
+++ b/src/init.ts
@@ -6,6 +6,7 @@ import { Globals } from './globals'
 import { ApiConfig, InitConfig, HostConfig, InstanceConfig } from './store/config/types'
 import axios from 'axios'
 import router from './router'
+import sanitizeEndpoint from '@/util/sanitize-endpoint'
 
 // Load API configuration
 /**
@@ -48,6 +49,18 @@ const getApiConfig = async (hostConfig: HostConfig): Promise<ApiConfig | Instanc
 
   if (hostConfig && 'blacklist' in hostConfig && hostConfig.blacklist.length) {
     blacklist = hostConfig.blacklist
+  }
+
+  // If endpoints are defined in the hostConfig file,
+  // we want to load these on initial application launch
+  if (hostConfig && 'endpoints' in hostConfig && hostConfig.endpoints.length) {
+    hostConfig.endpoints.map(async endpoint => {
+      const temp = sanitizeEndpoint(endpoint)
+      if (temp) {
+        endpoints.push(temp)
+      }
+    }
+    )
   }
 
   // Add the browsers url to our endpoints list, unless black listed.

--- a/src/util/__tests__/sanitize-endpoint.spec.ts
+++ b/src/util/__tests__/sanitize-endpoint.spec.ts
@@ -1,0 +1,14 @@
+import sanitizeEndpoint from '../sanitize-endpoint'
+
+describe('santizeEndpointChecks', () => {
+  it.each([
+    ['https://localhost/', 'https://localhost'],
+    ['https://localhost', 'https://localhost'],
+    ['https://test.example.com/some/subpath/', 'https://test.example.com/some/subpath'],
+    ['https://test.example.com/?query=parameter&test',
+      'https://test.example.com'],
+    ['garbage', undefined]
+  ])('Expects url Parsing of "%s" to be %s', (param, expected) => {
+    expect(sanitizeEndpoint(param)).toBe(expected)
+  })
+})

--- a/src/util/sanitize-endpoint.ts
+++ b/src/util/sanitize-endpoint.ts
@@ -1,0 +1,16 @@
+const sanitizeEndpoint = (endpoint: string|undefined) : string|undefined => {
+  if (endpoint) {
+    try {
+      const url = new URL(endpoint)
+      const path = url.pathname.endsWith('/')
+        ? url.pathname.slice(0, url.pathname.length - 1)
+        : url.pathname
+      return `${url.protocol}//${url.host}${path}`
+    } catch (e) {
+      console.debug('error parsing url', e)
+    }
+  }
+  return undefined
+}
+
+export default sanitizeEndpoint

--- a/src/util/sanitize-endpoint.ts
+++ b/src/util/sanitize-endpoint.ts
@@ -1,16 +1,17 @@
-const sanitizeEndpoint = (endpoint: string|undefined) : string|undefined => {
+import consola from 'consola'
+
+const sanitizeEndpoint = (endpoint?: string) => {
   if (endpoint) {
     try {
       const url = new URL(endpoint)
       const path = url.pathname.endsWith('/')
-        ? url.pathname.slice(0, url.pathname.length - 1)
+        ? url.pathname.slice(0, -1)
         : url.pathname
       return `${url.protocol}//${url.host}${path}`
     } catch (e) {
-      console.debug('error parsing url', e)
+      consola.debug('Error parsing endpoint url in config.json', e)
     }
   }
-  return undefined
 }
 
 export default sanitizeEndpoint


### PR DESCRIPTION
Enabling the use of the config.json to allow for a default list of endpoints to be populated on first load of the Fluidd interface.

Signed-off-by: Chris Owen <Chris@ChrisOwen.org>