### PR TITLE
chore: move forceMove, extrudeSpeed, extrudeLength state to store

### DIFF
--- a/src/components/widgets/toolhead/ExtruderMoves.vue
+++ b/src/components/widgets/toolhead/ExtruderMoves.vue
@@ -77,8 +77,6 @@ import { Waits } from '@/globals'
 @Component({})
 export default class ExtruderMoves extends Mixins(StateMixin, ToolheadMixin) {
   waits = Waits
-  feedSpeed = -1
-  feedLength = -1
   valid = true
 
   rules = {
@@ -94,31 +92,43 @@ export default class ExtruderMoves extends Mixins(StateMixin, ToolheadMixin) {
   }
 
   get maxExtrudeSpeed () {
-    return this.$store.getters['printer/getPrinterSettings']('extruder.max_extrude_only_velocity')
+    return this.activeExtruder?.max_extrude_only_velocity || 500
   }
 
   get maxExtrudeLength () {
-    return this.$store.getters['printer/getPrinterSettings']('extruder.max_extrude_only_distance')
+    return this.activeExtruder?.max_extrude_only_distance || 50
   }
 
   get extrudeSpeed () {
-    return (this.feedSpeed === -1)
+    const extrudeSpeed = this.$store.state.config.uiSettings.toolhead.extrudeSpeed
+
+    return extrudeSpeed === -1
       ? this.$store.state.config.uiSettings.general.defaultExtrudeSpeed
-      : this.feedSpeed
+      : extrudeSpeed
   }
 
-  set extrudeSpeed (val: number) {
-    this.feedSpeed = val
+  set extrudeSpeed (value: number) {
+    this.$store.dispatch('config/saveByPath', {
+      path: 'uiSettings.toolhead.extrudeSpeed',
+      value,
+      server: false
+    })
   }
 
   get extrudeLength () {
-    return (this.feedLength === -1)
+    const extrudeLength = this.$store.state.config.uiSettings.toolhead.extrudeLength
+
+    return extrudeLength === -1
       ? this.$store.state.config.uiSettings.general.defaultExtrudeLength
-      : this.feedLength
+      : extrudeLength
   }
 
-  set extrudeLength (val: number) {
-    this.feedLength = val
+  set extrudeLength (value: number) {
+    this.$store.dispatch('config/saveByPath', {
+      path: 'uiSettings.toolhead.extrudeLength',
+      value,
+      server: false
+    })
   }
 
   sendRetractGcode (amount: number, rate: number, wait?: string) {

--- a/src/components/widgets/toolhead/Toolhead.vue
+++ b/src/components/widgets/toolhead/Toolhead.vue
@@ -7,15 +7,12 @@
     >
       <v-col class="controls-wrapper">
         <extruder-selection v-if="multipleExtruders" />
-        <toolhead-moves
-          v-if="!printerPrinting"
-          :force-move="forceMove"
-        />
+        <toolhead-moves v-if="!printerPrinting" />
         <z-height-adjust v-if="printerPrinting" />
       </v-col>
 
       <v-col class="controls-wrapper">
-        <toolhead-position :force-move="forceMove" />
+        <toolhead-position />
         <extruder-moves v-if="!printerPrinting" />
         <z-height-adjust v-if="!printerPrinting" />
       </v-col>
@@ -28,7 +25,7 @@
 </template>
 
 <script lang="ts">
-import { Component, Mixins, Prop } from 'vue-property-decorator'
+import { Component, Mixins } from 'vue-property-decorator'
 import StateMixin from '@/mixins/state'
 import ToolheadMoves from '@/components/widgets/toolhead/ToolheadMoves.vue'
 import ExtruderMoves from '@/components/widgets/toolhead/ExtruderMoves.vue'
@@ -50,9 +47,6 @@ import PressureAdvanceAdjust from '@/components/widgets/toolhead/PressureAdvance
   }
 })
 export default class Toolhead extends Mixins(StateMixin) {
-  @Prop({ type: Boolean, default: false })
-  readonly forceMove!: boolean
-
   get multipleExtruders () {
     return this.$store.getters['printer/getExtruders'].length > 1
   }

--- a/src/components/widgets/toolhead/ToolheadCard.vue
+++ b/src/components/widgets/toolhead/ToolheadCard.vue
@@ -107,7 +107,7 @@
       </app-btn-collapse-group>
     </template>
 
-    <toolhead :force-move="forceMove" />
+    <toolhead />
 
     <manual-probe-dialog
       v-if="manualProbeDialogOpen"
@@ -137,7 +137,6 @@ import BedScrewsAdjustDialog from '@/components/common/BedScrewsAdjustDialog.vue
   }
 })
 export default class ToolheadCard extends Mixins(StateMixin, ToolheadMixin) {
-  forceMove = false
   manualProbeDialogOpen = false
   bedScrewsAdjustDialogOpen = false
 
@@ -165,7 +164,14 @@ export default class ToolheadCard extends Mixins(StateMixin, ToolheadMixin) {
   }
 
   get printerSupportsForceMove () {
-    return this.printerSettings.force_move?.enable_force_move ?? false
+    return (
+      (this.printerSettings.force_move?.enable_force_move ?? false) &&
+      !this.printerIsDelta
+    )
+  }
+
+  get printerIsDelta () {
+    return ['delta', 'rotary_delta'].includes(this.printerSettings.printer.kinematics)
   }
 
   get showManualProbeDialogAutomatically () {
@@ -174,6 +180,10 @@ export default class ToolheadCard extends Mixins(StateMixin, ToolheadMixin) {
 
   get showBedScrewsAdjustDialogAutomatically () {
     return this.$store.state.config.uiSettings.general.showBedScrewsAdjustDialogAutomatically
+  }
+
+  get forceMove () {
+    return this.$store.state.config.uiSettings.toolhead.forceMove
   }
 
   @Watch('isManualProbeActive')
@@ -212,7 +222,11 @@ export default class ToolheadCard extends Mixins(StateMixin, ToolheadMixin) {
       }
     }
 
-    this.forceMove = !this.forceMove
+    this.$store.dispatch('config/saveByPath', {
+      path: 'uiSettings.toolhead.forceMove',
+      value: !this.forceMove,
+      server: false
+    })
   }
 }
 </script>

