### PR TITLE
fix(i18n): adds missing 'start service' translation

### DIFF
--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -326,6 +326,7 @@ app:
         confirm_forcemove_toggle: Are you sure? This can damage the printer.
         confirm_reboot_host: Are you sure? This will reboot your host system.
         confirm_shutdown_host: Are you sure? This will shutdown your host system.
+        confirm_service_start: Are you sure you want to start the %{name} service?
         confirm_service_restart: Are you sure you want to restart the %{name} service?
         confirm_service_stop: Are you sure you want to stop the %{name} service?
         confirm_power_device_toggle: Are you sure? This will toggle the power of this device.


### PR DESCRIPTION
Fixes #944

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>