### PR TITLE
fix: mitigates Vuetify bug filtering items ahead

### DIFF
--- a/src/components/widgets/filesystem/FileSystem.vue
+++ b/src/components/widgets/filesystem/FileSystem.vue
@@ -303,24 +303,7 @@ export default class FileSystem extends Mixins(StateMixin, FilesMixin, ServicesM
       { text: '', value: 'data-table-icons', sortable: false, width: '24px' },
       {
         text: this.$t('app.general.table.header.name'),
-        value: 'name',
-        filter: (value: string) => {
-          for (const filter of this.filters) {
-            switch (filter) {
-              case 'hidden_files':
-                if (value.match(/^\.(?!\.$)/)) {
-                  return false
-                }
-                break
-              case 'klipper_backup_files':
-                if (value.match(/^printer-\d{8}_\d{6}\.cfg$/)) {
-                  return false
-                }
-                break
-            }
-          }
-          return true
-        }
+        value: 'name'
       }
     ]
 
@@ -348,18 +331,6 @@ export default class FileSystem extends Mixins(StateMixin, FilesMixin, ServicesM
         {
           text: this.$t('app.general.table.header.last_printed'),
           value: 'print_start_time',
-          filter: (value: string, search: string | null, item: FileBrowserEntry | AppFileWithMeta) => {
-            for (const filter of this.filters) {
-              switch (filter) {
-                case 'print_start_time':
-                  if (item.type === 'file' && value !== null) {
-                    return false
-                  }
-                  break
-              }
-            }
-            return true
-          },
           configurable: true
         }
       ]
@@ -413,7 +384,35 @@ export default class FileSystem extends Mixins(StateMixin, FilesMixin, ServicesM
       return this.transformTimelapseItems(files)
     }
 
-    return files
+    const filteredFiles = files.filter(file => {
+      if (file.type !== 'file') {
+        return true
+      }
+
+      for (const filter of this.filters) {
+        switch (filter) {
+          case 'hidden_files':
+            if (file.name?.match(/^\.(?!\.$)/)) {
+              return false
+            }
+            break
+          case 'klipper_backup_files':
+            if (file.name?.match(/^printer-\d{8}_\d{6}\.cfg$/)) {
+              return false
+            }
+            break
+          case 'print_start_time':
+            if (file.print_start_time !== null) {
+              return false
+            }
+            break
+        }
+      }
+
+      return true
+    })
+
+    return filteredFiles
   }
 
   getAllFiles (): FileBrowserEntry[] {


### PR DESCRIPTION
The source of this problem can be traced to this [open issue in the Vuetify library](https://github.com/vuetifyjs/vuetify/issues/11600), but this only became an issue for us with the changes from #812.

This fix refactors the code to not rely on the Vuetify DataTable filter capability and instead we now filter the items ahead of binding to the DataTable

Fixes #989

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>