### PR TITLE
feat: use service names provided by Moonraker

### DIFF
--- a/src/components/common/SystemCommands.vue
+++ b/src/components/common/SystemCommands.vue
@@ -108,7 +108,7 @@
             <v-btn
               icon
               :disabled="service.active_state === 'inactive'"
-              :style="service.name === 'moonraker' ? 'visibility: hidden;' : ''"
+              :style="service.name === moonrakerServiceName ? 'visibility: hidden;' : ''"
               @click="checkDialog(serviceStop, service, 'stop')"
             >
               <v-icon color="error">

--- a/src/mixins/services.ts
+++ b/src/mixins/services.ts
@@ -4,6 +4,10 @@ import { Component } from 'vue-property-decorator'
 
 @Component
 export default class ServicesMixin extends Vue {
+  get moonrakerServiceName () {
+    return this.$store.state.server.system_info?.instance_ids?.moonraker || 'moonraker'
+  }
+
   /**
    * Resets the UI when restarting/resetting Klipper
    */
@@ -42,14 +46,14 @@ export default class ServicesMixin extends Vue {
    * Restart the moonraker service itself.
    */
   serviceRestartMoonraker () {
-    this.serviceRestartByName('moonraker')
+    this.serviceRestartByName(this.moonrakerServiceName)
   }
 
   /**
    * Restart a service by name.
    */
   async serviceRestartByName (name: string) {
-    if (name === 'moonraker') {
+    if (name === this.moonrakerServiceName) {
       SocketActions.serverRestart()
       this.$store.commit('socket/setSocketDisconnecting', true)
     } else {
@@ -72,7 +76,7 @@ export default class ServicesMixin extends Vue {
    * Stop a service by name.
    */
   async serviceStopByName (name: string) {
-    if (name === 'moonraker') {
+    if (name === this.moonrakerServiceName) {
       throw new Error('Stopping the moonraker service is not supported')
     } else {
       if (name === 'klipper') {

--- a/src/store/server/getters.ts
+++ b/src/store/server/getters.ts
@@ -60,7 +60,7 @@ export const getters: GetterTree<ServerState, RootState> = {
    * Maps configuration files to an object representing a config doc link,
    * along with a service name.
    */
-  getConfigMapByFilename: (state, getters) => (filename: string) => {
+  getConfigMapByFilename: (state, getters, rootState) => (filename: string) => {
     const configMap = Globals.CONFIG_SERVICE_MAP
 
     // First, see if can find an exact match.
@@ -77,8 +77,11 @@ export const getters: GetterTree<ServerState, RootState> = {
     }
 
     if (item) {
+      const itemService = item?.service
+      const instanceIds = rootState.server.system_info?.instance_ids
+
       return {
-        serviceSupported: getters.getServices.some((i: ServiceInfo) => i.name === item?.service),
+        serviceSupported: (instanceIds && itemService in instanceIds) || getters.getServices.some((i: ServiceInfo) => i.name === itemService),
         ...item
       }
     }

--- a/src/store/server/types.ts
+++ b/src/store/server/types.ts
@@ -45,6 +45,8 @@ export interface SystemInfo {
   cpu_info?: CpuInfo;
   sd_info?: SDInfo;
   distribution?: DistroInfo;
+  virtualization?: Virtualization;
+  instance_ids: InstanceIds;
 }
 
 export interface ServiceState {
@@ -95,6 +97,16 @@ export interface DistroVersionParts {
   major: string;
   minor: string;
   build_number: string;
+}
+
+export interface Virtualization {
+  virt_type: string;
+  virt_identifier: string;
+}
+
+export interface InstanceIds {
+  moonraker: string;
+  klipper: string;
 }
 
 export interface ServerConfig {


### PR DESCRIPTION
Moonraker now provides the instance ids for the Moonraker and Klipper services, so we can restart the correct services when the respective config files change!

Fixes #638 

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>