### PR TITLE
fix(diagnostics): Metrics Explorer styling

### DIFF
--- a/src/components/widgets/diagnostics/StateExplorer.vue
+++ b/src/components/widgets/diagnostics/StateExplorer.vue
@@ -44,20 +44,20 @@ export default class StateExplorer extends Mixins(StateMixin) {
 
 <style lang="scss">
 .jv-container>.jv-code {
-  padding: 0;
+  padding: 0 !important;
 }
 
 .jv-container.jv-dark {
-  background: transparent;
-  color: rgba(255, 255, 255, 0.8);
+  background: transparent !important;
+  color: rgba(255, 255, 255, 0.8) !important;
 
-  .jv-item.jv-object { color: rgba(255, 255, 255, 0.8); }
-  .jv-item.jv-array { color: rgba(255, 255, 255, 0.8); }
-  .jv-key { color: rgba(255, 255, 255, 0.8); }
+  .jv-item.jv-object { color: rgba(255, 255, 255, 0.8) !important; }
+  .jv-item.jv-array { color: rgba(255, 255, 255, 0.8) !important; }
+  .jv-key { color: rgba(255, 255, 255, 0.8) !important; }
 
   .jv-ellipsis {
-    color: rgba(255, 255, 255, 0.5);
-    background-color: rgba(255, 255, 255, 0.2);
+    color: rgba(255, 255, 255, 0.5) !important;
+    background-color: rgba(255, 255, 255, 0.2) !important;
   }
 }
 </style>


### PR DESCRIPTION
Before, the production build would apply the `vue-json-viewer` styles _after_ the component styles, rendering the component styles useless (this didn't happen in the dev build). This is the easiest way to solve this without changing any of the bundling logic I think.

| Before | After
| --- | --- |
| ![image](https://user-images.githubusercontent.com/25269274/187047879-d550cbba-8fb0-4519-bfac-1cb8ada6e9be.png) | ![image](https://user-images.githubusercontent.com/25269274/187047832-beaa1912-9627-49e2-9881-868a4eaca5e6.png) |