### PR TITLE
fix: allow initial layer in GcodePreviewCard

### DIFF
--- a/src/components/widgets/gcode-preview/GcodePreviewCard.vue
+++ b/src/components/widgets/gcode-preview/GcodePreviewCard.vue
@@ -181,10 +181,6 @@ export default class GcodePreviewCard extends Mixins(StateMixin, FilesMixin) {
   moveProgress = 0
   excludeObjectDialog = false
 
-  get visibleLayer () {
-    return this.currentLayer + 1
-  }
-
   @Watch('layerCount')
   onLayerCountChanged () {
     this.currentLayer = 0
@@ -293,7 +289,7 @@ export default class GcodePreviewCard extends Mixins(StateMixin, FilesMixin) {
   }
 
   get currentLayerHeight (): number {
-    return this.$store.getters['gcodePreview/getLayers'][this.currentLayer - 1]?.z ?? 0
+    return this.$store.getters['gcodePreview/getLayers'][this.currentLayer]?.z ?? 0
   }
 
   get followProgress (): boolean {
@@ -323,7 +319,7 @@ export default class GcodePreviewCard extends Mixins(StateMixin, FilesMixin) {
   }
 
   setCurrentLayer (value: number) {
-    if (value > 0) this.currentLayer = value
+    if (value >= 0) this.currentLayer = value
   }
 
   setMoveProgress (value: number) {


### PR DESCRIPTION
This fixes an issue where the GCodePreviewCard has a slider to select the current layer, and that start at 1, but the backend `currentLayer` starts at 0, however the `setCurrentLayer` was incorrectly checking for `> 0`, so we could never select the initial layer.

The `currentLayerHeight` needs to be based on the actual current layer and not on the previous one as that could be from a different object on a multi-print and thus show the incorrect value.

I also removed `visibleLayer` getter as it is not in use anywhere.

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>