### PR TITLE
fix: ensures CodeLens is not shown if disabled

### DIFF
--- a/src/components/widgets/filesystem/FileEditor.vue
+++ b/src/components/widgets/filesystem/FileEditor.vue
@@ -40,22 +40,6 @@ export default class FileEditor extends Vue {
   // Our editor, once init'd.
   editor: Monaco.editor.IStandaloneCodeEditor | null = null
 
-  // Base editor options.
-  opts: Monaco.editor.IStandaloneEditorConstructionOptions = {
-    contextmenu: true,
-    readOnly: this.readonly,
-    codeLens: this.codeLens,
-    automaticLayout: true,
-    fontSize: 16,
-    scrollbar: {
-      useShadows: false
-    },
-    minimap: {
-      enabled: (!this.isMobile)
-    },
-    rulers: (this.isMobile) ? [80, 120] : []
-  }
-
   get isMobile () {
     return this.$vuetify.breakpoint.mobile
   }
@@ -80,7 +64,18 @@ export default class FileEditor extends Vue {
 
     // Create an editor instance.
     this.editor = monaco.editor.create(this.monacoEditor, {
-      ...this.opts
+      contextmenu: true,
+      readOnly: this.readonly,
+      codeLens: this.codeLens,
+      automaticLayout: true,
+      fontSize: 16,
+      scrollbar: {
+        useShadows: false
+      },
+      minimap: {
+        enabled: (!this.isMobile)
+      },
+      rulers: (this.isMobile) ? [80, 120] : []
     })
 
     // Define the model. The filename will map to the supported languages.


### PR DESCRIPTION
This is another issue was caused by the migration to Vite, where regular variables are not reactive by nature (which actually respects Vue defaults).

Inlining the variable fixes the problem.

Fixes #977

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>