### PR TITLE
fix: check stepper_z exists before applying z_offset

### DIFF
--- a/src/components/widgets/toolhead/ZHeightAdjust.vue
+++ b/src/components/widgets/toolhead/ZHeightAdjust.vue
@@ -131,7 +131,9 @@ export default class ZHeightAdjust extends Mixins(StateMixin) {
   }
 
   get printerUsesProbeAsEndstop (): boolean {
-    return this.$store.getters['printer/getPrinterSettings']('stepper_z.endstop_pin') === 'probe:z_virtual_endstop'
+    const stepper = this.$store.getters['printer/getPrinterSettings']('stepper_z')
+
+    return !stepper || stepper.endstop_pin === 'probe:z_virtual_endstop'
   }
 
   async handleZApplyDialog () {


### PR DESCRIPTION
If there is no `stepper_z` in the config, we can't call `Z_OFFSET_APPLY_ENDSTOP`, so just assume we are using a probe and call `Z_OFFSET_APPLY_PROBE` instead.

Fixes #889 

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>