--- a/src/components/widgets/toolhead/ToolheadMoves.vue
+++ b/src/components/widgets/toolhead/ToolheadMoves.vue
@@ -183,7 +183,7 @@
 </template>
 
 <script lang="ts">
-import { Component, Mixins, Prop } from 'vue-property-decorator'
+import { Component, Mixins } from 'vue-property-decorator'
 import StateMixin from '@/mixins/state'
 import ToolheadMixin from '@/mixins/toolhead'
 import { Waits } from '@/globals'
@@ -194,15 +194,16 @@ export default class ToolheadMoves extends Mixins(StateMixin, ToolheadMixin) {
   moveLength = ''
   fab = false
 
-  @Prop({ type: Boolean, default: false })
-  readonly forceMove!: boolean
+  get forceMove () {
+    return this.$store.state.config.uiSettings.toolhead.forceMove
+  }
 
   get kinematics () {
     return this.$store.getters['printer/getPrinterSettings']('printer.kinematics') || ''
   }
 
   get canHomeXY () {
-    return this.kinematics !== 'delta'
+    return ['delta', 'rotary_delta'].includes(this.kinematics)
   }
 
   get toolheadMoveDistances () {

--- a/src/components/widgets/toolhead/ToolheadPosition.vue
+++ b/src/components/widgets/toolhead/ToolheadPosition.vue
@@ -130,15 +130,12 @@
 </template>
 
 <script lang="ts">
-import { Component, Mixins, Prop } from 'vue-property-decorator'
+import { Component, Mixins } from 'vue-property-decorator'
 import StateMixin from '@/mixins/state'
 import ToolheadMixin from '@/mixins/toolhead'
 
 @Component({})
 export default class ToolheadPosition extends Mixins(StateMixin, ToolheadMixin) {
-  @Prop({ type: Boolean, default: false })
-  readonly forceMove!: boolean
-
   get gcodePosition () {
     return this.$store.state.printer.printer.gcode_move.gcode_position
   }
@@ -153,6 +150,10 @@ export default class ToolheadPosition extends Mixins(StateMixin, ToolheadMixin) 
 
   get useGcodeCoords () {
     return this.$store.state.config.uiSettings.general.useGcodeCoords
+  }
+
+  get forceMove () {
+    return this.$store.state.config.uiSettings.toolhead.forceMove
   }
 
   get xForceMove () {

--- a/src/store/config/index.ts
+++ b/src/store/config/index.ts
@@ -147,6 +147,9 @@ export const defaultState = (): ConfigState => {
           gcodes: [],
           config: []
         }
+      },
+      toolhead: {
+        forceMove: false
       }
     }
   }

--- a/src/store/config/index.ts
+++ b/src/store/config/index.ts
@@ -149,7 +149,9 @@ export const defaultState = (): ConfigState => {
         }
       },
       toolhead: {
-        forceMove: false
+        forceMove: false,
+        extrudeSpeed: -1,
+        extrudeLength: -1
       }
     }
   }

--- a/src/store/config/types.ts
+++ b/src/store/config/types.ts
@@ -25,7 +25,9 @@ export interface UiSettings {
 }
 
 export interface ToolheadConfig {
-  forceMove: boolean
+  forceMove: boolean;
+  extrudeSpeed: number;
+  extrudeLength: number;
 }
 
 export interface HostConfig {

--- a/src/store/config/types.ts
+++ b/src/store/config/types.ts
@@ -21,6 +21,11 @@ export interface UiSettings {
   tableHeaders: AppTableConfiguredHeaders;
   gcodePreview: GcodePreviewConfig;
   fileSystem: FileSystemConfig;
+  toolhead: ToolheadConfig;
+}
+
+export interface ToolheadConfig {
+  forceMove: boolean
 }
 
 export interface HostConfig {


### PR DESCRIPTION
Expose the `forceMove`, `extrudeLength` and `extrudeSpeed` state from the store instead of keeping it local on the component.

Also disable force move for Delta printers as we currently only support "stepper[xyz]" (further changes must be done for Delta support)

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>