### PR TITLE
fix: pressure advance and acceleration units

### DIFF
--- a/src/components/widgets/limits/PrinterLimits.vue
+++ b/src/components/widgets/limits/PrinterLimits.vue
@@ -60,7 +60,7 @@
             :disabled="!klippyReady"
             :overridable="true"
             :locked="!klippyReady || isMobile"
-            suffix="mm/s^2"
+            suffix="mm/s²"
             @change="setAcceleration($event)"
           />
         </v-col>
@@ -79,7 +79,7 @@
             :disabled="!klippyReady"
             :overridable="true"
             :locked="!klippyReady || isMobile"
-            suffix="mm/s^2"
+            suffix="mm/s²"
             @change="setDeceleration($event)"
           />
         </v-col>

--- a/src/components/widgets/toolhead/PressureAdvanceAdjust.vue
+++ b/src/components/widgets/toolhead/PressureAdvanceAdjust.vue
@@ -6,7 +6,7 @@
     >
       <app-slider
         :label="$t('app.general.label.pressure_advance')"
-        suffix="mm/s"
+        suffix="s"
         :value="activeExtruder.pressure_advance || 0"
         :overridable="true"
         :reset-value="activeExtruder.config_pressure_advance || 0"


### PR DESCRIPTION
Fixes Pressure Advance units, as it is measures in `mm/(mm/s)` which can be simplified just to `s` (though missing a bit of the significance)

For the [Klipper docs](https://www.klipper3d.org/Config_Reference.html#extruder):

![image](https://user-images.githubusercontent.com/85504/188872550-e52fb97c-0902-4b77-aef7-fae7894047cd.png)

Also changes presentation of acceleration values.

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>