### PR TITLE
chore: removes duplicate auto-complete entries

### DIFF
--- a/src/store/console/getters.ts
+++ b/src/store/console/getters.ts
@@ -41,9 +41,7 @@ export const getters: GetterTree<ConsoleState, RootState> = {
       'TESTZ',
       'ABORT',
       'ACCEPT',
-      'ADJUSTED',
-      'GET_POSITION',
-      'SET_RETRACTION'
+      'ADJUSTED'
     ]
     additional.forEach(command => {
       if (command in commands !== true) {


### PR DESCRIPTION
Not a big deal change, but `GET_POSITION` and `SET_RETRACTION` are provided from Klipper via Moonraker API, so there is no need to add these here.

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>