### PR TITLE
fix: properly scale print finish ETA

### DIFF
--- a/src/components/widgets/status/StatusTab.vue
+++ b/src/components/widgets/status/StatusTab.vue
@@ -119,7 +119,7 @@
               </status-label>
 
               <status-label :label="$t('app.general.label.finish_time')">
-                <span v-if="estimates.eta > 0 && printerPrinting">{{ $filters.formatAbsoluteDateTime(estimates.eta) }}</span>
+                <span v-if="estimates.eta > 0 && printerPrinting">{{ $filters.formatAbsoluteDateTime(estimates.eta * 1000) }}</span>
               </status-label>
             </v-col>
           </v-row>


### PR DESCRIPTION
Fixes an issue where the print finish ETA would show a full date in 1970 instead of the proper time