### PR TITLE
fix: temperature chart legend

### DIFF
--- a/src/components/widgets/thermals/TemperatureTargets.vue
+++ b/src/components/widgets/thermals/TemperatureTargets.vue
@@ -243,10 +243,6 @@ export default class TemperatureTargets extends Mixins(StateMixin) {
     return this.$store.getters['printer/getSensors']
   }
 
-  get chartableSensors () {
-    return this.$store.getters['printer/getChartableSensors']
-  }
-
   get chartSelectedLegends () {
     return this.$store.getters['charts/getSelectedLegends']
   }

--- a/src/components/widgets/thermals/ThermalChart.vue
+++ b/src/components/widgets/thermals/ThermalChart.vue
@@ -164,7 +164,6 @@ export default class ThermalChart extends Vue {
         formatter: (params: any) => {
           let text = ''
           params
-            .reverse()
             .forEach((param: any) => {
               if (
                 !param.seriesName.toLowerCase().endsWith('target') &&
@@ -177,7 +176,7 @@ export default class ThermalChart extends Vue {
                   <div>
                     ${param.marker}
                     <span style="font-size:${fontSize}px;color:${fontColor};font-weight:400;margin-left:2px">
-                      ${param.seriesName}:
+                      ${this.$filters.startCase(param.seriesName)}:
                     </span>
                     <span style="float:right;margin-left:20px;font-size:${fontSize}px;color:${fontColor};font-weight:900">
                       ${param.value[param.seriesName].toFixed(2)}<small>°C</small>`

--- a/src/store/printer/getters.ts
+++ b/src/store/printer/getters.ts
@@ -616,24 +616,32 @@ export const getters: GetterTree<PrinterState, RootState> = {
    * to chart.
    */
   getChartableSensors: (state) => {
-    let sensors: string[] = []
-    const keys = [
-      'temperature_fan',
-      'temperature_probe',
-      'z_thermal_adjust',
-      'temperature_sensor'
+    const keyGroups = [
+      [
+        'temperature_fan'
+      ],
+      [
+        'temperature_probe',
+        'z_thermal_adjust',
+        'temperature_sensor'
+      ]
     ]
 
-    for (const key of Object.keys(state.printer)) {
-      if (keys.some(e => key.startsWith(e))) {
-        sensors.push(key)
-      }
-    }
+    const printerKeys = Object.keys(state.printer)
 
-    if (state.printer.heaters.available_heaters.length > 0) {
-      sensors = [...sensors, ...state.printer.heaters.available_heaters]
-    }
-    return sensors
+    const sensors = keyGroups.flatMap(keyGroup => {
+      return printerKeys
+        .filter(key => keyGroup.some(x => key.startsWith(x)))
+        .sort((a, b) => a.localeCompare(b))
+    })
+
+    const heaters = (state.printer.heaters.available_heaters as string[])
+      .sort((a, b) => a.localeCompare(b))
+
+    return [
+      ...heaters,
+      ...sensors
+    ]
   },
 
   getBedScrews: (_, getters) => {


### PR DESCRIPTION
Show the Temperature Chart legend with pretty names correctly sorted in the same order as the above Temperature List.

## Before

![image](https://user-images.githubusercontent.com/85504/206475450-2c7a020e-61cb-4c1a-90cb-a1edbbed80ea.png)

## After

![image](https://user-images.githubusercontent.com/85504/206475336-12464a15-1a1b-482d-8edc-608fcddbbb99.png)

Fixes #972 

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>