### PR TITLE
feat: adds variance to bed mesh chart

### DIFF
--- a/src/components/widgets/bedmesh/BedMeshCard.vue
+++ b/src/components/widgets/bedmesh/BedMeshCard.vue
@@ -28,6 +28,7 @@
         ref="chart"
         :options="options"
         :data="series"
+        :graphics="graphics"
         :height="(isMobile) ? '225px' : '525px'"
       />
 
@@ -119,6 +120,21 @@ export default class BedMeshCard extends Mixins(StateMixin, ToolheadMixin) {
       this.createFlatSeries('mesh_matrix_flat')
     ]
     return series
+  }
+
+  get graphics () {
+    const variance = this.mesh[this.matrix].variance
+
+    return [{
+      type: 'text',
+      right: 10,
+      top: 0,
+      z: 100,
+      silent: true,
+      style: {
+        text: `Variance: ${variance.toFixed(4)}`
+      }
+    }]
   }
 
   createFlatSeries (matrix: string) {

--- a/src/components/widgets/bedmesh/BedMeshChart.vue
+++ b/src/components/widgets/bedmesh/BedMeshChart.vue
@@ -19,13 +19,16 @@
 
 <script lang='ts'>
 import { Vue, Component, Prop, Watch, Ref } from 'vue-property-decorator'
-import type { ECharts } from 'echarts'
-import { merge } from 'lodash-es'
+import type { ECharts, EChartsOption, GraphicComponentOption } from 'echarts'
+import { merge, cloneDeepWith } from 'lodash-es'
 
 @Component({})
 export default class EChartsBedMesh extends Vue {
   @Prop({ type: Array, required: true, default: {} })
   readonly data!: []
+
+  @Prop({ type: Array, required: false, default: () => [] })
+  readonly graphics!: GraphicComponentOption[]
 
   @Prop({ type: Object, default: {} })
   readonly options!: any
@@ -42,28 +45,23 @@ export default class EChartsBedMesh extends Vue {
 
   @Watch('flatSurface')
   onFlatSurfaceChange (value: boolean) {
-    if (this.chart) {
-      let type = 'legendUnSelect'
-      if (value) type = 'legendSelect'
-      this.chart.dispatchAction({
-        type,
-        name: 'mesh_matrix_flat'
-      })
-      this.chart.dispatchAction({
-        type,
-        name: 'probed_matrix_flat'
-      })
-    }
+    const type = value ? 'legendSelect' : 'legendUnSelect'
+    this.chart.dispatchAction({
+      type,
+      name: 'mesh_matrix_flat'
+    })
+    this.chart.dispatchAction({
+      type,
+      name: 'probed_matrix_flat'
+    })
   }
 
   beforeDestroy () {
     if (typeof window === 'undefined') return
-    if (this.chart) {
-      this.chart.dispose()
-    }
+    this.chart.dispose()
   }
 
-  get opts () {
+  get opts (): EChartsOption {
     // If options includes series data, rip it out so we can merge it with
     // the given series in our initial options.
     const darkMode = this.$store.state.config.uiSettings.theme.isDark
@@ -124,6 +122,22 @@ export default class EChartsBedMesh extends Vue {
       }
     }
 
+    const graphic = cloneDeepWith(this.graphics, g => {
+      switch (g.type) {
+        case 'text':
+          return {
+            ...g,
+            style: {
+              ...g.style,
+              fill: fontColor,
+              fontSize
+            }
+          }
+        default:
+          return undefined
+      }
+    })
+
     const opts = {
       legend: {
         show: false
@@ -181,8 +195,9 @@ export default class EChartsBedMesh extends Vue {
           panMouseButton: 'right'
         }
       },
+      graphic,
       series: [...this.data]
-    }
+    } as EChartsOption
 
     // Merge the default options with the given prop.
     merge(opts, this.options)

--- a/src/vue-echarts-chunk.ts
+++ b/src/vue-echarts-chunk.ts
@@ -10,7 +10,8 @@ import {
   GridComponent,
   DataZoomComponent,
   LegendComponent,
-  VisualMapComponent
+  VisualMapComponent,
+  GraphicComponent
 } from 'echarts/components'
 import { SVGRenderer, CanvasRenderer } from 'echarts/renderers'
 
@@ -23,6 +24,7 @@ use([
   LegendComponent,
   LineChart,
   VisualMapComponent,
+  GraphicComponent,
   SurfaceChart,
   Grid3DComponent,
   SVGRenderer,


### PR DESCRIPTION
Variance will show directly on the chart on all views (I see no reason why not to show it on the Tune as there is enough space for the value on the chart)

![image](https://user-images.githubusercontent.com/85504/188321664-a4c1f3aa-f920-4755-8538-7b9a3a1be06d.png)

Fixes #853 

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>