### PR TITLE
fix: disable force_move on axis with multiple steppers

### DIFF
--- a/src/components/widgets/toolhead/ToolheadMoves.vue
+++ b/src/components/widgets/toolhead/ToolheadMoves.vue
@@ -11,7 +11,7 @@
       >
         <app-btn-toolhead-move
           :color="axisButtonColor(yHomed)"
-          :disabled="axisButtonDisabled(yHomed)"
+          :disabled="axisButtonDisabled(yHomed, yHasMultipleSteppers)"
           icon="$up"
           @click="sendMoveGcode('Y', toolheadMoveLength)"
         />
@@ -22,7 +22,7 @@
       >
         <app-btn-toolhead-move
           :color="axisButtonColor(zHomed)"
-          :disabled="axisButtonDisabled(zHomed)"
+          :disabled="axisButtonDisabled(zHomed, zHasMultipleSteppers)"
           icon="$up"
           @click="sendMoveGcode('Z', toolheadMoveLength)"
         />
@@ -51,7 +51,7 @@
       <v-col cols="auto">
         <app-btn-toolhead-move
           :color="axisButtonColor(xHomed)"
-          :disabled="axisButtonDisabled(xHomed)"
+          :disabled="axisButtonDisabled(xHomed, xHasMultipleSteppers)"
           icon="$left"
           @click="sendMoveGcode('X', toolheadMoveLength, true)"
         />
@@ -76,7 +76,7 @@
       >
         <app-btn-toolhead-move
           :color="axisButtonColor(xHomed)"
-          :disabled="axisButtonDisabled(xHomed)"
+          :disabled="axisButtonDisabled(xHomed, xHasMultipleSteppers)"
           icon="$right"
           @click="sendMoveGcode('X', toolheadMoveLength)"
         />
@@ -121,8 +121,8 @@
         class="ml-12 mr-7"
       >
         <app-btn-toolhead-move
-          :color="axisButtonColor(xHomed)"
-          :disabled="axisButtonDisabled(yHomed)"
+          :color="axisButtonColor(yHomed)"
+          :disabled="axisButtonDisabled(yHomed, yHasMultipleSteppers)"
           icon="$down"
           @click="sendMoveGcode('Y', toolheadMoveLength, true)"
         />
@@ -133,7 +133,7 @@
       >
         <app-btn-toolhead-move
           :color="axisButtonColor(zHomed)"
-          :disabled="axisButtonDisabled(yHomed)"
+          :disabled="axisButtonDisabled(zHomed, zHasMultipleSteppers)"
           icon="$down"
           @click="sendMoveGcode('Z', toolheadMoveLength, true)"
         />
@@ -231,8 +231,8 @@ export default class ToolheadMoves extends Mixins(StateMixin, ToolheadMixin) {
     return axisHomed ? 'primary' : undefined
   }
 
-  axisButtonDisabled (axisHomed: boolean) {
-    return !this.klippyReady || (!axisHomed && !this.forceMove)
+  axisButtonDisabled (axisHomed: boolean, axisMultipleSteppers: boolean) {
+    return !this.klippyReady || (!axisHomed && !(this.forceMove && !axisMultipleSteppers))
   }
 
   /**

--- a/src/components/widgets/toolhead/ToolheadPosition.vue
+++ b/src/components/widgets/toolhead/ToolheadPosition.vue
@@ -17,7 +17,7 @@
           dense
           class="v-input--width-small"
           type="number"
-          :disabled="!klippyReady || (!xHomed && !forceMove)"
+          :disabled="!klippyReady || (!xHomed && !xForceMove)"
           :readonly="printerBusy"
           :value="(useGcodeCoords) ? gcodePosition[0].toFixed(2) : toolheadPosition[0].toFixed(2)"
           @change="moveTo('X', $event)"
@@ -35,7 +35,7 @@
           dense
           class="v-input--width-small"
           type="number"
-          :disabled="!klippyReady || (!yHomed && !forceMove)"
+          :disabled="!klippyReady || (!yHomed && !yForceMove)"
           :readonly="printerBusy"
           :value="(useGcodeCoords) ? gcodePosition[1].toFixed(2) : toolheadPosition[1].toFixed(2)"
           @change="moveTo('Y', $event)"
@@ -53,7 +53,7 @@
           dense
           class="v-input--width-small"
           type="number"
-          :disabled="!klippyReady || (!zHomed && !forceMove)"
+          :disabled="!klippyReady || (!zHomed && !zForceMove)"
           :readonly="printerBusy"
           :value="(useGcodeCoords) ? gcodePosition[2].toFixed(2) : toolheadPosition[2].toFixed(2)"
           @change="moveTo('Z', $event)"
@@ -153,6 +153,18 @@ export default class ToolheadPosition extends Mixins(StateMixin, ToolheadMixin) 
 
   get useGcodeCoords () {
     return this.$store.state.config.uiSettings.general.useGcodeCoords
+  }
+
+  get xForceMove () {
+    return this.forceMove && !this.xHasMultipleSteppers
+  }
+
+  get yForceMove () {
+    return this.forceMove && !this.yHasMultipleSteppers
+  }
+
+  get zForceMove () {
+    return this.forceMove && !this.zHasMultipleSteppers
   }
 
   get requestedSpeed () {

--- a/src/mixins/toolhead.ts
+++ b/src/mixins/toolhead.ts
@@ -34,6 +34,18 @@ export default class ToolheadMixin extends Vue {
     return this.$store.getters['printer/getHomedAxes']('z')
   }
 
+  get xHasMultipleSteppers (): boolean {
+    return !!this.$store.getters['printer/getPrinterConfig']('stepper_x1')
+  }
+
+  get yHasMultipleSteppers (): boolean {
+    return !!this.$store.getters['printer/getPrinterConfig']('stepper_y1')
+  }
+
+  get zHasMultipleSteppers (): boolean {
+    return !!this.$store.getters['printer/getPrinterConfig']('stepper_z1')
+  }
+
   get hasHomingOverride (): boolean {
     return this.$store.getters['printer/getHasHomingOverride']
   }


### PR DESCRIPTION
If a `stepper_k1` is found on the configuration, then we will disable the controls for that K axis when Force Move mode is enabled.

Here's an example where `stepper_z1` exists in the printer configuration, and as such we disabled both the Z axis controls and the Z position textbox:

![image](https://user-images.githubusercontent.com/85504/188437006-09217a81-0e37-4c12-9b30-a3fe18b8aa9d.png)

This PR also fixed some minor issues where the wrong axis were being checked!

Fixes #856 

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>