### PR TITLE
chore: refactors validation rules

### DIFF
--- a/src/components/common/AddInstanceDialog.vue
+++ b/src/components/common/AddInstanceDialog.vue
@@ -29,7 +29,10 @@
             persistent-hint
             :hint="$t('app.endpoint.hint.add_printer')"
             :loading="verifying"
-            :rules="[rules.required, rules.url]"
+            :rules="[
+              $rules.required,
+              customRules.url
+            ]"
           >
             <template #append-outer>
               <v-icon
@@ -119,9 +122,10 @@ export default class AddInstanceDialog extends Mixins(StateMixin) {
   error: any = null
   note: any = null
 
-  rules = {
-    required: (v: string) => !!v || this.$t('app.general.simple_form.error.required'),
-    url: (v: string) => (this.validUrl(v)) || this.$t('app.general.simple_form.error.invalid_url')
+  get customRules () {
+    return {
+      url: (v: string) => (this.validUrl(v)) || this.$t('app.general.simple_form.error.invalid_url')
+    }
   }
 
   /**

--- a/src/components/settings/GcodePreviewSettings.vue
+++ b/src/components/settings/GcodePreviewSettings.vue
@@ -44,7 +44,11 @@
       <app-setting :title="$t('app.setting.label.extrusion_line_width')">
         <v-text-field
           :value="extrusionLineWidth"
-          :rules="[rules.numRequired, rules.numMin]"
+          :rules="[
+            $rules.required,
+            $rules.numberValid,
+            $rules.numberGreaterThan(0)
+          ]"
           filled
           dense
           single-line
@@ -59,7 +63,11 @@
       <app-setting :title="$t('app.setting.label.move_line_width')">
         <v-text-field
           :value="moveLineWidth"
-          :rules="[rules.numRequired, rules.numMin]"
+          :rules="[
+            $rules.required,
+            $rules.numberValid,
+            $rules.numberGreaterThan(0)
+          ]"
           filled
           dense
           single-line
@@ -74,7 +82,11 @@
       <app-setting :title="$t('app.setting.label.retraction_icon_size')">
         <v-text-field
           :value="retractionIconSize"
-          :rules="[rules.numRequired, rules.numMin]"
+          :rules="[
+            $rules.required,
+            $rules.numberValid,
+            $rules.numberGreaterThan(0)
+          ]"
           filled
           dense
           single-line
@@ -152,11 +164,6 @@ import { defaultState } from '@/store/config/index'
   components: {}
 })
 export default class GcodePreviewSettings extends Vue {
-  rules = {
-    numRequired: (v: number | string) => v !== '' || this.$t('app.general.simple_form.error.required'),
-    numMin: (v: number) => v > 0 || this.$t('app.general.simple_form.error.min', { min: 0 })
-  }
-
   get extrusionLineWidth () {
     return this.$store.state.config.uiSettings.gcodePreview.extrusionLineWidth
   }

--- a/src/components/settings/GeneralSettings.vue
+++ b/src/components/settings/GeneralSettings.vue
@@ -15,7 +15,9 @@
           dense
           single-line
           hide-details="auto"
-          :rules="instanceNameRules"
+          :rules="[
+            $rules.required
+          ]"
           :value="instanceName"
           :default-value="$globals.APP_NAME"
           @change="setInstanceName"
@@ -93,7 +95,6 @@
           single-line
           hide-details="auto"
           :items="[{ text: $tc('app.setting.label.none'), value: null }, ...powerDevicesList]"
-          :value="topNavPowerToggle"
           item-value="value"
           item-text="text"
         />
@@ -167,10 +168,6 @@ import { VInput } from '@/types'
 export default class GeneralSettings extends Mixins(StateMixin) {
   @Ref('instanceName')
   readonly instanceNameElement!: VInput
-
-  instanceNameRules = [
-    (v: string) => !!v || 'Required'
-  ]
 
   get estimateTypes () {
     return [

--- a/src/components/settings/ToolheadSettings.vue
+++ b/src/components/settings/ToolheadSettings.vue
@@ -162,7 +162,7 @@
           :rules="[
             $rules.lengthGreaterThanOrEqual(1),
             $rules.lengthLessThanOrEqual(6),
-            $rules.arrayOnlyNumbers
+            $rules.numberArrayValid
           ]"
         />
       </app-setting>
@@ -184,7 +184,7 @@
           :rules="[
             $rules.lengthGreaterThanOrEqual(1),
             $rules.lengthLessThanOrEqual(4),
-            $rules.arrayOnlyNumbers
+            $rules.numberArrayValid
           ]"
         />
       </app-setting>

--- a/src/components/settings/ToolheadSettings.vue
+++ b/src/components/settings/ToolheadSettings.vue
@@ -55,7 +55,11 @@
       <app-setting :title="$t('app.setting.label.default_extrude_length')">
         <v-text-field
           :value="defaultExtrudeLength"
-          :rules="[rules.numRequired, rules.numMin]"
+          :rules="[
+            $rules.required,
+            $rules.numberValid,
+            $rules.numberGreaterThanOrEqual(1)
+          ]"
           filled
           dense
           single-line
@@ -70,7 +74,11 @@
       <app-setting :title="$t('app.setting.label.default_extrude_speed')">
         <v-text-field
           :value="defaultExtrudeSpeed"
-          :rules="[rules.numRequired, rules.numMin]"
+          :rules="[
+            $rules.required,
+            $rules.numberValid,
+            $rules.numberGreaterThanOrEqual(1)
+          ]"
           filled
           dense
           single-line
@@ -86,7 +94,10 @@
         <v-select
           :value="defaultToolheadMoveLength"
           :items="toolheadMoveDistances"
-          :rules="[rules.numRequired]"
+          :rules="[
+            $rules.required,
+            $rules.numberValid
+          ]"
           filled
           dense
           single-line
@@ -101,7 +112,11 @@
       <app-setting :title="$t('app.setting.label.default_toolhead_xy_speed')">
         <v-text-field
           :value="defaultToolheadXYSpeed"
-          :rules="[rules.numRequired, rules.numMin]"
+          :rules="[
+            $rules.required,
+            $rules.numberValid,
+            $rules.numberGreaterThanOrEqual(1)
+          ]"
           filled
           dense
           single-line
@@ -116,7 +131,11 @@
       <app-setting :title="$t('app.setting.label.default_toolhead_z_speed')">
         <v-text-field
           :value="defaultToolheadZSpeed"
-          :rules="[rules.numRequired, rules.numMin]"
+          :rules="[
+            $rules.required,
+            $rules.numberValid,
+            $rules.numberGreaterThanOrEqual(1)
+          ]"
           filled
           dense
           single-line
@@ -140,7 +159,11 @@
           small-chips
           append-icon=""
           deletable-chips
-          :rules="[rules.arrayNumMin(1), rules.arrayNumMax(6), rules.arrayOnlyNumbers]"
+          :rules="[
+            $rules.lengthGreaterThanOrEqual(1),
+            $rules.lengthLessThanOrEqual(6),
+            $rules.arrayOnlyNumbers
+          ]"
         />
       </app-setting>
 
@@ -158,7 +181,11 @@
           small-chips
           append-icon=""
           deletable-chips
-          :rules="[rules.arrayNumMin(1), rules.arrayNumMax(4), rules.arrayOnlyNumbers]"
+          :rules="[
+            $rules.lengthGreaterThanOrEqual(1),
+            $rules.lengthLessThanOrEqual(4),
+            $rules.arrayOnlyNumbers
+          ]"
         />
       </app-setting>
 
@@ -230,14 +257,6 @@ export default class ToolHeadSettings extends Vue {
 
   @Ref('zAdjustValues')
   readonly zAdjustValuesElement!: VInput
-
-  rules = {
-    numRequired: (v: number | string) => v !== '' || this.$t('app.general.simple_form.error.required'),
-    numMin: (v: number) => v >= 1 || this.$t('app.general.simple_form.error.min', { min: 1 }),
-    arrayNumMin: (min: number) => (v: any[]) => v.length >= min || this.$t('app.general.simple_form.error.min', { min }),
-    arrayNumMax: (max: number) => (v: any[]) => v.length <= max || this.$t('app.general.simple_form.error.max', { max }),
-    arrayOnlyNumbers: (v: any[]) => !v.some(isNaN) || this.$t('app.general.simple_form.error.arrayofnums')
-  }
 
   get defaultExtrudeSpeed () {
     return this.$store.state.config.uiSettings.general.defaultExtrudeSpeed

--- a/src/components/settings/auth/UserConfigDialog.vue
+++ b/src/components/settings/auth/UserConfigDialog.vue
@@ -25,7 +25,10 @@
             dense
             class="mt-0"
             hide-details="auto"
-            :rules="[rules.required, rules.max]"
+            :rules="[
+              $rules.required,
+              $rules.lengthLessThanOrEqual(60)
+            ]"
           />
         </app-setting>
 
@@ -40,7 +43,11 @@
             type="password"
             class="mt-0"
             hide-details="auto"
-            :rules="[rules.required, rules.min, rules.password]"
+            :rules="[
+              $rules.required,
+              $rules.lengthGreaterThanOrEqual(4),
+              $rules.passwordNotEqualUsername(user.username)
+            ]"
           />
         </app-setting>
 
@@ -81,13 +88,6 @@ export default class UserConfigDialog extends Vue {
   readonly user!: AppUser
 
   valid = false
-
-  rules = {
-    required: (v: string) => (v !== undefined && v !== '') || this.$t('app.general.simple_form.error.required'),
-    password: (v: string) => (v.toLowerCase() !== this.user.username.toLowerCase()) || this.$t('app.general.simple_form.error.password_username'),
-    min: (v: string) => (v !== undefined && v.length >= 4) || this.$t('app.general.simple_form.error.min', { min: 4 }),
-    max: (v: string) => (v !== undefined && v.length <= 60) || this.$t('app.general.simple_form.error.max', { max: 60 })
-  }
 
   handleSave () {
     if (this.valid) {

--- a/src/components/settings/auth/UserPasswordDialog.vue
+++ b/src/components/settings/auth/UserPasswordDialog.vue
@@ -41,7 +41,9 @@
             type="password"
             class="mt-0"
             hide-details="auto"
-            :rules="[rules.required]"
+            :rules="[
+              $rules.required
+            ]"
           />
         </app-setting>
 
@@ -56,7 +58,11 @@
             type="password"
             class="mt-0"
             hide-details="auto"
-            :rules="[rules.required, rules.password, rules.min]"
+            :rules="[
+              $rules.required,
+              $rules.numberGreaterThanOrEqual(4),
+              $rules.passwordNotEqualUsername(currentUser)
+            ]"
           />
         </app-setting>
 
@@ -114,12 +120,6 @@ export default class UserPasswordDialog extends Vue {
   loading = false
 
   valid = false
-
-  rules = {
-    required: (v: string) => (v && v !== undefined && v !== '') || this.$t('app.general.simple_form.error.required'),
-    password: (v: string) => (v && v.toLowerCase() !== this.currentUser.toLowerCase()) || this.$t('app.general.simple_form.error.password_username'),
-    min: (v: string) => (v && v !== undefined && v.length >= 4) || this.$t('app.general.simple_form.error.min', { min: 4 })
-  }
 
   get currentUser () {
     const currentUser = this.$store.getters['auth/getCurrentUser']

--- a/src/components/settings/cameras/CameraConfigDialog.vue
+++ b/src/components/settings/cameras/CameraConfigDialog.vue
@@ -35,7 +35,9 @@
             dense
             class="mt-0"
             hide-details="auto"
-            :rules="[rules.required]"
+            :rules="[
+              $rules.required
+            ]"
           />
         </app-setting>
 
@@ -110,7 +112,9 @@
             dense
             single-line
             hide-details="auto"
-            :rules="[rules.required]"
+            :rules="[
+              $rules.required
+            ]"
           />
         </app-setting>
 
@@ -140,7 +144,9 @@
             dense
             single-line
             hide-details="auto"
-            :rules="[rules.required]"
+            :rules="[
+              $rules.required
+            ]"
           />
         </app-setting>
 
@@ -158,7 +164,10 @@
             dense
             single-line
             hide-details="auto"
-            :rules="[rules.required, rules.aspect]"
+            :rules="[
+              $rules.required,
+              $rules.aspectRatioValid
+            ]"
           />
         </app-setting>
 
@@ -199,18 +208,7 @@ export default class CameraConfigDialog extends Vue {
   @Prop({ type: Object, required: true })
   readonly camera!: CameraConfig
 
-  cameraUrlRules = [
-    (v: string) => !!v || this.$t('app.general.simple_form.error.required')
-  ]
-
   valid = false
-
-  rules = {
-    required: (v: string) => (v !== undefined && v !== '') || this.$t('app.general.simple_form.error.required'),
-    minFps: (v: number) => (v >= 1) || this.$t('app.general.simple_form.error.min', { min: 1 }),
-    maxFps: (v: number) => (v <= 60) || this.$t('app.general.simple_form.error.max', { max: 60 }),
-    aspect: (v: string) => /^\d+\s*[:/]\s*\d+$/.test(v) || this.$t('app.general.simple_form.error.invalid_aspect')
-  }
 
   handleSave () {
     if (this.valid) {

--- a/src/components/settings/console/ConsoleFilterDialog.vue
+++ b/src/components/settings/console/ConsoleFilterDialog.vue
@@ -142,7 +142,7 @@ export default class ConsoleFilterDialog extends Vue {
         text: this.$t('app.setting.label.expression'),
         value: ConsoleFilterType.Expression,
         rules: [
-          this.$rules.regExpValid
+          this.$rules.regExpPatternValid
         ]
       }
     ]

--- a/src/components/settings/console/ConsoleFilterDialog.vue
+++ b/src/components/settings/console/ConsoleFilterDialog.vue
@@ -40,7 +40,10 @@
             dense
             class="mt-0"
             hide-details="auto"
-            :rules="[rules.required, rules.uniqueName]"
+            :rules="[
+              $rules.required,
+              customRules.uniqueName
+            ]"
           />
         </app-setting>
 
@@ -74,7 +77,10 @@
             dense
             class="mt-0"
             hide-details="auto"
-            :rules="type.rules"
+            :rules="[
+              $rules.required,
+              ...type.rules
+            ]"
           />
         </app-setting>
 
@@ -110,33 +116,44 @@ export default class ConsoleFilterDialog extends Vue {
   readonly value!: boolean
 
   @Prop({ type: Object, required: true })
-  readonly rules!: any
-
-  @Prop({ type: Object, required: true })
   readonly filter!: ConsoleFilter
 
   valid = true
 
-  types = [
-    {
-      text: this.$t('app.setting.label.contains'),
-      value: ConsoleFilterType.Contains,
-      rules: [this.rules.required]
-    },
-    {
-      text: this.$t('app.setting.label.starts_with'),
-      value: ConsoleFilterType.StartsWith,
-      rules: [this.rules.required]
-    },
-    {
-      text: this.$t('app.setting.label.expression'),
-      value: ConsoleFilterType.Expression,
-      rules: [this.rules.required, this.rules.validExpression]
+  get customRules () {
+    return {
+      uniqueName: (v: string) => !this.filters.some((c: ConsoleFilter) => c.id !== this.filter.id && c.name.toLowerCase() === v.toLowerCase()) || this.$t('app.general.simple_form.error.exists')
     }
-  ]
+  }
+
+  get types () {
+    return [
+      {
+        text: this.$t('app.setting.label.contains'),
+        value: ConsoleFilterType.Contains,
+        rules: []
+      },
+      {
+        text: this.$t('app.setting.label.starts_with'),
+        value: ConsoleFilterType.StartsWith,
+        rules: []
+      },
+      {
+        text: this.$t('app.setting.label.expression'),
+        value: ConsoleFilterType.Expression,
+        rules: [
+          this.$rules.regExpValid
+        ]
+      }
+    ]
+  }
 
   get type () {
     return this.types.find(f => f.value === this.filter?.type) || this.types[0]
+  }
+
+  get filters () {
+    return this.$store.getters['console/getFilters']
   }
 
   handleSave () {

--- a/src/components/settings/console/ConsoleSettings.vue
+++ b/src/components/settings/console/ConsoleSettings.vue
@@ -68,7 +68,6 @@
         v-if="dialogState.open"
         v-model="dialogState.open"
         :filter="dialogState.filter"
-        :rules="dialogState.rules"
         @save="handleSaveFilter"
       />
     </v-card>
@@ -89,7 +88,6 @@ import ConsoleFilterDialog from './ConsoleFilterDialog.vue'
 export default class ConsoleSettings extends Mixins(StateMixin) {
   dialogState: any = {
     open: false,
-    rules: null,
     filter: null
   }
 
@@ -110,20 +108,6 @@ export default class ConsoleSettings extends Mixins(StateMixin) {
 
     this.dialogState = {
       open: true,
-      rules: {
-        required: (v: string) => !!v || this.$t('app.general.simple_form.error.required'),
-        uniqueName: (v: string) => !this.filters.some((c: ConsoleFilter) => c.id !== this.dialogState.filter.id && c.name.toLowerCase() === v.toLowerCase()) || this.$t('app.general.simple_form.error.exists'),
-        validExpression: (v: string) => {
-          try {
-            if (v) {
-              // eslint-disable-next-line
-              new RegExp(v)
-            }
-            return true
-          } catch (e) { }
-          return this.$t('app.general.simple_form.error.invalid_expression')
-        }
-      },
       filter: filterCopy
     }
   }

--- a/src/components/settings/macros/MacroCategories.vue
+++ b/src/components/settings/macros/MacroCategories.vue
@@ -100,7 +100,6 @@
         :title="categoryDialogState.title"
         :label="categoryDialogState.label"
         :name="categoryDialogState.name"
-        :rules="categoryDialogState.rules"
         @save="categoryDialogState.handler"
       />
     </v-card>
@@ -125,7 +124,6 @@ export default class MacroSettings extends Mixins(StateMixin) {
     label: '',
     category: null,
     name: '',
-    rules: [],
     handler: this.handleAddCategory
   }
 
@@ -150,10 +148,6 @@ export default class MacroSettings extends Mixins(StateMixin) {
       label: this.$t('app.general.label.name'),
       category: null,
       name: '',
-      rules: [
-        (v: string) => !!v || this.$t('app.general.simple_form.error.required'),
-        (v: string) => this.categories.findIndex((c: MacroCategory) => c.name.toLowerCase() === v.toLowerCase()) < 0 || this.$t('app.general.simple_form.error.exists')
-      ],
       handler: this.handleAddCategory
     }
   }
@@ -165,10 +159,6 @@ export default class MacroSettings extends Mixins(StateMixin) {
       label: this.$t('app.general.label.name'),
       category,
       name: category.name,
-      rules: [
-        (v: string) => !!v || this.$t('app.general.simple_form.error.required'),
-        (v: string) => this.categories.findIndex((c: MacroCategory) => c.name.toLowerCase() === v.toLowerCase()) < 0 || this.$t('app.general.simple_form.error.exists')
-      ],
       handler: this.handleEditCategory
     }
   }

--- a/src/components/settings/macros/MacroCategoryDialog.vue
+++ b/src/components/settings/macros/MacroCategoryDialog.vue
@@ -23,7 +23,10 @@
             autofocus
             outlined
             :label="label"
-            :rules="rules"
+            :rules="[
+              $rules.required,
+              customRules.uniqueName
+            ]"
             hide-details="auto"
             required
           />
@@ -52,6 +55,7 @@
 </template>
 
 <script lang="ts">
+import { MacroCategory } from '@/store/macros/types'
 import { Component, Vue, Prop } from 'vue-property-decorator'
 
 @Component({})
@@ -65,14 +69,17 @@ export default class MacroCategoryDialog extends Vue {
   @Prop({ type: String, required: true })
   readonly label!: string
 
-  @Prop({ type: Array, required: false })
-  readonly rules!: []
-
   @Prop({ type: String, required: true })
   readonly name!: string
 
   newName = ''
   valid = true
+
+  get customRules () {
+    return {
+      uniqueName: (v: string) => this.categories.findIndex((c: MacroCategory) => c.name.toLowerCase() === v.toLowerCase()) < 0 || this.$t('app.general.simple_form.error.exists')
+    }
+  }
 
   mounted () {
     this.newName = this.name

--- a/src/components/settings/presets/PresetDialog.vue
+++ b/src/components/settings/presets/PresetDialog.vue
@@ -17,7 +17,9 @@
         <app-setting :title="$t('app.setting.label.thermal_preset_name')">
           <v-text-field
             v-model="preset.name"
-            :rules="[rules.required]"
+            :rules="[
+              $rules.required
+            ]"
             hide-details="auto"
             filled
             dense
@@ -30,7 +32,7 @@
           v-for="(item, i) in heaters"
         >
           <app-setting
-            :key="i + 'heater'"
+            :key="`${i}heater`"
             :title="item.name"
           >
             <v-checkbox
@@ -41,7 +43,11 @@
 
             <v-text-field
               v-model.number="preset.values[item.name].value"
-              :rules="[rules.numRequired, rules.numMin]"
+              :rules="[
+                $rules.required,
+                $rules.numberValid,
+                $rules.numberGreaterThan(0)
+              ]"
               hide-details="auto"
               type="number"
               suffix="°C"
@@ -58,7 +64,7 @@
           v-for="(item, i) in fans"
         >
           <app-setting
-            :key="i + 'fan'"
+            :key="`${i}fan`"
             :title="item.name"
           >
             <v-checkbox
@@ -69,7 +75,11 @@
 
             <v-text-field
               v-model.number="preset.values[item.name].value"
-              :rules="[rules.numRequired, rules.numMin]"
+              :rules="[
+                $rules.required,
+                $rules.numberValid,
+                $rules.numberGreaterThan(0)
+              ]"
               hide-details="auto"
               type="number"
               suffix="°C"
@@ -135,12 +145,6 @@ export default class TemperaturePresetDialog extends Vue {
 
   get fans (): Fan[] {
     return this.$store.getters['printer/getOutputs'](['temperature_fan'])
-  }
-
-  rules = {
-    required: (v: string) => !!v || this.$t('app.general.simple_form.error.required'),
-    numRequired: (v: number | string) => v !== '' || this.$t('app.general.simple_form.error.required'),
-    numMin: (v: number) => v >= 0 || this.$t('app.general.simple_form.error.min', { min: 1 })
   }
 
   handleSave () {

--- a/src/components/settings/timelapse/TimelapseSettings.vue
+++ b/src/components/settings/timelapse/TimelapseSettings.vue
@@ -19,7 +19,6 @@
           single-line
           hide-details="auto"
           :items="cameras"
-          :value="camera"
           :disabled="cameraBlocked"
         />
       </app-setting>
@@ -36,7 +35,6 @@
           single-line
           hide-details="auto"
           :items="supportedModes"
-          :value="mode"
           :disabled="modeBlocked"
         />
       </app-setting>
@@ -53,7 +51,11 @@
         <v-text-field
           ref="delayCompElement"
           :value="delayComp"
-          :rules="[rules.numRequired, rules.validNum, rules.numMin]"
+          :rules="[
+            $rules.required,
+            $rules.numberValid,
+            $rules.numberGreaterThanOrEqual(0)
+          ]"
           :disabled="delayCompBlocked"
           :hide-details="delayCompElement ? delayCompElement.valid : true"
           filled
@@ -144,12 +146,6 @@ export default class TimelapseSettings extends Mixins(StateMixin) {
   readonly delayCompElement!: VInput
 
   renderSettingsDialogOpen = false
-
-  rules = {
-    numRequired: (v: number | string) => v !== '' || this.$t('app.general.simple_form.error.required'),
-    validNum: (v: string) => !isNaN(+v) || this.$t('app.general.simple_form.error.invalid_number'),
-    numMin: (v: number) => v >= 0 || this.$t('app.general.simple_form.error.min', { min: 0 })
-  }
 
   get supportedModes (): {text: string, value: TimelapseMode}[] {
     return [{

--- a/src/components/settings/timelapse/subsettings/CustomParkPositionSettings.vue
+++ b/src/components/settings/timelapse/subsettings/CustomParkPositionSettings.vue
@@ -8,7 +8,12 @@
       <v-text-field
         ref="parkPosXElement"
         :value="parkPosX"
-        :rules="[rules.numRequired, rules.validNum, rules.numMin(printerMinX), rules.numMax(printerMaxX)]"
+        :rules="[
+          $rules.required,
+          $rules.numberValid,
+          $rules.numberGreaterThanOrEqual(printerMinX),
+          $rules.numberLessThanOrEqual(printerMaxX)
+        ]"
         :disabled="getCustomParkPosBlocked('x')"
         :hide-details="parkPosXElement ? parkPosXElement.valid : true"
         filled
@@ -27,7 +32,12 @@
       <v-text-field
         ref="parkPosYElement"
         :value="parkPosY"
-        :rules="[rules.numRequired, rules.validNum, rules.numMin(printerMinY), rules.numMax(printerMaxY)]"
+        :rules="[
+          $rules.required,
+          $rules.numberValid,
+          $rules.numberGreaterThanOrEqual(printerMinY),
+          $rules.numberLessThanOrEqual(printerMaxY)
+        ]"
         :disabled="getCustomParkPosBlocked('y')"
         :hide-details="parkPosYElement ? parkPosYElement.valid : true"
         filled
@@ -63,13 +73,6 @@ export default class LayerMacroSettings extends Mixins(StateMixin) {
 
   @Ref('parkPosYElement')
   readonly parkPosYElement?: VInput
-
-  rules = {
-    numRequired: (v: number | string) => v !== '' || this.$t('app.general.simple_form.error.required'),
-    validNum: (v: string) => !isNaN(+v) || this.$t('app.general.simple_form.error.invalid_number'),
-    numMin: (min: number) => (v: number) => v >= min || this.$t('app.general.simple_form.error.min', { min }),
-    numMax: (max: number) => (v: number) => v <= max || this.$t('app.general.simple_form.error.max', { max })
-  }
 
   getCustomParkPosBlocked (axis: 'x' | 'y') {
     return this.$store.getters['timelapse/isBlockedSetting'](`park_custom_pos_${axis}`)

--- a/src/components/settings/timelapse/subsettings/ParkExtrudeRetractSettings.vue
+++ b/src/components/settings/timelapse/subsettings/ParkExtrudeRetractSettings.vue
@@ -8,7 +8,11 @@
       <v-text-field
         ref="parkRetractDistanceElement"
         :value="parkRetractDistance"
-        :rules="[rules.numRequired, rules.validNum, rules.numMin(0)]"
+        :rules="[
+          $rules.required,
+          $rules.numberValid,
+          $rules.numberGreaterThanOrEqual(0)
+        ]"
         :disabled="parkRetractDistanceBlocked"
         :hide-details="parkRetractDistanceElement ? parkRetractDistanceElement.valid : true"
         filled
@@ -27,7 +31,11 @@
       <v-text-field
         ref="parkRetractSpeedElement"
         :value="parkRetractSpeed"
-        :rules="[rules.numRequired, rules.validNum, rules.numAboveZero]"
+        :rules="[
+          $rules.required,
+          $rules.numberValid,
+          $rules.numberGreaterThan(0)
+        ]"
         :disabled="parkRetractSpeedBlocked"
         :hide-details="parkRetractSpeedElement ? parkRetractSpeedElement.valid : true"
         filled
@@ -46,7 +54,11 @@
       <v-text-field
         ref="parkExtrudeDistanceElement"
         :value="parkExtrudeDistance"
-        :rules="[rules.numRequired, rules.validNum, rules.numMin(0)]"
+        :rules="[
+          $rules.required,
+          $rules.numberValid,
+          $rules.numberGreaterThanOrEqual(0)
+        ]"
         :disabled="parkExtrudeDistanceBlocked"
         :hide-details="parkExtrudeDistanceElement ? parkExtrudeDistanceElement.valid : true"
         filled
@@ -65,7 +77,11 @@
       <v-text-field
         ref="parkExtrudeSpeedElement"
         :value="parkExtrudeSpeed"
-        :rules="[rules.numRequired, rules.validNum, rules.numAboveZero]"
+        :rules="[
+          $rules.required,
+          $rules.numberValid,
+          $rules.numberGreaterThan(0)
+        ]"
         :disabled="parkExtrudeSpeedBlocked"
         :hide-details="parkExtrudeSpeedElement ? parkExtrudeSpeedElement.valid : true"
         filled
@@ -105,14 +121,6 @@ export default class LayerMacroSettings extends Mixins(StateMixin) {
 
   @Ref('parkExtrudeSpeedElement')
   readonly parkExtrudeSpeedElement!: VInput
-
-  rules = {
-    numRequired: (v: number | string) => v !== '' || this.$t('app.general.simple_form.error.required'),
-    validNum: (v: string) => !isNaN(+v) || this.$t('app.general.simple_form.error.invalid_number'),
-    numMin: (min: number) => (v: number) => v >= min || this.$t('app.general.simple_form.error.min', { min }),
-    numAboveZero: (v: number) => v > 0 || this.$t('app.general.simple_form.error.min', { min: '> 0' }),
-    numMax: (max: number) => (v: number) => v <= max || this.$t('app.general.simple_form.error.min', { max })
-  }
 
   get parkRetractDistanceBlocked (): boolean {
     return this.$store.getters['timelapse/isBlockedSetting']('park_retract_distance')

--- a/src/components/settings/timelapse/subsettings/ToolheadParkingSettings.vue
+++ b/src/components/settings/timelapse/subsettings/ToolheadParkingSettings.vue
@@ -23,7 +23,11 @@
         <v-text-field
           ref="parkTimeElement"
           :value="parkTime"
-          :rules="[rules.numRequired, rules.validNum, rules.numMin(0)]"
+          :rules="[
+            $rules.required,
+            $rules.numberValid,
+            $rules.numberGreaterThanOrEqual(0)
+          ]"
           :disabled="parkTimeBlocked"
           :hide-details="parkTimeElement ? parkTimeElement.valid : true"
           filled
@@ -42,7 +46,11 @@
         <v-text-field
           ref="parkTravelSpeedElement"
           :value="parkTravelSpeed"
-          :rules="[rules.numRequired, rules.validNum, rules.numMin(0)]"
+          :rules="[
+            $rules.required,
+            $rules.numberValid,
+            $rules.numberGreaterThanOrEqual(0)
+          ]"
           :disabled="parkTravelSpeedBlocked"
           :hide-details="parkTravelSpeedElement ? parkTravelSpeedElement.valid : true"
           filled
@@ -80,7 +88,11 @@
         <v-text-field
           ref="parkPosDZElement"
           :value="parkPosZ"
-          :rules="[rules.numRequired, rules.validNum, rules.numMin(0)]"
+          :rules="[
+            $rules.required,
+            $rules.numberValid,
+            $rules.numberGreaterThanOrEqual(0)
+          ]"
           :disabled="parkPosZBlocked"
           :hide-details="parkPosDZElement ? parkPosDZElement.valid : true"
           filled
@@ -136,13 +148,6 @@ export default class LayerMacroSettings extends Mixins(StateMixin) {
 
   @Ref('parkPosDZElement')
   readonly parkPosDZElement?: VInput
-
-  rules = {
-    numRequired: (v: number | string) => v !== '' || this.$t('app.general.simple_form.error.required'),
-    validNum: (v: string) => !isNaN(+v) || this.$t('app.general.simple_form.error.invalid_number'),
-    numMin: (min: number) => (v: number) => v >= min || this.$t('app.general.simple_form.error.min', { min }),
-    numMax: (max: number) => (v: number) => v <= max || this.$t('app.general.simple_form.error.min', { max })
-  }
 
   get parkPositions (): {text: string, value: ParkPosition}[] {
     const values: ParkPosition[] = ['front_left', 'front_right', 'center', 'back_left', 'back_right', 'custom']

--- a/src/components/settings/timelapse/subsettings/modes/HyperlapseSettings.vue
+++ b/src/components/settings/timelapse/subsettings/modes/HyperlapseSettings.vue
@@ -8,7 +8,11 @@
       <v-text-field
         ref="hyperlapseCycleElement"
         :value="hyperlapseCycle"
-        :rules="[rules.numRequired, rules.validNum, rules.numMin]"
+        :rules="[
+          $rules.required,
+          $rules.numberValid,
+          $rules.numberGreaterThanOrEqual(1)
+        ]"
         :disabled="hyperlapseCycleBlocked"
         :hide-details="hyperlapseCycleElement ? hyperlapseCycleElement.valid : true"
         filled
@@ -37,12 +41,6 @@ import { VInput } from '@/types'
 export default class HyperlapseSettings extends Mixins(StateMixin) {
   @Ref('hyperlapseCycleElement')
   readonly hyperlapseCycleElement!: VInput
-
-  rules = {
-    numRequired: (v: number | string) => v !== '' || this.$t('app.general.simple_form.error.required'),
-    validNum: (v: string) => !isNaN(+v) || this.$t('app.general.simple_form.error.invalid_number'),
-    numMin: (v: number) => v >= 1 || this.$t('app.general.simple_form.error.min', { min: 1 })
-  }
 
   get hyperlapseCycleBlocked () {
     return this.$store.getters['timelapse/isBlockedSetting']('hyperlapse_cycle')

--- a/src/components/ui/AppSlider.vue
+++ b/src/components/ui/AppSlider.vue
@@ -195,12 +195,12 @@ export default class AppSlider extends Mixins(StateMixin) {
     // Apply a min and max rule as per the slider.
     const rules = [
       ...this.rules,
-      (v: string | number) => !isNaN(+v) || this.$t('app.general.simple_form.error.invalid_number'),
-      (v: string | number) => +v >= this.min || this.$t('app.general.simple_form.error.min', { min: this.min })
+      this.$rules.numberValid,
+      this.$rules.numberGreaterThanOrEqual(this.min)
     ]
     if (!this.overridable) {
       rules.push(
-        (v: string | number) => +v <= this.max || this.$t('app.general.simple_form.error.max', { max: this.max })
+        this.$rules.numberLessThanOrEqual(this.max)
       )
     }
     return rules

--- a/src/components/widgets/bedmesh/SaveMeshDialog.vue
+++ b/src/components/widgets/bedmesh/SaveMeshDialog.vue
@@ -22,7 +22,9 @@
             filled
             required
             class="mb-4"
-            :rules="rules"
+            :rules="[
+              $rules.required
+            ]"
             hide-details="auto"
             :label="$t('app.bedmesh.label.profile_name')"
           />
@@ -85,10 +87,6 @@ export default class SaveMeshDialog extends Mixins(StateMixin, ToolheadMixin) {
   valid = true
   name = 'default'
   removeDefault = false
-
-  rules = [
-    (v: string) => !!v || this.$t('app.general.simple_form.error.required')
-  ]
 
   handleSubmit () {
     if (this.valid) {

--- a/src/components/widgets/diagnostics/config/AxesConfigStep.vue
+++ b/src/components/widgets/diagnostics/config/AxesConfigStep.vue
@@ -53,7 +53,9 @@
             dense
             single-line
             hide-details="auto"
-            :rules="[rules.required]"
+            :rules="[
+              $rules.required
+            ]"
           />
         </app-setting>
 
@@ -67,7 +69,9 @@
             single-line
             hide-details="auto"
             :hint="$t('app.setting.label.optional')"
-            :rules="[rules.validNum]"
+            :rules="[
+              $rules.numberValid
+            ]"
             :suffix="config.axes[i].unit"
           />
         </app-setting>
@@ -82,7 +86,9 @@
             single-line
             hide-details="auto"
             :hint="$t('app.setting.label.optional')"
-            :rules="[rules.validNum]"
+            :rules="[
+              $rules.numberValid
+            ]"
             :suffix="config.axes[i].unit"
           />
         </app-setting>
@@ -105,11 +111,6 @@ export default class AxesConfigStep extends Vue {
 
   currentStep = 1
   steps = [this.$t('app.setting.label.left_y'), this.$t('app.setting.label.right_y')]
-
-  rules = {
-    required: (v: string) => (v !== undefined && v !== '') || this.$t('app.general.simple_form.error.required'),
-    validNum: (v: string) => ([undefined, ''].includes(v) || !isNaN(+v)) || this.$t('app.general.simple_form.error.invalid_number')
-  }
 }
 </script>
 

--- a/src/components/widgets/diagnostics/config/CardConfigStep.vue
+++ b/src/components/widgets/diagnostics/config/CardConfigStep.vue
@@ -7,7 +7,9 @@
         dense
         single-line
         hide-details="auto"
-        :rules="[rules.required]"
+        :rules="[
+          $rules.required
+        ]"
       />
     </app-setting>
 
@@ -52,7 +54,10 @@
         single-line
         hide-details="auto"
         suffix="px"
-        :rules="[rules.required, rules.min]"
+        :rules="[
+          $rules.required,
+          $rules.numberGreaterThanOrEqual(1)
+        ]"
       />
     </app-setting>
   </div>
@@ -70,11 +75,6 @@ import { Icons } from '@/globals'
 export default class CardConfigStep extends Vue {
   @Prop({ type: Object, required: true })
   readonly config!: DiagnosticsCardConfig
-
-  rules = {
-    required: (v: string) => (v !== undefined && v !== '') || this.$t('app.general.simple_form.error.required'),
-    min: (v: number) => (v >= 1) || this.$t('app.general.simple_form.error.min', { min: 1 })
-  }
 
   get icons () {
     const icons = Object.keys(Icons)

--- a/src/components/widgets/diagnostics/config/MetricsConfigStep.vue
+++ b/src/components/widgets/diagnostics/config/MetricsConfigStep.vue
@@ -65,7 +65,9 @@
                   dense
                   single-line
                   hide-details="auto"
-                  :rules="[rules.required]"
+                  :rules="[
+                    $rules.required
+                  ]"
                 />
               </app-setting>
 
@@ -176,10 +178,6 @@ export default class MetricsConfigStep extends Vue {
     { text: this.$t('app.setting.label.dotted'), value: 'dotted' },
     { text: this.$t('app.setting.label.dashed'), value: 'dashed' }
   ]
-
-  rules = {
-    required: (v: string) => (v !== undefined && v !== '') || this.$t('app.general.simple_form.error.required')
-  }
 
   handleColorChange (prop: 'lineColor' | 'fillColor', metric: Metric, event: any) {
     metric.style[prop] = event.color.hexString

--- a/src/components/widgets/filesystem/FileNameDialog.vue
+++ b/src/components/widgets/filesystem/FileNameDialog.vue
@@ -21,7 +21,9 @@
             autofocus
             outlined
             :label="label"
-            :rules="rules"
+            :rules="[
+              $rules.required
+            ]"
             hide-details="auto"
             required
           />
@@ -64,9 +66,6 @@ export default class FileNameDialog extends Mixins(StateMixin) {
 
   @Prop({ type: String, required: true })
   readonly label!: string
-
-  @Prop({ type: Array, required: false })
-  readonly rules!: []
 
   @Prop({ type: String, required: true })
   readonly name!: string

--- a/src/components/widgets/filesystem/FileSystem.vue
+++ b/src/components/widgets/filesystem/FileSystem.vue
@@ -89,7 +89,6 @@
       :name="fileNameDialogState.value"
       :title="fileNameDialogState.title"
       :label="fileNameDialogState.label"
-      :rules="fileNameDialogState.rules"
       @save="fileNameDialogState.handler"
     />
 
@@ -255,7 +254,6 @@ export default class FileSystem extends Mixins(StateMixin, FilesMixin, ServicesM
     title: '',
     value: '',
     label: '',
-    rules: [],
     handler: ''
   }
 
@@ -573,9 +571,6 @@ export default class FileSystem extends Mixins(StateMixin, FilesMixin, ServicesM
     if (this.disabled) return
     let title = this.$t('app.file_system.title.rename_dir')
     let label = this.$t('app.file_system.label.dir_name')
-    const rules: any = [
-      (v: string) => !!v || this.$t('app.general.simple_form.error.required')
-    ]
     if (item.type === 'file') {
       title = this.$t('app.file_system.title.rename_file')
       label = this.$t('app.file_system.label.file_name')
@@ -585,7 +580,6 @@ export default class FileSystem extends Mixins(StateMixin, FilesMixin, ServicesM
       title,
       label,
       value: item.name,
-      rules,
       handler: this.handleRename
     }
   }
@@ -597,7 +591,6 @@ export default class FileSystem extends Mixins(StateMixin, FilesMixin, ServicesM
       title: this.$t('app.file_system.title.add_file'),
       label: this.$t('app.file_system.label.file_name'),
       value: '',
-      rules: [(v: string) => !!v || this.$t('app.general.simple_form.error.required')],
       handler: this.handleAddFile
     }
   }
@@ -609,7 +602,6 @@ export default class FileSystem extends Mixins(StateMixin, FilesMixin, ServicesM
       title: this.$t('app.file_system.title.add_dir'),
       label: this.$t('app.file_system.label.dir_name'),
       value: '',
-      rules: [(v: string) => !!v || this.$t('app.general.simple_form.error.required')],
       handler: this.handleAddDir
     }
   }

--- a/src/components/widgets/outputs/OutputFan.vue
+++ b/src/components/widgets/outputs/OutputFan.vue
@@ -7,7 +7,9 @@
       :value="value"
       :reset-value="0"
       :label="(rpm) ? `${fan.prettyName} <small>${rpm}</small>` : fan.prettyName"
-      :rules="rules"
+      :rules="[
+        customRules.minFan
+      ]"
       :disabled="!klippyReady"
       :locked="!klippyReady || isMobile"
       @change="handleChange"
@@ -81,13 +83,18 @@ export default class OutputFan extends Mixins(StateMixin) {
     return this.$vuetify.breakpoint.mobile
   }
 
-  rules = [
-    (v: string | number) => {
-      const off_below = (this.fan?.config?.off_below || 0) * 100
-      if (!off_below) return true
-      v = +v
-      return (v >= off_below || v === 0) || this.$t('app.general.simple_form.error.min_or_0', { min: off_below })
+  get customRules () {
+    return {
+      minFan: (v: string | number) => {
+        const off_below = (this.fan.config?.off_below || 0) * 100
+
+        if (!off_below) return true
+
+        v = +v
+
+        return (v >= off_below || v === 0) || this.$t('app.general.simple_form.error.min_or_0', { min: off_below })
+      }
     }
-  ]
+  }
 }
 </script>

--- a/src/components/widgets/thermals/InputTemperature.vue
+++ b/src/components/widgets/thermals/InputTemperature.vue
@@ -12,7 +12,9 @@
         hide-details="auto"
         :disabled="!klippyReady"
         :loading="loading"
-        :rules="[rules.min, rules.max]"
+        :rules="[
+          $rules.numberGreaterThanOrEqualOrZero(min),
+          $rules.numberLessThanOrEqualOrZero(max)]"
         suffix="°C"
         class="v-input--width-x-small"
         @keyup.enter="emitChange"
@@ -47,11 +49,6 @@ export default class InputTemperature extends Mixins(StateMixin) {
 
   valid = true
   inputValue = 0
-
-  rules = {
-    min: (v: number | string) => (v >= this.min || v === '' || v === '0' || v === 0 || this.min === null) || this.$t('app.general.simple_form.error.min_or_0', { min: this.min }),
-    max: (v: number | string) => (v <= this.max || v === '' || v === '0' || v === 0 || this.max === null) || this.$t('app.general.simple_form.error.max', { max: this.max })
-  }
 
   emitChange () {
     if (this.valid) {

--- a/src/components/widgets/timelapse/TimelapseRenderSettingsDialog.vue
+++ b/src/components/widgets/timelapse/TimelapseRenderSettingsDialog.vue
@@ -39,7 +39,11 @@
         <v-text-field
           ref="outputFramerateElement"
           :value="outputFramerate"
-          :rules="[rules.numRequired, rules.validNum, rules.numMin]"
+          :rules="[
+            $rules.required,
+            $rules.numberValid,
+            $rules.numberGreaterThanOrEqual(0)
+          ]"
           :disabled="outputFramerateBlocked"
           :hide-details="outputFramerateElement ? outputFramerateElement.valid : true"
           filled
@@ -57,7 +61,11 @@
           <v-text-field
             ref="targetLengthElement"
             :value="targetLength"
-            :rules="[rules.numRequired, rules.validNum, rules.numMin]"
+            :rules="[
+              $rules.required,
+              $rules.numberValid,
+              $rules.numberGreaterThanOrEqual(0)
+            ]"
             :disabled="targetLengthBlocked"
             :hide-details="targetLengthElement ? targetLengthElement.valid : true"
             filled
@@ -76,7 +84,11 @@
           <v-text-field
             ref="minFpsElement"
             :value="minFps"
-            :rules="[rules.numRequired, rules.validNum, rules.numMin]"
+            :rules="[
+              $rules.required,
+              $rules.numberValid,
+              $rules.numberGreaterThanOrEqual(0)
+            ]"
             :disabled="minFpsBlocked"
             :hide-details="minFpsElement ? minFpsElement.valid : true"
             filled
@@ -95,7 +107,11 @@
           <v-text-field
             ref="maxFpsElement"
             :value="maxFps"
-            :rules="[rules.numRequired, rules.validNum, rules.numMin]"
+            :rules="[
+              $rules.required,
+              $rules.numberValid,
+              $rules.numberGreaterThanOrEqual(0)
+            ]"
             :disabled="maxFpsBlocked"
             :hide-details="maxFpsElement ? maxFpsElement.valid : true"
             filled
@@ -128,7 +144,11 @@
         <v-text-field
           ref="duplicateFramesElement"
           :value="duplicateFrames"
-          :rules="[rules.numRequired, rules.validNum, rules.numMin]"
+          :rules="[
+            $rules.required,
+            $rules.numberValid,
+            $rules.numberGreaterThanOrEqual(0)
+          ]"
           :disabled="duplicateFramesBlocked"
           :hide-details="duplicateFramesElement ? duplicateFramesElement.valid : true"
           filled
@@ -223,12 +243,6 @@ export default class TimelapseRenderSettingsDialog extends Mixins(StateMixin) {
 
   @Ref('duplicateFramesElement')
   readonly duplicateFramesElement!: VInput
-
-  rules = {
-    numRequired: (v: number | string) => v !== '' || this.$t('app.general.simple_form.error.required'),
-    validNum: (v: string) => !isNaN(+v) || this.$t('app.general.simple_form.error.invalid_number'),
-    numMin: (v: number) => v >= 0 || this.$t('app.general.simple_form.error.min', { min: 0 })
-  }
 
   get lengthEstimate () {
     const totalFrames = this.frameCount + this.duplicateLastFrameCount

--- a/src/components/widgets/toolhead/ExtruderMoves.vue
+++ b/src/components/widgets/toolhead/ExtruderMoves.vue
@@ -12,7 +12,10 @@
           ref="lengthfield"
           v-model.number="extrudeLength"
           :disabled="!klippyReady"
-          :rules="[rules.min, rules.maxLength]"
+          :rules="[
+            $rules.numberGreaterThanOrEqual(0.1),
+            $rules.numberLessThanOrEqual(maxExtrudeLength)
+          ]"
           hide-details
           outlined
           dense
@@ -43,7 +46,10 @@
         <v-text-field
           v-model.number="extrudeSpeed"
           :disabled="!klippyReady"
-          :rules="[rules.min, rules.maxSpeed]"
+          :rules="[
+            $rules.numberGreaterThanOrEqual(0.1),
+            $rules.numberLessThanOrEqual(maxExtrudeSpeed)
+          ]"
           hide-details
           outlined
           dense
@@ -76,18 +82,6 @@ import { Waits } from '@/globals'
 export default class ExtruderMoves extends Mixins(StateMixin, ToolheadMixin) {
   waits = Waits
   valid = true
-
-  rules = {
-    min: (v: number) => {
-      return (v >= 0.1) || this.$t('app.general.simple_form.error.min', { min: 0.1 })
-    },
-    maxSpeed: (v: number) => {
-      return (v <= this.maxExtrudeSpeed) || this.$t('app.general.simple_form.error.max', { max: this.maxExtrudeSpeed })
-    },
-    maxLength: (v: number) => {
-      return (v <= this.maxExtrudeLength) || this.$t('app.general.simple_form.error.max', { max: this.maxExtrudeLength })
-    }
-  }
 
   get maxExtrudeSpeed () {
     return this.activeExtruder?.max_extrude_only_velocity || 500

--- a/src/plugins/filters.ts
+++ b/src/plugins/filters.ts
@@ -247,16 +247,8 @@ export const Rules = {
     return ((v ?? '') !== '') || i18n.t('app.general.simple_form.error.required')
   },
 
-  numberValid (v?: string | number | null) {
+  numberValid (v: any) {
     return !isNaN(+(v ?? NaN)) || i18n.t('app.general.simple_form.error.invalid_number')
-  },
-
-  numberRequired (v: any) {
-    if ((v ?? '') !== '') {
-      return !isNaN(+v) || i18n.t('app.general.simple_form.error.invalid_number')
-    } else {
-      return i18n.t('app.general.simple_form.error.required')
-    }
   },
 
   numberGreaterThan (min: number) {
@@ -299,8 +291,8 @@ export const Rules = {
     return (v: string | any[]) => v.length <= max || i18n.t('app.general.simple_form.error.max', { max })
   },
 
-  arrayOnlyNumbers (v: any[]) {
-    return !v.some(i => isNaN(+(i ?? NaN))) || i18n.t('app.general.simple_form.error.arrayofnums')
+  numberArrayValid (v: any[]) {
+    return !v.some(i => i === '' || isNaN(+(i ?? NaN))) || i18n.t('app.general.simple_form.error.arrayofnums')
   },
 
   passwordNotEqualUsername (username?: string | null) {
@@ -311,7 +303,7 @@ export const Rules = {
     return /^\d+\s*[:/]\s*\d+$/.test(v) || i18n.t('app.general.simple_form.error.invalid_aspect')
   },
 
-  regExpValid (v: string) {
+  regExpPatternValid (v: string) {
     try {
       // eslint-disable-next-line no-new
       new RegExp(v)
@@ -321,7 +313,7 @@ export const Rules = {
     }
   },
 
-  regExValid (regExp: RegExp, errorMessage: string | TranslateResult) {
+  regExpValid (regExp: RegExp, errorMessage: string | TranslateResult) {
     return (v: string) => regExp.test(v) || errorMessage || 'Invalid'
   }
 }

--- a/src/plugins/filters.ts
+++ b/src/plugins/filters.ts
@@ -4,8 +4,8 @@ import { camelCase, startCase, capitalize, isFinite } from 'lodash-es'
 import { ApiConfig } from '@/store/config/types'
 import tinycolor from '@ctrl/tinycolor'
 import { Globals, Waits } from '@/globals'
-
-// import router from '@/router'
+import i18n from '@/plugins/i18n'
+import type { TranslateResult } from 'vue-i18n'
 
 /**
  * credit: taken from Vuetify source
@@ -242,12 +242,98 @@ export const Filters = {
   }
 }
 
+export const Rules = {
+  required (v: any) {
+    return ((v ?? '') !== '') || i18n.t('app.general.simple_form.error.required')
+  },
+
+  numberValid (v?: string | number | null) {
+    return !isNaN(+(v ?? NaN)) || i18n.t('app.general.simple_form.error.invalid_number')
+  },
+
+  numberRequired (v: any) {
+    if ((v ?? '') !== '') {
+      return !isNaN(+v) || i18n.t('app.general.simple_form.error.invalid_number')
+    } else {
+      return i18n.t('app.general.simple_form.error.required')
+    }
+  },
+
+  numberGreaterThan (min: number) {
+    return (v: number) => v > min || i18n.t('app.general.simple_form.error.min', { min: `> ${min}` })
+  },
+
+  numberGreaterThanOrEqual (min: number) {
+    return (v: number) => v >= min || i18n.t('app.general.simple_form.error.min', { min })
+  },
+
+  numberGreaterThanOrEqualOrZero (min: number) {
+    return (v: number) => +v === 0 || v >= min || i18n.t('app.general.simple_form.error.min_or_0', { min })
+  },
+
+  numberGreaterThanOrZero (min: number) {
+    return (v: number) => +v === 0 || v > min || i18n.t('app.general.simple_form.error.min_or_0', { min: `> ${min}` })
+  },
+
+  numberLessThan (max: number) {
+    return (v: number) => v < max || i18n.t('app.general.simple_form.error.max', { max: `< ${max}` })
+  },
+
+  numberLessThanOrEqual (max: number) {
+    return (v: number) => v <= max || i18n.t('app.general.simple_form.error.max', { max })
+  },
+
+  numberLessThanOrEqualOrZero (max: number) {
+    return (v: number) => +v === 0 || v <= max || i18n.t('app.general.simple_form.error.max', { max })
+  },
+
+  numberLessThanOrZero (max: number) {
+    return (v: number) => +v === 0 || v < max || i18n.t('app.general.simple_form.error.max', { max })
+  },
+
+  lengthGreaterThanOrEqual (min: number) {
+    return (v: string | any[]) => v.length >= min || i18n.t('app.general.simple_form.error.min', { min })
+  },
+
+  lengthLessThanOrEqual (max: number) {
+    return (v: string | any[]) => v.length <= max || i18n.t('app.general.simple_form.error.max', { max })
+  },
+
+  arrayOnlyNumbers (v: any[]) {
+    return !v.some(i => isNaN(+(i ?? NaN))) || i18n.t('app.general.simple_form.error.arrayofnums')
+  },
+
+  passwordNotEqualUsername (username?: string | null) {
+    return (v: string) => (v.toLowerCase() !== (username ?? '').toLowerCase()) || i18n.t('app.general.simple_form.error.password_username')
+  },
+
+  aspectRatioValid (v: string) {
+    return /^\d+\s*[:/]\s*\d+$/.test(v) || i18n.t('app.general.simple_form.error.invalid_aspect')
+  },
+
+  regExpValid (v: string) {
+    try {
+      // eslint-disable-next-line no-new
+      new RegExp(v)
+      return true
+    } catch (e) {
+      return i18n.t('app.general.simple_form.error.invalid_expression')
+    }
+  },
+
+  regExValid (regExp: RegExp, errorMessage: string | TranslateResult) {
+    return (v: string) => regExp.test(v) || errorMessage || 'Invalid'
+  }
+}
+
 export const FiltersPlugin = {
   install (Vue: typeof _Vue) {
     Vue.prototype.$filters = Filters
+    Vue.prototype.$rules = Rules
     Vue.prototype.$globals = Globals
     Vue.prototype.$waits = Waits
     Vue.$filters = Filters
+    Vue.$rules = Rules
     Vue.$globals = Globals
     Vue.$waits = Waits
   }
@@ -256,12 +342,14 @@ export const FiltersPlugin = {
 declare module 'vue/types/vue' {
   interface Vue {
     $filters: typeof Filters;
+    $rules: typeof Rules;
     $globals: typeof Globals;
     $waits: typeof Waits;
   }
 
   interface VueConstructor {
     $filters: typeof Filters;
+    $rules: typeof Rules;
     $globals: typeof Globals;
     $waits: typeof Waits;
   }


### PR DESCRIPTION
Adds a new global `Vue.$rules` that contains most of the validation rules we use.

For the remaining rules, I've made sure that these are using property `get`, as it seems that since Vite migration some of these are not reactive and thus, can't read from existing properties.

Fixes #937

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>