### PR TITLE
style: alternative alignment for ExtruderStats

### DIFF
--- a/src/components/widgets/toolhead/ExtruderStats.vue
+++ b/src/components/widgets/toolhead/ExtruderStats.vue
@@ -1,62 +1,58 @@
 <template>
-  <div>
-    <v-divider />
-    <v-expansion-panels
-      accordion
-      multiple
-      flat
-    >
-      <v-expansion-panel>
-        <v-expansion-panel-header>
-          <template #default="{ open }">
-            <v-row no-gutters>
-              <v-col
-                class="text--secondary text-center"
-                :class="{ 'text--disabled': !klippyReady }"
-              >
-                <v-fade-transition>
-                  <span v-if="!open">~ {{ estimatedExtrudedLength }} mm @ {{ estimatedVolumetricFlow }} mm³/s, {{ estimatedMaxSpeed }} mm/s</span>
-                </v-fade-transition>
-              </v-col>
-            </v-row>
-          </template>
-        </v-expansion-panel-header>
-        <v-expansion-panel-content>
-          <div
-            class="text-center"
-            :class="{ 'text--disabled': !klippyReady }"
-          >
-            <p
-              v-html="$t('app.tool.label.stats_active_extruder', {
-                filamentDiameter,
-                nozzleDiameter
-              })"
-            />
-            <p
-              v-html="$t('app.tool.label.stats_volumetric_flow', {
-                extrudeSpeed,
-                estimatedVolumetricFlow
-              })"
-            />
-            <p
-              v-html="$t('app.tool.label.stats_extruded_length', {
-                extrudeLength,
-                extrudeFactor: (extrudeFactor * 100).toFixed(),
-                estimatedExtrudedLength
-              })"
-            />
-            <p
-              v-html="$t('app.tool.label.stats_max_speed', {
-                layerHeight,
-                estimatedMaxSpeed
-              })"
-            />
-          </div>
-        </v-expansion-panel-content>
-      </v-expansion-panel>
-    </v-expansion-panels>
-    <v-divider />
-  </div>
+  <v-expansion-panels
+    accordion
+    multiple
+    flat
+  >
+    <v-expansion-panel>
+      <v-expansion-panel-header>
+        <template #default="{ open }">
+          <v-row no-gutters>
+            <v-col
+              class="text--secondary text-center"
+              :class="{ 'text--disabled': !klippyReady }"
+            >
+              <v-fade-transition>
+                <span v-if="!open">~ {{ estimatedExtrudedLength }} mm @ {{ estimatedVolumetricFlow }} mm³/s, {{ estimatedMaxSpeed }} mm/s</span>
+              </v-fade-transition>
+            </v-col>
+          </v-row>
+        </template>
+      </v-expansion-panel-header>
+      <v-expansion-panel-content>
+        <div
+          class="text-center"
+          :class="{ 'text--disabled': !klippyReady }"
+        >
+          <p
+            v-html="$t('app.tool.label.stats_active_extruder', {
+              filamentDiameter,
+              nozzleDiameter
+            })"
+          />
+          <p
+            v-html="$t('app.tool.label.stats_volumetric_flow', {
+              extrudeSpeed,
+              estimatedVolumetricFlow
+            })"
+          />
+          <p
+            v-html="$t('app.tool.label.stats_extruded_length', {
+              extrudeLength,
+              extrudeFactor: (extrudeFactor * 100).toFixed(),
+              estimatedExtrudedLength
+            })"
+          />
+          <p
+            v-html="$t('app.tool.label.stats_max_speed', {
+              layerHeight,
+              estimatedMaxSpeed
+            })"
+          />
+        </div>
+      </v-expansion-panel-content>
+    </v-expansion-panel>
+  </v-expansion-panels>
 </template>
 
 <script lang="ts">
@@ -119,10 +115,3 @@ export default class ExtruderMoves extends Mixins(StateMixin, ToolheadMixin) {
   }
 }
 </script>
-
-<style type="scss" scoped>
-:deep(.v-expansion-panel-header) {
-  padding-left: 0px;
-  padding-right: 0px;
-}
-</style>

--- a/src/components/widgets/toolhead/Toolhead.vue
+++ b/src/components/widgets/toolhead/Toolhead.vue
@@ -1,29 +1,35 @@
 <template>
-  <v-card-text>
-    <v-row
-      justify="space-between"
-      align="start"
-      class="mb-2"
-    >
-      <v-col class="controls-wrapper">
-        <extruder-selection v-if="multipleExtruders" />
-        <toolhead-moves v-if="!printerPrinting" />
-        <z-height-adjust v-if="printerPrinting" />
-      </v-col>
+  <div>
+    <v-card-text>
+      <v-row
+        justify="space-between"
+        align="start"
+      >
+        <v-col class="controls-wrapper">
+          <extruder-selection v-if="multipleExtruders" />
+          <toolhead-moves v-if="!printerPrinting" />
+          <z-height-adjust v-if="printerPrinting" />
+        </v-col>
 
-      <v-col class="controls-wrapper">
-        <toolhead-position />
-        <extruder-moves v-if="!printerPrinting" />
-        <z-height-adjust v-if="!printerPrinting" />
-      </v-col>
-      <v-col cols="12">
-        <extruder-stats />
-      </v-col>
-    </v-row>
+        <v-col class="controls-wrapper">
+          <toolhead-position />
+          <extruder-moves v-if="!printerPrinting" />
+          <z-height-adjust v-if="!printerPrinting" />
+        </v-col>
+      </v-row>
+    </v-card-text>
 
-    <speed-and-flow-adjust />
-    <pressure-advance-adjust v-if="showPressureAdvance" />
-  </v-card-text>
+    <v-divider />
+
+    <extruder-stats />
+
+    <v-divider />
+
+    <v-card-text>
+      <speed-and-flow-adjust />
+      <pressure-advance-adjust v-if="showPressureAdvance" />
+    </v-card-text>
+  </div>
 </template>
 
 <script lang="ts">


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/85504/203333481-407bb52a-c02c-423d-b71f-e651251caacd.png)

After:

![image](https://user-images.githubusercontent.com/85504/203333513-7748c435-95e7-40e2-9a05-526394dc629a.png)

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>