### PR TITLE
Replaces static error messages with translations

### DIFF
--- a/src/components/settings/GcodePreviewSettings.vue
+++ b/src/components/settings/GcodePreviewSettings.vue
@@ -48,7 +48,7 @@
           filled
           dense
           single-line
-          hide-details
+          hide-details="auto"
           suffix="mm"
           @change="setExtrusionLineWidth"
         />
@@ -63,7 +63,7 @@
           filled
           dense
           single-line
-          hide-details
+          hide-details="auto"
           suffix="mm"
           @change="setMoveLineWidth"
         />
@@ -78,7 +78,7 @@
           filled
           dense
           single-line
-          hide-details
+          hide-details="auto"
           suffix="mm"
           @change="setRetractionIconSize"
         />
@@ -153,8 +153,8 @@ import { defaultState } from '@/store/config/index'
 })
 export default class GcodePreviewSettings extends Vue {
   rules = {
-    numRequired: (v: number | string) => v !== '' || 'Required',
-    numMin: (v: number) => v > 0 || 'Must be greater than 0'
+    numRequired: (v: number | string) => v !== '' || this.$t('app.general.simple_form.error.required'),
+    numMin: (v: number) => v > 0 || this.$t('app.general.simple_form.error.min', { min: 0 })
   }
 
   get extrusionLineWidth () {

--- a/src/components/settings/ToolheadSettings.vue
+++ b/src/components/settings/ToolheadSettings.vue
@@ -59,7 +59,7 @@
           filled
           dense
           single-line
-          hide-details
+          hide-details="auto"
           suffix="mm"
           @change="setDefaultExtrudeLength"
         />
@@ -74,7 +74,7 @@
           filled
           dense
           single-line
-          hide-details
+          hide-details="auto"
           suffix="mm/s"
           @change="setDefaultExtrudeSpeed"
         />
@@ -90,7 +90,7 @@
           filled
           dense
           single-line
-          hide-details
+          hide-details="auto"
           suffix="mm"
           @change="setDefaultToolheadMoveLength"
         />
@@ -105,7 +105,7 @@
           filled
           dense
           single-line
-          hide-details
+          hide-details="auto"
           suffix="mm/s"
           @change="setDefaultToolheadYXSpeed"
         />
@@ -120,7 +120,7 @@
           filled
           dense
           single-line
-          hide-details
+          hide-details="auto"
           suffix="mm/s"
           @change="setDefaultToolheadZSpeed"
         />

--- a/src/components/settings/cameras/CameraConfigDialog.vue
+++ b/src/components/settings/cameras/CameraConfigDialog.vue
@@ -200,7 +200,7 @@ export default class CameraConfigDialog extends Vue {
   readonly camera!: CameraConfig
 
   cameraUrlRules = [
-    (v: string) => !!v || 'Required'
+    (v: string) => !!v || this.$t('app.general.simple_form.error.required')
   ]
 
   valid = false


### PR DESCRIPTION
Replaces static error messages with translations and also ensures these are shown when required.

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>