### PR TITLE
fix: dispatch even if database creation fails

### DIFF
--- a/src/init.ts
+++ b/src/init.ts
@@ -166,11 +166,15 @@ export const appInit = async (apiConfig?: ApiConfig, hostConfig?: HostConfig): P
         if (value) store.dispatch(root.dispatch, value)
       } else {
         if (!value) {
-          await httpClient.post('/server/database/item', {
-            namespace: NAMESPACE,
-            key: root.name,
-            value: {}
-          })
+          try {
+            await httpClient.post('/server/database/item', {
+              namespace: NAMESPACE,
+              key: root.name,
+              value: {}
+            })
+          } catch (e) {
+            consola.debug('Error creating database item', e)
+          }
         }
 
         await store.dispatch(root.dispatch, value || {})


### PR DESCRIPTION
Fixes bug introduced by #839: if Moonraker is down, Fluidd will not load (blank page is shown)

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>