### PR TITLE
style: open fullscreen thumbnails on thumbnail click

### DIFF
--- a/src/components/widgets/filesystem/FileSystemContextMenu.vue
+++ b/src/components/widgets/filesystem/FileSystemContextMenu.vue
@@ -84,16 +84,6 @@
               <v-list-item-title>{{ $t('app.general.btn.preview_gcode') }}</v-list-item-title>
             </v-list-item>
             <v-list-item
-              v-if="'thumbnails' in file && file.thumbnails && file.thumbnails.length"
-              link
-              @click="$emit('view-thumbnail', file)"
-            >
-              <v-list-item-icon>
-                <v-icon>$imageSizeSelectLarge</v-icon>
-              </v-list-item-icon>
-              <v-list-item-title>{{ $t('app.general.btn.view_thumbnail') }}</v-list-item-title>
-            </v-list-item>
-            <v-list-item
               v-if="!rootProperties.readonly"
               link
               @click="$emit('rename', file)"
@@ -120,9 +110,10 @@
           class="px-2 d-none d-sm-flex"
         >
           <img
-            class="mr-2 ml-2"
+            class="mr-2 ml-2 thumbnail"
             :src="getThumbUrl(file.thumbnails, file.path, true, file.modified)"
             :height="150"
+            @click="$emit('view-thumbnail', file)"
           >
         </v-col>
       </v-row>
@@ -189,3 +180,9 @@ export default class FileSystemContextMenu extends Mixins(StateMixin, FilesMixin
   }
 }
 </script>
+
+<style lang="scss" scoped>
+  .thumbnail {
+    cursor: pointer;
+  }
+</style>

--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -193,7 +193,6 @@ app:
       upload: Upload
       upload_print: Upload & Print
       view: View
-      view_thumbnail: View Thumbnail
       reset_stats: Reset Stats
     error:
       app_setup_link: >-

--- a/src/locales/hu.yaml
+++ b/src/locales/hu.yaml
@@ -197,7 +197,6 @@ app:
       upload: Feltöltés
       upload_print: Feltöltés & Nyomtatás
       view: Nézet
-      view_thumbnail: Miniatűr mutatása
       reset_stats: Statisztikák törlése
     error:
       app_setup_link: >-


### PR DESCRIPTION
Removes the "View Thumbnail" button from the UI and replaces it with the functionality to simply click the thumbnail in order to open it in the file previewer.

Maybe the `zoom-in` cursor style is more appropriate here?

Follow-Up for #891