### PR TITLE
fix: Camera iframe width

### DIFF
--- a/src/components/widgets/camera/CameraItem.vue
+++ b/src/components/widgets/camera/CameraItem.vue
@@ -27,6 +27,7 @@
       :src="cameraUrl"
       class="camera-image"
       style="border: none; width: 100%"
+      :style="{height: fullscreen ? '100vh' : `${cameraHeight}px`}"
     />
 
     <div

--- a/src/components/widgets/camera/CameraItem.vue
+++ b/src/components/widgets/camera/CameraItem.vue
@@ -26,8 +26,7 @@
       ref="camera_image"
       :src="cameraUrl"
       class="camera-image"
-      :height="cameraHeight"
-      frameBorder="0"
+      style="border: none; width: 100%"
     />
 
     <div


### PR DESCRIPTION
This is a quick fix for #778 that just sets the iframes width to a static 100%.
It's not optimal, so I am planning to rewrite the sizing logic for iframes for the next minor release (have it dynamically scale based on the container so it automatically matches the rest of the displayed cameras) and I'm therefore leaving #778 open. This  would be a breaking change, so I am not including it in this patch.

This also fixes the size of the iframe in full screen mode, making it cover the entire contentbox.

Before
![image](https://user-images.githubusercontent.com/25269274/190919684-8a872062-842b-4e2f-bf00-f9f2cf917149.png)

After
![image](https://user-images.githubusercontent.com/25269274/190919671-bc3218a0-31ed-4304-8b6b-9ad849976db0.png)
