### PR TITLE
chore: use latest changelog-reader-action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
           echo ::set-output name=current_version::${GITHUB_REF#refs/tags/v}
 
       - name: Read ChangeLog
-        uses: pedrolamas/changelog-reader-action@d71e9d8dc93a56c192a84bddd8af46cf3b1d284b
+        uses: mindsers/changelog-reader-action@v2.2.0
         id: changelog
         with:
           validation_depth: 1


### PR DESCRIPTION
Reverts the fixes from #688 as new version of this action has been published that (hopefully) fixes the issues we've been seeing.

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>