### PR TITLE
style: move macro tooltips to the top of the buttons

### DIFF
--- a/src/components/widgets/macros/Macros.vue
+++ b/src/components/widgets/macros/Macros.vue
@@ -42,7 +42,7 @@
           <v-tooltip
             v-for="macro in category.macros"
             :key="`category-${macro.name}`"
-            bottom
+            top
           >
             <template #activator="{ on, attrs }">
               <app-macro-btn
@@ -102,7 +102,7 @@
           <v-tooltip
             v-for="macro in uncategorizedMacros"
             :key="`category-${macro.name}`"
-            bottom
+            top
           >
             <template #activator="{ on, attrs }">
               <app-macro-btn


### PR DESCRIPTION
Moving macro buttons tooltips to the top for consistency purposes (matches the toolhead controls) and also this way the mouse cursor never blocks them!

![image](https://user-images.githubusercontent.com/85504/196394738-b34199dd-9ab3-41d2-9cd5-ebcf2a8c4f6c.png)

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>