### PR TITLE
fix: script error on AppMacroBtn click

### DIFF
--- a/src/components/ui/AppMacroBtn.vue
+++ b/src/components/ui/AppMacroBtn.vue
@@ -3,8 +3,10 @@
     v-if="paramList.length === 0 || !enableParams"
     :disabled="(macro.disabledWhilePrinting && printerPrinting) || !klippyReady"
     :style="borderStyle"
-    @click="$emit('click', macro.name)"
-    v-on="$listeners"
+    v-on="{
+      ...$listeners,
+      click: () => $emit('click', macro.name)
+    }"
   >
     <slot />
   </app-btn>
@@ -15,8 +17,10 @@
     <app-btn
       :disabled="(macro.disabledWhilePrinting && printerPrinting) || !klippyReady"
       :style="borderStyle"
-      @click="$emit('click', macro.name)"
-      v-on="$listeners"
+      v-on="{
+        ...$listeners,
+        click: () => $emit('click', macro.name)
+      }"
     >
       <slot />
     </app-btn>


### PR DESCRIPTION
Fixes an error where clicking a macro button shows an error message:

![image](https://user-images.githubusercontent.com/85504/197762777-9f8f9113-5d90-4670-a3d8-5c947fb6391c.png)

This issue was introduced by the changes in #915

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>