### PR TITLE
fix: sort temperature sensors by type and name

### DIFF
--- a/src/store/printer/getters.ts
+++ b/src/store/printer/getters.ts
@@ -549,6 +549,7 @@ export const getters: GetterTree<PrinterState, RootState> = {
       }
     }
     return pins
+      .sort((a, b) => a.type.localeCompare(b.type) || a.name.localeCompare(b.name))
   },
 
   /**
@@ -601,6 +602,7 @@ export const getters: GetterTree<PrinterState, RootState> = {
     }, {} as Record<string, Sensor>)
 
     return Object.values(sensors)
+      .sort((a, b) => a.type.localeCompare(b.type) || a.name.localeCompare(b.name))
   },
 
   /**


### PR DESCRIPTION
Currently the thermals are grouped by heaters on top, then temperature fan, and finally temperature sensors, but these are unordered inside these groups.

This PR ensures that we still keep the above grouping, and then inside each group we sort by sensor type, and finally name.

![image](https://user-images.githubusercontent.com/85504/203123327-0d4867b3-c80c-42c5-966e-f21058a9b35a.png)

Fixes #956 

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>