### PR TITLE
fix: disable controls if Klipper not ready

### DIFF
--- a/src/components/ui/AppBtnCollapseGroup.vue
+++ b/src/components/ui/AppBtnCollapseGroup.vue
@@ -13,6 +13,7 @@
     transition="slide-y-transition"
     left
     offset-y
+    :disabled="disabled"
     :close-on-content-click="false"
   >
     <template #activator="{ on, attrs }">
@@ -20,6 +21,7 @@
         fab
         :x-small="size === 'x-small'"
         :small="size === 'small'"
+        :disabled="disabled"
         text
         color=""
         v-bind="attrs"
@@ -51,6 +53,9 @@ export default class AppBtnCollapseGroup extends Vue {
 
   @Prop({ type: String, default: 'x-small' })
   readonly size!: string
+
+  @Prop({ type: Boolean, default: false })
+  readonly disabled!: boolean
 
   get isCollapsed () {
     if (this.collapsed) return true

--- a/src/components/widgets/filesystem/FileSystemContextMenu.vue
+++ b/src/components/widgets/filesystem/FileSystemContextMenu.vue
@@ -20,20 +20,26 @@
             <v-list-item
               v-if="canPrint"
               link
+              :disabled="!printerReady"
               @click="$emit('print', file)"
             >
               <v-list-item-icon>
-                <v-icon>$printer</v-icon>
+                <v-icon :disabled="!printerReady">
+                  $printer
+                </v-icon>
               </v-list-item-icon>
               <v-list-item-title>{{ $t('app.general.btn.print') }}</v-list-item-title>
             </v-list-item>
             <v-list-item
               v-if="canPreheat"
               link
+              :disabled="!printerReady"
               @click="$emit('preheat', file)"
             >
               <v-list-item-icon>
-                <v-icon>$fire</v-icon>
+                <v-icon :disabled="!printerReady">
+                  $fire
+                </v-icon>
               </v-list-item-icon>
               <v-list-item-title>{{ $t('app.general.btn.preheat') }}</v-list-item-title>
             </v-list-item>
@@ -155,17 +161,17 @@ export default class FileSystemContextMenu extends Mixins(StateMixin, FilesMixin
   }
 
   get canPrint () {
-    return this.file.type !== 'directory' &&
+    return (
+      this.file.type !== 'directory' &&
       this.rootProperties.accepts.includes('.' + this.file.extension) &&
-      this.rootProperties.canPrint &&
-      this.printerReady
+      this.rootProperties.canPrint
+    )
   }
 
   get canPreheat () {
     return (
       'first_layer_extr_temp' in this.file &&
-      'first_layer_bed_temp' in this.file &&
-      this.printerReady
+      'first_layer_bed_temp' in this.file
     )
   }
 

--- a/src/components/widgets/filesystem/FileSystemContextMenu.vue
+++ b/src/components/widgets/filesystem/FileSystemContextMenu.vue
@@ -176,9 +176,11 @@ export default class FileSystemContextMenu extends Mixins(StateMixin, FilesMixin
   }
 
   get printerReady () {
-    return !this.printerPrinting &&
+    return (
+      !this.printerPrinting &&
       !this.printerPaused &&
       this.klippyReady
+    )
   }
 
   get canPreviewGcode () {

--- a/src/components/widgets/filesystem/FileSystemContextMenu.vue
+++ b/src/components/widgets/filesystem/FileSystemContextMenu.vue
@@ -16,11 +16,9 @@
         no-gutters
       >
         <v-col>
-          <v-list
-            dense
-          >
+          <v-list dense>
             <v-list-item
-              v-if="file.type !== 'directory' && rootProperties.accepts.includes('.' + file.extension) && rootProperties.canPrint"
+              v-if="canPrint"
               link
               @click="$emit('print', file)"
             >
@@ -80,7 +78,7 @@
               <v-list-item-title>{{ $t('app.general.btn.preview_gcode') }}</v-list-item-title>
             </v-list-item>
             <v-list-item
-              v-if="file.type !== 'directory' && file.thumbnails?.length"
+              v-if="'thumbnails' in file && file.thumbnails && file.thumbnails.length"
               link
               @click="$emit('view-thumbnail', file)"
             >
@@ -156,14 +154,25 @@ export default class FileSystemContextMenu extends Mixins(StateMixin, FilesMixin
     return this.$store.getters['files/getRootProperties'](this.root)
   }
 
+  get canPrint () {
+    return this.file.type !== 'directory' &&
+      this.rootProperties.accepts.includes('.' + this.file.extension) &&
+      this.rootProperties.canPrint &&
+      this.printerReady
+  }
+
   get canPreheat () {
     return (
       'first_layer_extr_temp' in this.file &&
       'first_layer_bed_temp' in this.file &&
-      !this.printerPrinting &&
+      this.printerReady
+    )
+  }
+
+  get printerReady () {
+    return !this.printerPrinting &&
       !this.printerPaused &&
       this.klippyReady
-    )
   }
 
   get canPreviewGcode () {

--- a/src/views/Tune.vue
+++ b/src/views/Tune.vue
@@ -1,7 +1,10 @@
 <template>
-  <v-row :dense="$vuetify.breakpoint.smAndDown">
+  <v-row
+    v-if="klippyReady"
+    :dense="$vuetify.breakpoint.smAndDown"
+  >
     <v-col
-      v-if="supportsBedMesh && klippyReady"
+      v-if="supportsBedMesh"
       cols="12"
       md="8"
     >
@@ -12,7 +15,7 @@
       md="4"
     >
       <bed-mesh-controls
-        v-if="supportsBedMesh && klippyReady"
+        v-if="supportsBedMesh"
         class="mb-2 mb-sm-4"
       />
       <end-stops-card class="mb-2 mb-sm-4" />


### PR DESCRIPTION
Disables the following controls if `klipperReady` is false:

- `Print` and `Preheat` on the file context menu
- All the panels in the "Tune" page

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>