### PR TITLE
fix: show html formatted welcome message

### DIFF
--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -16,7 +16,7 @@
         @submit.prevent="handleLogin"
       >
         <div class="text-center">
-          <p>{{ $t('app.general.msg.welcome_back') }} </p>
+          <p v-html="$t('app.general.msg.welcome_back')" />
 
           <v-alert
             v-if="error"


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/85504/198568243-a4dc0038-7b3c-453e-9c16-d1c041aa10de.png)

After:

![image](https://user-images.githubusercontent.com/85504/198568155-75e8b29e-2a3c-404d-85ad-d542e2ab792b.png)

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>