### PR TITLE
style: improves ExcludeObjectsDialog states visibility

### DIFF
--- a/src/components/widgets/exclude-objects/ExcludeObjectsDialog.vue
+++ b/src/components/widgets/exclude-objects/ExcludeObjectsDialog.vue
@@ -16,11 +16,17 @@
           <v-simple-table>
             <tbody>
               <tr
-                v-for="part in parts"
-                :key="part.name"
+                v-for="name in parts"
+                :key="name"
               >
-                <td class="partName">
-                  {{ part.name }}
+                <td
+                  :class="{
+                    'text--disabled': isPartExcluded(name),
+                    'info--text': isPartCurrent(name)
+                  }"
+                  class="partName"
+                >
+                  {{ name }}
                 </td>
                 <td class="actions">
                   <app-btn
@@ -28,8 +34,8 @@
                     x-small
                     fab
                     text
-                    :disabled="isPartExcluded(part.name)"
-                    @click="cancelObject(part.name)"
+                    :disabled="isPartExcluded(name)"
+                    @click="cancelObject(name)"
                   >
                     <v-icon color="error">
                       $cancelled
@@ -55,21 +61,26 @@ export default class ExcludeObjectDialog extends Mixins(StateMixin) {
     open!: boolean
 
   get parts () {
-    return this.$store.getters['parts/getParts']
+    const parts = this.$store.getters['parts/getParts']
+    return Object.keys(parts)
   }
 
   isPartExcluded (name: string) {
     return this.$store.getters['parts/getIsPartExcluded'](name)
   }
 
-  async cancelObject (id: string) {
+  isPartCurrent (name: string) {
+    return this.$store.getters['parts/getIsPartCurrent'](name)
+  }
+
+  async cancelObject (name: string) {
     const res = await this.$confirm(
       this.$tc('app.general.simple_form.msg.confirm_exclude_object'),
       { title: this.$tc('app.general.label.confirm'), color: 'card-heading', icon: '$error' }
     )
 
     if (res) {
-      const reqId = id.toUpperCase().replace(/\s/g, '_')
+      const reqId = name.toUpperCase().replace(/\s/g, '_')
 
       this.sendGcode(`EXCLUDE_OBJECT NAME=${reqId}`)
     }


### PR DESCRIPTION
Highlight the current printing part and show the full row as disabled for excluded parts.

## Before

![image](https://user-images.githubusercontent.com/85504/204101773-aa2c5807-0474-44ba-986f-d8585e5536ea.png)

## After

![image](https://user-images.githubusercontent.com/85504/204101762-eddce16d-565a-4fec-ad91-37929187247e.png)

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>