### PR TITLE
feat: user/device specific layouts

### DIFF
--- a/src/components/common/CollapsableCard.vue
+++ b/src/components/common/CollapsableCard.vue
@@ -253,8 +253,11 @@ export default class CollapsableCard extends Vue {
     if (this.layoutPath) {
       if (this.layoutPath.includes('.')) {
         const split = this.layoutPath.split('.')
+        let name = split[0]
+        if (name === 'dashboard') name = this.$store.getters['layout/getSpecificLayout']
+
         return {
-          name: split[0],
+          name,
           id: split[1]
         }
       } else {
@@ -294,6 +297,7 @@ export default class CollapsableCard extends Vue {
 
   set isCollapsed (collapsed: boolean) {
     const value = this.layout
+    console.log(value, this._layoutPath)
     if (value && this._layoutPath) {
       value.collapsed = collapsed
       this.$store.dispatch('layout/onUpdateConfig', { name: this._layoutPath.name, value })
@@ -319,6 +323,7 @@ export default class CollapsableCard extends Vue {
     const value = this.layout
     if (value && this._layoutPath) {
       value.enabled = enabled
+      console.log({ ...this._layoutPath }, value)
       this.$store.dispatch('layout/onUpdateConfig', { name: this._layoutPath.name, value })
     }
   }

--- a/src/components/common/CollapsableCard.vue
+++ b/src/components/common/CollapsableCard.vue
@@ -254,7 +254,7 @@ export default class CollapsableCard extends Vue {
       if (this.layoutPath.includes('.')) {
         const split = this.layoutPath.split('.')
         let name = split[0]
-        if (name === 'dashboard') name = this.$store.getters['layout/getSpecificLayout']
+        if (name === 'dashboard') name = this.$store.getters['layout/getSpecificLayoutName']
 
         return {
           name,

--- a/src/components/common/CollapsableCard.vue
+++ b/src/components/common/CollapsableCard.vue
@@ -297,7 +297,6 @@ export default class CollapsableCard extends Vue {
 
   set isCollapsed (collapsed: boolean) {
     const value = this.layout
-    console.log(value, this._layoutPath)
     if (value && this._layoutPath) {
       value.collapsed = collapsed
       this.$store.dispatch('layout/onUpdateConfig', { name: this._layoutPath.name, value })
@@ -323,7 +322,6 @@ export default class CollapsableCard extends Vue {
     const value = this.layout
     if (value && this._layoutPath) {
       value.enabled = enabled
-      console.log({ ...this._layoutPath }, value)
       this.$store.dispatch('layout/onUpdateConfig', { name: this._layoutPath.name, value })
     }
   }

--- a/src/components/layout/AppBar.vue
+++ b/src/components/layout/AppBar.vue
@@ -138,6 +138,22 @@
         @click.stop="handleResetLayout"
         v-html="$t('app.general.btn.reset_layout')"
       />
+      <template v-if="isDashboard">
+        <app-btn
+          small
+          class="mx-2 ml-8"
+          color="primary"
+          @click.stop="handleSetDefaultLayout"
+          v-html="$t('app.general.btn.set_default_layout')"
+        />
+        <app-btn
+          small
+          class="mx-2"
+          color="primary"
+          @click.stop="handleResetDefaultLayout"
+          v-html="$t('app.general.btn.reset_default_layout')"
+        />
+      </template>
     </template>
 
     <user-password-dialog
@@ -240,17 +256,45 @@ export default class AppBar extends Mixins(StateMixin, ServicesMixin) {
     this.$store.commit('config/setLayoutMode', false)
   }
 
+  get isDashboard () {
+    return this.$route.path === '/'
+  }
+
   handleResetLayout () {
     const pathLayouts = {
       '/diagnostics': 'diagnostics'
-    } as { [key: string]: string }
+    } as Record<string, string>
 
-    const toReset = pathLayouts[this.$route.path] ?? this.$store.getters['layout/getSpecificLayout']
-    const layoutDefaultState = defaultState()
+    const pathLayout = pathLayouts[this.$route.path]
+    let layoutDefaultState
+    if (pathLayout) {
+      // reset to default init state
+      layoutDefaultState = defaultState().layouts[pathLayouts[this.$route.path]]
+    } else {
+      // reset dashboard to default layout
+      layoutDefaultState = this.$store.getters['layout/getLayout']('dashboard')
+    }
+
+    const toReset = pathLayout ?? this.$store.getters['layout/getSpecificLayout']
 
     this.$store.dispatch('layout/onLayoutChange', {
       name: toReset,
-      value: layoutDefaultState.layouts[toReset]
+      value: layoutDefaultState
+    })
+  }
+
+  handleSetDefaultLayout () {
+    const currentLayoutName = this.$store.getters['layout/getSpecificLayout']
+    this.$store.dispatch('layout/onLayoutChange', {
+      name: 'dashboard',
+      value: this.$store.getters['layout/getLayout'](currentLayoutName)
+    })
+  }
+
+  handleResetDefaultLayout () {
+    this.$store.dispatch('layout/onLayoutChange', {
+      name: 'dashboard',
+      value: defaultState().layouts.dashboard
     })
   }
 

--- a/src/components/layout/AppBar.vue
+++ b/src/components/layout/AppBar.vue
@@ -139,9 +139,13 @@
         v-html="$t('app.general.btn.reset_layout')"
       />
       <template v-if="isDashboard">
+        <v-divider
+          vertical
+          class="mx-2"
+        />
         <app-btn
           small
-          class="mx-2 ml-8"
+          class="mx-2"
           color="primary"
           @click.stop="handleSetDefaultLayout"
           v-html="$t('app.general.btn.set_default_layout')"

--- a/src/components/layout/AppBar.vue
+++ b/src/components/layout/AppBar.vue
@@ -245,7 +245,7 @@ export default class AppBar extends Mixins(StateMixin, ServicesMixin) {
       '/diagnostics': 'diagnostics'
     } as { [key: string]: string }
 
-    const toReset = pathLayouts[this.$route.path] ?? 'dashboard'
+    const toReset = pathLayouts[this.$route.path] ?? this.$store.getters['layout/getSpecificLayout']
     const layoutDefaultState = defaultState()
 
     this.$store.dispatch('layout/onLayoutChange', {

--- a/src/components/layout/AppBar.vue
+++ b/src/components/layout/AppBar.vue
@@ -279,7 +279,7 @@ export default class AppBar extends Mixins(StateMixin, ServicesMixin) {
       layoutDefaultState = this.$store.getters['layout/getLayout']('dashboard')
     }
 
-    const toReset = pathLayout ?? this.$store.getters['layout/getSpecificLayout']
+    const toReset = pathLayout ?? this.$store.getters['layout/getSpecificLayoutName']
 
     this.$store.dispatch('layout/onLayoutChange', {
       name: toReset,
@@ -288,7 +288,7 @@ export default class AppBar extends Mixins(StateMixin, ServicesMixin) {
   }
 
   handleSetDefaultLayout () {
-    const currentLayoutName = this.$store.getters['layout/getSpecificLayout']
+    const currentLayoutName = this.$store.getters['layout/getSpecificLayoutName']
     this.$store.dispatch('layout/onLayoutChange', {
       name: 'dashboard',
       value: this.$store.getters['layout/getLayout'](currentLayoutName)

--- a/src/components/layout/AppBar.vue
+++ b/src/components/layout/AppBar.vue
@@ -273,7 +273,7 @@ export default class AppBar extends Mixins(StateMixin, ServicesMixin) {
     let layoutDefaultState
     if (pathLayout) {
       // reset to default init state
-      layoutDefaultState = defaultState().layouts[pathLayouts[this.$route.path]]
+      layoutDefaultState = defaultState().layouts[pathLayout]
     } else {
       // reset dashboard to default layout
       layoutDefaultState = this.$store.getters['layout/getLayout']('dashboard')

--- a/src/components/widgets/filesystem/FileSystemContextMenu.vue
+++ b/src/components/widgets/filesystem/FileSystemContextMenu.vue
@@ -159,7 +159,7 @@ export default class FileSystemContextMenu extends Mixins(StateMixin, FilesMixin
   }
 
   get canPreviewGcode () {
-    return (this.$store.getters['layout/isEnabledInLayout']('dashboard', 'gcode-preview-card') && this.root === 'gcodes')
+    return (this.$store.getters['layout/isEnabledInLayout'](this.$store.getters['layout/getSpecificLayout'], 'gcode-preview-card') && this.root === 'gcodes')
   }
 }
 </script>

--- a/src/components/widgets/filesystem/FileSystemContextMenu.vue
+++ b/src/components/widgets/filesystem/FileSystemContextMenu.vue
@@ -159,7 +159,7 @@ export default class FileSystemContextMenu extends Mixins(StateMixin, FilesMixin
   }
 
   get canPreviewGcode () {
-    const layoutName = this.$store.getters['layout/getSpecificLayout']
+    const layoutName = this.$store.getters['layout/getSpecificLayoutName']
     return (this.$store.getters['layout/isEnabledInLayout'](layoutName, 'gcode-preview-card') && this.root === 'gcodes')
   }
 }

--- a/src/components/widgets/filesystem/FileSystemContextMenu.vue
+++ b/src/components/widgets/filesystem/FileSystemContextMenu.vue
@@ -159,7 +159,8 @@ export default class FileSystemContextMenu extends Mixins(StateMixin, FilesMixin
   }
 
   get canPreviewGcode () {
-    return (this.$store.getters['layout/isEnabledInLayout'](this.$store.getters['layout/getSpecificLayout'], 'gcode-preview-card') && this.root === 'gcodes')
+    const layoutName = this.$store.getters['layout/getSpecificLayout']
+    return (this.$store.getters['layout/isEnabledInLayout'](layoutName, 'gcode-preview-card') && this.root === 'gcodes')
   }
 }
 </script>

--- a/src/locales/de.yaml
+++ b/src/locales/de.yaml
@@ -165,7 +165,8 @@ app:
       rename: Umbenennen
       reprint: Druck wiederholen
       reset_file: Datei zurücksetzen
-      reset_layout: Layout zurücksetzen
+      reset_layout: Auf Standardlayout zurücksetzen
+      reset_default_layout: Standardlayout zurücksetzen
       restart_firmware: Firmware Neustarten
       restart_service: '%{service} neustarten'
       restart_service_klipper: Klipper neustarten
@@ -177,6 +178,7 @@ app:
       save_restart: Speichern & Neu starten
       send: Senden
       set_color: Farbe setzen
+      set_default_layout: Als Standardlayout setzen
       shutdown: Herunterfahren
       socket_reconnect: Neu verbinden
       socket_refresh: Aktualisieren erzwingen

--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -165,7 +165,8 @@ app:
       rename: Rename
       reprint: Re-Print
       reset_file: Clear File
-      reset_layout: Reset Layout
+      reset_layout: Reset to Default Layout
+      reset_default_layout: Reset Default Layout
       restart_firmware: Firmware Restart
       restart_service: Restart %{service}
       restart_service_klipper: Restart Klipper
@@ -178,6 +179,7 @@ app:
       save_config_and_restart: Save config & restart
       send: Send
       set_color: Set Color
+      set_default_layout: Set as Default Layout
       shutdown: Shutdown
       snooze: Snooze
       socket_reconnect: Re-Connect

--- a/src/store/layout/actions.ts
+++ b/src/store/layout/actions.ts
@@ -18,7 +18,7 @@ export const actions: ActionTree<LayoutState, RootState> = {
 
   async onLayoutChange ({ commit, state }, payload: { name: string; value: LayoutConfig }) {
     const layout = state.layouts[payload.name]
-    if (layout) {
+    if (layout || payload.name.startsWith('dashboard')) {
       commit('setLayoutChange', payload)
       await SocketActions.serverWrite(
         Globals.MOONRAKER_DB.fluidd.ROOTS.layout.name + '.layouts',
@@ -27,8 +27,14 @@ export const actions: ActionTree<LayoutState, RootState> = {
     }
   },
 
-  async onUpdateConfig ({ commit, state }, payload: { name: string; value: LayoutConfig }) {
-    const containers = state.layouts[payload.name]
+  async onUpdateConfig ({ commit, state, dispatch }, payload: { name: string; value: LayoutConfig }) {
+    let containers = state.layouts[payload.name]
+    if (!containers) {
+      // user/device specific layout doesn't exist yet, so we create it
+      dispatch('onLayoutChange', { name: payload.name, value: state.layouts.dashboard })
+      containers = state.layouts[payload.name]
+    }
+
     if (containers) {
       for (const container in containers) {
         const i = containers[container].findIndex(layout => layout.id === payload.value.id)

--- a/src/store/layout/getters.ts
+++ b/src/store/layout/getters.ts
@@ -2,6 +2,7 @@ import { GetterTree } from 'vuex'
 import { LayoutState, LayoutContainer, LayoutConfig } from './types'
 import { RootState } from '../types'
 import { cloneDeep } from 'lodash-es'
+import vuetify from '@/plugins/vuetify'
 
 export const getters: GetterTree<LayoutState, RootState> = {
   /**
@@ -24,6 +25,8 @@ export const getters: GetterTree<LayoutState, RootState> = {
     if (state.layouts[name]) {
       return cloneDeep(state.layouts[name])
       // return { ...state.layouts[name] }
+    } else if (name.startsWith('dashboard')) {
+      return cloneDeep(state.layouts.dashboard)
     }
   },
 
@@ -53,5 +56,13 @@ export const getters: GetterTree<LayoutState, RootState> = {
         if (config) return { ...config }
       }
     }
+  },
+
+  getSpecificLayout: (state, getters, rootState, rootGetters): string => {
+    const user = rootGetters['auth/getCurrentUser']
+    if (!user) return 'dashboard'
+
+    const size = vuetify.framework.breakpoint.name
+    return `dashboard-${size}-${user.username}`
   }
 }

--- a/src/store/layout/getters.ts
+++ b/src/store/layout/getters.ts
@@ -58,7 +58,7 @@ export const getters: GetterTree<LayoutState, RootState> = {
     }
   },
 
-  getSpecificLayout: (state, getters, rootState, rootGetters): string => {
+  getSpecificLayoutName: (state, getters, rootState, rootGetters): string => {
     const user = rootGetters['auth/getCurrentUser']
     if (!user) return 'dashboard'
 

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -131,7 +131,7 @@ export default class Dashboard extends Mixins(StateMixin) {
   }
 
   get layout () {
-    return this.$store.getters['layout/getLayout']('dashboard')
+    return this.$store.getters['layout/getLayout'](this.$store.getters['layout/getSpecificLayout'])
   }
 
   @Watch('layout')
@@ -172,7 +172,7 @@ export default class Dashboard extends Mixins(StateMixin) {
   handleStopDrag () {
     this.drag = false
     this.$store.dispatch('layout/onLayoutChange', {
-      name: 'dashboard',
+      name: this.layoutName,
       value: {
         container1: this.containers[0],
         container2: this.containers[1],

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -131,7 +131,7 @@ export default class Dashboard extends Mixins(StateMixin) {
   }
 
   get layout () {
-    const layoutName = this.$store.getters['layout/getSpecificLayout']
+    const layoutName = this.$store.getters['layout/getSpecificLayoutName']
     return this.$store.getters['layout/getLayout'](layoutName)
   }
 
@@ -173,7 +173,7 @@ export default class Dashboard extends Mixins(StateMixin) {
   handleStopDrag () {
     this.drag = false
     this.$store.dispatch('layout/onLayoutChange', {
-      name: this.$store.getters['layout/getSpecificLayout'],
+      name: this.$store.getters['layout/getSpecificLayoutName'],
       value: {
         container1: this.containers[0],
         container2: this.containers[1],

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -131,7 +131,8 @@ export default class Dashboard extends Mixins(StateMixin) {
   }
 
   get layout () {
-    return this.$store.getters['layout/getLayout'](this.$store.getters['layout/getSpecificLayout'])
+    const layoutName = this.$store.getters['layout/getSpecificLayout']
+    return this.$store.getters['layout/getLayout'](layoutName)
   }
 
   @Watch('layout')

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -172,7 +172,7 @@ export default class Dashboard extends Mixins(StateMixin) {
   handleStopDrag () {
     this.drag = false
     this.$store.dispatch('layout/onLayoutChange', {
-      name: this.layoutName,
+      name: this.$store.getters['layout/getSpecificLayout'],
       value: {
         container1: this.containers[0],
         container2: this.containers[1],


### PR DESCRIPTION
Creates user and device specific layouts on layout change (based on concatenation of `dashboard-{user}-{device-size}`, clones current `dashboard` if no custom one exists yet).

Allows the overriding of the default layout for new users (or other devices), which can also be reset to the initial state.
Not 100% sure about the placement and usage of header buttons here, but it's what was there before:
![image](https://user-images.githubusercontent.com/25269274/192634610-88df68db-ac91-433e-8008-2e6012f90e4d.png)

Closes #370
Closes #410
