### PR TITLE
refactor: timelapseBrowser property in FileSystem

### DIFF
--- a/src/views/Timelapse.vue
+++ b/src/views/Timelapse.vue
@@ -14,7 +14,6 @@
           name="timelapse"
           bulk-actions
           :max-height="816"
-          :timelapse-browser="true"
         />
       </collapsable-card>
     </v-col>


### PR DESCRIPTION
Seems to me we can go without that `timelapseProperty` just by checking the root (as we do for others)

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>