### PR TITLE
feat: uses macro description as button tooltip

### DIFF
--- a/src/components/ui/AppMacroBtn.vue
+++ b/src/components/ui/AppMacroBtn.vue
@@ -1,45 +1,25 @@
 <template>
-  <v-tooltip
+  <app-btn
     v-if="paramList.length === 0 || !enableParams"
-    :disabled="!description"
-    bottom
+    :disabled="(macro.disabledWhilePrinting && printerPrinting) || !klippyReady"
+    :style="borderStyle"
+    @click="$emit('click', macro.name)"
+    v-on="$listeners"
   >
-    <template #activator="{ on, attrs }">
-      <app-btn
-        v-bind="attrs"
-        :disabled="(macro.disabledWhilePrinting && printerPrinting) || !klippyReady"
-        :style="borderStyle"
-        class="me-2 mb-2"
-        v-on="on"
-        @click="$emit('click', macro.name)"
-      >
-        <slot />
-      </app-btn>
-    </template>
-    <span>{{ description }}</span>
-  </v-tooltip>
-
+    <slot />
+  </app-btn>
   <app-btn-group
     v-else
     :elevation="6"
   >
-    <v-tooltip
-      :disabled="!description"
-      bottom
+    <app-btn
+      :disabled="(macro.disabledWhilePrinting && printerPrinting) || !klippyReady"
+      :style="borderStyle"
+      @click="$emit('click', macro.name)"
+      v-on="$listeners"
     >
-      <template #activator="{ on, attrs }">
-        <app-btn
-          v-bind="attrs"
-          :disabled="(macro.disabledWhilePrinting && printerPrinting) || !klippyReady"
-          :style="borderStyle"
-          v-on="on"
-          @click="$emit('click', macro.name)"
-        >
-          <slot />
-        </app-btn>
-      </template>
-      <span>{{ description }}</span>
-    </v-tooltip>
+      <slot />
+    </app-btn>
     <v-menu
       left
       offset-y
@@ -125,12 +105,6 @@ export default class AppMacroBtn extends Mixins(StateMixin) {
   readonly enableParams!: boolean
 
   params: { [index: string]: { value: string | number; reset: string | number }} = {}
-
-  get description () {
-    if (!this.macro.config || this.macro.config.description === 'G-Code macro') return undefined
-
-    return this.macro.config.description
-  }
 
   get paramList () {
     return Object.keys(this.params)

--- a/src/components/widgets/macros/Macros.vue
+++ b/src/components/widgets/macros/Macros.vue
@@ -39,18 +39,27 @@
         </v-expansion-panel-header>
 
         <v-expansion-panel-content>
-          <app-macro-btn
+          <v-tooltip
             v-for="macro in category.macros"
             :key="`category-${macro.name}`"
-            :macro="macro"
-            :loading="hasWait(`${waits.onMacro}${macro.name}`)"
-            :elevation="2"
-            enable-params
-            class="me-2 mb-2 float-left"
-            @click="sendGcode($event, `${waits.onMacro}${macro.name}`)"
+            bottom
           >
-            {{ macro.alias || macro.name }}
-          </app-macro-btn>
+            <template #activator="{ on, attrs }">
+              <app-macro-btn
+                v-bind="attrs"
+                :macro="macro"
+                :loading="hasWait(`${waits.onMacro}${macro.name}`)"
+                :elevation="2"
+                enable-params
+                class="me-2 mb-2 float-left"
+                v-on="on"
+                @click="sendGcode($event, `${waits.onMacro}${macro.name}`)"
+              >
+                {{ macro.alias || macro.name }}
+              </app-macro-btn>
+            </template>
+            <span>{{ macro.config.description }}</span>
+          </v-tooltip>
         </v-expansion-panel-content>
       </v-expansion-panel>
 
@@ -90,19 +99,27 @@
         </v-expansion-panel-header>
 
         <v-expansion-panel-content>
-          <template v-for="macro in uncategorizedMacros">
-            <app-macro-btn
-              :key="`category-${macro.name}`"
-              :macro="macro"
-              :loading="hasWait(`${waits.onMacro}${macro.name}`)"
-              :elevation="2"
-              enable-params
-              class="me-2 mb-2 float-left"
-              @click="sendGcode($event, `${waits.onMacro}${macro.name}`)"
-            >
-              {{ macro.alias || macro.name }}
-            </app-macro-btn>
-          </template>
+          <v-tooltip
+            v-for="macro in uncategorizedMacros"
+            :key="`category-${macro.name}`"
+            bottom
+          >
+            <template #activator="{ on, attrs }">
+              <app-macro-btn
+                v-bind="attrs"
+                :macro="macro"
+                :loading="hasWait(`${waits.onMacro}${macro.name}`)"
+                :elevation="2"
+                enable-params
+                class="me-2 mb-2 float-left"
+                v-on="on"
+                @click="sendGcode($event, `${waits.onMacro}${macro.name}`)"
+              >
+                {{ macro.alias || macro.name }}
+              </app-macro-btn>
+            </template>
+            <span>{{ macro.config.description }}</span>
+          </v-tooltip>
         </v-expansion-panel-content>
       </v-expansion-panel>
     </v-expansion-panels>


### PR DESCRIPTION
All macro buttons will show the description configured on Klipper as a tooltip:

![image](https://user-images.githubusercontent.com/85504/196012263-1621ac53-bd0e-4f8d-bb8b-db1c6449e865.png)

M117 and M118 (only visible if overrided!) will now only show a single "message" parameter:

![image](https://user-images.githubusercontent.com/85504/196012252-f9a1f126-ce56-49e0-be67-179f16e03157.png)

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>