### PR TITLE
fix: extrusion estimation spacing

### DIFF
--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -617,18 +617,18 @@ app:
         <span class="secondary--text">and</span>
         %{nozzleDiameter} mm nozzle
       stats_volumetric_flow: >-
-        Extruding at %{extrudeSpeed} mm/s
-        <span class="secondary--text">, the extruder should be able to provide an</span>
+        Extruding at %{extrudeSpeed} mm/s<span class="secondary--text">,
+        the extruder should be able to provide an</span>
         estimated volumetric flow of %{estimatedVolumetricFlow} mm³/s
       stats_extruded_length: >-
-        Extruding %{extrudeLength} mm of filament at %{extrudeFactor} % flow
-        <span class="secondary--text">, will provide an</span>
+        Extruding %{extrudeLength} mm of filament at
+        %{extrudeFactor} % flow<span class="secondary--text">,
+        will provide an</span>
         estimated output length of %{estimatedExtrudedLength} mm
       stats_max_speed: >-
         <span class="secondary--text">Assuming a</span>
-        %{layerHeight} mm layer height
-        <span class="secondary--text">, the </span>
-        estimated maximum print speed is %{estimatedMaxSpeed} mm/s
+        %{layerHeight} mm layer height<span class="secondary--text">,
+        the</span> estimated maximum print speed is %{estimatedMaxSpeed} mm/s
   version:
     btn:
       check_for_updates: Check for updates


### PR DESCRIPTION
Removes spaces leading commas:

Before
![image](https://user-images.githubusercontent.com/25269274/203325737-eb6331a2-96b7-4ce2-9ff4-29d5dad60122.png)

After
![image](https://user-images.githubusercontent.com/25269274/203325183-7adcb5fb-50f7-440a-945e-c0b1ecd998a5.png)
