### PR TITLE
fix: stop slider animation on navigating to page

### DIFF
--- a/src/components/ui/AppSlider.vue
+++ b/src/components/ui/AppSlider.vue
@@ -206,7 +206,7 @@ export default class AppSlider extends Mixins(StateMixin) {
     return rules
   }
 
-  mounted () {
+  created () {
     this.lockState = this.locked
     this.internalValue = this.value
     this.internalMax = this.max


### PR DESCRIPTION
The AppSlider is animating every time we enter the container page (just go to Dashboard, navigate to another page, then back to Dashboard, and observe the AppSlider controls behavior)

This PR fixes that ensuring the value is set when the slider is created so that the animation does not occur.

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>