### PR TITLE
feat: allow Fluidd to run fully offline

### DIFF
--- a/components.d.ts
+++ b/components.d.ts
@@ -43,6 +43,7 @@ declare module 'vue' {
     FlashMessage: typeof import('./src/components/common/FlashMessage.vue')['default']
     KlippyStatusCard: typeof import('./src/components/common/KlippyStatusCard.vue')['default']
     ManualProbeDialog: typeof import('./src/components/common/ManualProbeDialog.vue')['default']
+    RegisterServiceWorker: typeof import('./src/components/common/RegisterServiceWorker.vue')['default']
     RouterLink: typeof import('vue-router')['RouterLink']
     RouterView: typeof import('vue-router')['RouterView']
     SocketDisconnected: typeof import('./src/components/common/SocketDisconnected.vue')['default']

--- a/src/App.vue
+++ b/src/App.vue
@@ -63,6 +63,8 @@
               (!authenticated && apiConnected)
           "
         />
+
+        <register-service-worker />
       </v-container>
 
       <socket-disconnected

--- a/src/components/common/RegisterServiceWorker.vue
+++ b/src/components/common/RegisterServiceWorker.vue
@@ -1,26 +1,21 @@
 <template>
   <div>
     <v-snackbar
-      v-model="open"
-      :timeout="needRefresh ? undefined: 10000"
+      v-model="needRefresh"
+      timeout="-1"
+      multi-line
+      elevation="24"
+      bottom
+      right
     >
-      <span v-if="offlineReady">
-        Fluidd is ready to work offline
-      </span>
-      <span v-else>
-        New content available, please click on reload button to update.
-      </span>
-      <template
-        v-if="needRefresh"
-        #action="{ attrs }"
-      >
-        <v-btn
-          text
+      <span v-html="$t('app.general.msg.needs_refresh')" />
+      <template #action="{ attrs }">
+        <app-btn
           v-bind="attrs"
           @click="updateServiceWorker"
         >
-          Reload
-        </v-btn>
+          {{ $t('app.general.btn.reload') }}
+        </app-btn>
       </template>
     </v-snackbar>
   </div>
@@ -29,25 +24,16 @@
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator'
 import consola from 'consola'
+import { EventBus } from '@/eventBus'
 
 @Component({})
 export default class RegisterServiceWorker extends Vue {
   updateSW: ((reloadPage?: boolean) => Promise<void>) | null = null
-  offlineReady = false
   needRefresh = false
-
-  get open () {
-    return this.offlineReady || this.needRefresh
-  }
-
-  set open (value: boolean) {
-    this.offlineReady = false
-    this.needRefresh = false
-  }
 
   onOfflineReady () {
     consola.debug('[PWA] ready for offline work')
-    this.offlineReady = true
+    EventBus.$emit(this.$tc('app.general.msg.offline_ready'), { timeout: 5000 })
   }
 
   onNeedRefresh () {
@@ -84,3 +70,10 @@ export default class RegisterServiceWorker extends Vue {
   }
 }
 </script>
+
+<style lang="scss" scoped>
+  :deep(.v-snack__wrapper .v-snack__content) {
+    overflow: hidden;
+    overflow-wrap: break-word;
+  }
+</style>

--- a/src/components/common/RegisterServiceWorker.vue
+++ b/src/components/common/RegisterServiceWorker.vue
@@ -1,0 +1,86 @@
+<template>
+  <div>
+    <v-snackbar
+      v-model="open"
+      :timeout="needRefresh ? undefined: 10000"
+    >
+      <span v-if="offlineReady">
+        Fluidd is ready to work offline
+      </span>
+      <span v-else>
+        New content available, please click on reload button to update.
+      </span>
+      <template
+        v-if="needRefresh"
+        #action="{ attrs }"
+      >
+        <v-btn
+          text
+          v-bind="attrs"
+          @click="updateServiceWorker"
+        >
+          Reload
+        </v-btn>
+      </template>
+    </v-snackbar>
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Vue } from 'vue-property-decorator'
+import consola from 'consola'
+
+@Component({})
+export default class RegisterServiceWorker extends Vue {
+  updateSW: ((reloadPage?: boolean) => Promise<void>) | null = null
+  offlineReady = false
+  needRefresh = false
+
+  get open () {
+    return this.offlineReady || this.needRefresh
+  }
+
+  set open (value: boolean) {
+    this.offlineReady = false
+    this.needRefresh = false
+  }
+
+  onOfflineReady () {
+    consola.debug('[PWA] ready for offline work')
+    this.offlineReady = true
+  }
+
+  onNeedRefresh () {
+    consola.debug('[PWA] needs refresh')
+    this.needRefresh = true
+  }
+
+  onRegistered (registration?: ServiceWorkerRegistration) {
+    consola.debug('[PWA] registered', registration)
+  }
+
+  onRegisterError (e: any) {
+    consola.error('[PWA] registration error', e)
+  }
+
+  updateServiceWorker () {
+    this.updateSW && this.updateSW(true)
+  }
+
+  async mounted () {
+    try {
+      const { registerSW } = await import('virtual:pwa-register')
+
+      this.updateSW = registerSW({
+        immediate: true,
+        onOfflineReady: this.onOfflineReady,
+        onNeedRefresh: this.onNeedRefresh,
+        onRegistered: this.onRegistered,
+        onRegisterError: this.onRegisterError
+      })
+    } catch {
+      consola.error('[PWA] disabled')
+    }
+  }
+}
+</script>

--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -166,6 +166,7 @@ app:
       reboot: Reboot
       recover: Recover
       refresh: Refresh
+      reload: Reload
       remove: Remove
       remove_all: Remove All
       rename: Rename
@@ -308,6 +309,8 @@ app:
         Click <b>Adjusted</b> if a significant adjustment is necessary on the current screw; otherwise, click <b>Accept</b> to continue.
       welcome_back: >-
         Welcome back.<br>Sign in below to stay in touch with your printer.
+      offline_ready: Fluidd is now ready to work offline.
+      needs_refresh: New content available, please click the <b>Reload</b> button to update.
     simple_form:
       error:
         arrayofnums: Only numbers

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -22,8 +22,7 @@ export default defineConfig({
       ],
       workbox: {
         globPatterns: [
-          '**/*.{js,css,html}',
-          'assets/*.*'
+          '**/*.{js,css,html,ttf,woff,woff2,wasm}'
         ],
         maximumFileSizeToCacheInBytes: 4 * 1024 ** 2,
         navigateFallbackDenylist: [

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,7 +14,6 @@ import version from './vite.config.inject-version'
 export default defineConfig({
   plugins: [
     VitePWA({
-      registerType: 'autoUpdate',
       includeAssets: [
         '**/*.svg',
         '**/*.png',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -40,6 +40,9 @@ export default defineConfig({
               cacheName: 'config',
               matchOptions: {
                 ignoreSearch: true
+              },
+              precacheFallback: {
+                fallbackURL: 'config.json'
               }
             }
           }
@@ -77,7 +80,8 @@ export default defineConfig({
         ]
       },
       devOptions: {
-        enabled: true
+        enabled: true,
+        type: 'module'
       }
     }),
     vue(),

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,13 +23,26 @@ export default defineConfig({
       ],
       workbox: {
         globPatterns: [
-          '**/*.{js,css,html,ttf,woff,woff2}'
+          '**/*.{js,css,html}',
+          'assets/*.*'
         ],
         maximumFileSizeToCacheInBytes: 4 * 1024 ** 2,
         navigateFallbackDenylist: [
           /^\/websocket/,
           /^\/(printer|api|access|machine|server)\//,
           /^\/webcam[2-4]?\//
+        ],
+        runtimeCaching: [
+          {
+            urlPattern: (options) => (options.sameOrigin && options.url.pathname.startsWith('/config.json')),
+            handler: 'StaleWhileRevalidate',
+            options: {
+              cacheName: 'config',
+              matchOptions: {
+                ignoreSearch: true
+              }
+            }
+          }
         ]
       },
       manifest: {


### PR DESCRIPTION
After the first load, Fluidd will be able to run completely offline!

What this means is that even if the host device where Fluidd was installed to goes offline, users will still be able to open Fluidd and connect to Moonraker (assuming it can be reached!)

This is by taking full advantage of the ServiceWorker cache features, so that all files are cached, including the "config.json" file which is the only dynamic file we have (so users can still change values on this file, click "refresh", and Fluidd will use the latest and cache the file for later offline work)

These changes will also improve the loading speed of Fluidd as most of the files required to run it will always be cached in the browser!

On first load, Fluidd will quickly show a flash message indicating that it is ready to run offline:

![image](https://user-images.githubusercontent.com/85504/208893609-10ef754a-b3aa-4290-9b94-7d018a6190bd.png)

On subsequent releases and updates of Fluidd, when the user loads Fluidd for the first time and cached files are updated, we will show a message on the bottom right corner indicating as such:

![image](https://user-images.githubusercontent.com/85504/208893897-defd5132-0977-4556-99a8-11cf6a1a1ea1.png)

At this stage the user can click "Reload" or hit F5 and Fluidd will be fully updated!

**Dev Note:** under dev this can be quite tricky to test, so my advice is to do an `npm run build` and then `npm run serve:prod`, load Fluidd, and once you see the indication of "ready for offline", stop the serve and hit F5 to see it hit the cache!

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>