### PR TITLE
style: make upload & print icon consistent

### DIFF
--- a/src/components/layout/AppBar.vue
+++ b/src/components/layout/AppBar.vue
@@ -71,7 +71,7 @@
 
       <div v-if="authenticated && socketConnected && showUploadAndPrint">
         <app-upload-and-print-btn
-          :disabled="printerPrinting || printerPaused"
+          :disabled="printerPrinting || printerPaused || !klippyReady"
           @upload="handleUploadAndPrint"
         />
       </div>

--- a/src/components/layout/AppUploadAndPrintBtn.vue
+++ b/src/components/layout/AppUploadAndPrintBtn.vue
@@ -14,7 +14,7 @@
           @click="uploadFile.click()"
         >
           <v-icon>
-            $fileUpload
+            $progressUpload
           </v-icon>
         </app-btn>
       </template>


### PR DESCRIPTION
Use correct icon for "Upload and Print" functionality (using same one as in the popup menu of the Files card).

![image](https://user-images.githubusercontent.com/85504/210401564-6390bd0b-9696-4e85-a9af-a4fad7d4709b.png)

Fixes #1000 

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>