### PR TITLE
feat: supports Klipper output pin toggle in AppBar

### DIFF
--- a/src/components/settings/GeneralSettings.vue
+++ b/src/components/settings/GeneralSettings.vue
@@ -154,6 +154,8 @@ import { Component, Mixins, Ref } from 'vue-property-decorator'
 import StateMixin from '@/mixins/state'
 import { VInput } from '@/types'
 import { SupportedLocales, DateFormats, TimeFormats } from '@/globals'
+import { OutputPin } from '@/store/printer/types'
+import { Device } from '@/store/power/types'
 
 @Component({
   components: {}
@@ -263,7 +265,18 @@ export default class GeneralSettings extends Mixins(StateMixin) {
   }
 
   get powerDevicesList () {
-    return this.$store.state.power.devices.map((device: { device: string }) => ({ text: device.device, value: device.device }))
+    const devices = this.$store.state.power.devices as Device[]
+    const deviceEntries = devices.map(device => ({ text: device.device, value: device.device }))
+
+    const pins = this.$store.getters['printer/getPins'] as OutputPin[]
+    const pinEntries = pins.map(outputPin => ({ text: outputPin.name, value: `${outputPin.name}:klipper` }))
+
+    return [
+      { header: 'Moonraker' },
+      ...deviceEntries,
+      { header: 'Klipper' },
+      ...pinEntries
+    ]
   }
 
   get confirmOnPowerDeviceChange () {

--- a/src/store/printer/getters.ts
+++ b/src/store/printer/getters.ts
@@ -438,6 +438,12 @@ export const getters: GetterTree<PrinterState, RootState> = {
     return outputs.sort((output: OutputPin) => output.pwm ? 1 : -1)
   },
 
+  getPinByName: (state, getters) => (name: string) => {
+    const pins = getters.getPins as OutputPin[]
+
+    return pins.find(pin => pin.name === name)
+  },
+
   /**
   * Return available fans and output pins
   */


### PR DESCRIPTION
We already allowed for a Moonraker Power Device toggle on the top AppBar, this adds the possibility of using a Klipper OutputPin instead!

Only visible difference is on the "Power toggle in top navigation" dropdown setting:

![image](https://user-images.githubusercontent.com/85504/205914472-1557fd08-f6cf-4fbc-bc91-ebbc09bd55ee.png)

Everything else remains unchanged, although for Klipper output pin toggle it will show the `SET_PIN` commands on the console.

This will deprecate #864

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>