### PR TITLE
style: consistent margins across all card buttons

### DIFF
--- a/src/components/widgets/bedmesh/BedMeshCard.vue
+++ b/src/components/widgets/bedmesh/BedMeshCard.vue
@@ -14,7 +14,7 @@
       <app-btn
         color=""
         fab
-        small
+        x-small
         text
         @click="$filters.routeTo($router, '/tune')"
       >

--- a/src/components/widgets/console/ConsoleCard.vue
+++ b/src/components/widgets/console/ConsoleCard.vue
@@ -30,6 +30,7 @@
         fab
         x-small
         text
+        class="ml-1"
         @click="console.scrollToLatest(true)"
       >
         <v-icon>{{ flipLayout ? '$up' : '$down' }}</v-icon>
@@ -39,8 +40,9 @@
         v-if="!fullScreen"
         color=""
         fab
-        small
+        x-small
         text
+        class="ml-1"
         @click="$filters.routeTo($router, '/console')"
       >
         <v-icon>$fullScreen</v-icon>
@@ -51,6 +53,7 @@
         fab
         x-small
         text
+        class="ml-1"
         @click="handleClear"
       >
         <v-icon>$delete</v-icon>

--- a/src/components/widgets/endstops/EndStopsCard.vue
+++ b/src/components/widgets/endstops/EndStopsCard.vue
@@ -11,6 +11,7 @@
         fab
         x-small
         text
+        class="ml-1"
         @click="queryEndstops"
       >
         <v-icon>$refresh</v-icon>

--- a/src/components/widgets/gcode-preview/GcodePreviewCard.vue
+++ b/src/components/widgets/gcode-preview/GcodePreviewCard.vue
@@ -10,6 +10,7 @@
         <app-btn
           :disabled="!printerFile || printerFileLoaded"
           small
+          class="ml-1"
           @click="loadCurrent"
         >
           {{ $t('app.gcode.btn.load_current_file') }}

--- a/src/components/widgets/jobs/JobsCard.vue
+++ b/src/components/widgets/jobs/JobsCard.vue
@@ -9,7 +9,7 @@
       <app-btn
         color=""
         fab
-        small
+        x-small
         text
         @click="$filters.routeTo($router, '/jobs')"
       >

--- a/src/components/widgets/system/McuCard.vue
+++ b/src/components/widgets/system/McuCard.vue
@@ -9,6 +9,7 @@
         fab
         x-small
         text
+        class="ml-1"
         @click="showMcuConstantsDialog"
       >
         <v-icon>$viewHeadline</v-icon>

--- a/src/components/widgets/thermals/TemperatureCard.vue
+++ b/src/components/widgets/thermals/TemperatureCard.vue
@@ -22,8 +22,8 @@
       <app-btn-collapse-group :collapsed="menuCollapsed">
         <app-btn
           small
-          class="ma-1"
           :disabled="!klippyReady"
+          class="ml-1"
           @click="chartVisible = !chartVisible"
         >
           <v-icon left>
@@ -33,7 +33,6 @@
         </app-btn>
 
         <temperature-presets-menu
-          class="ma-1"
           @applyOff="handleApplyOff"
           @applyPreset="handleApplyPreset"
         />

--- a/src/components/widgets/thermals/TemperaturePresetsMenu.vue
+++ b/src/components/widgets/thermals/TemperaturePresetsMenu.vue
@@ -11,6 +11,7 @@
         :disabled="!klippyReady"
         v-bind="attrs"
         small
+        class="ml-1"
         v-on="on"
       >
         <v-icon


### PR DESCRIPTION
Changes are quite subtle and just in terms of making sure that the left-margin on all the buttons is set to 1.

I also changed the full-screen button from small to x-small, making it consistent with the rest of the buttons.

Before:

![image](https://user-images.githubusercontent.com/85504/194309539-1b6ed6e3-bad9-4823-ad92-f73dfaa5b3d7.png)

After:

![image](https://user-images.githubusercontent.com/85504/194309450-2b17f025-5748-4899-84d9-3e6681c94813.png)

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>