### PR TITLE
feat: Crowsnest camera support

### DIFF
--- a/src/components/widgets/camera/CameraItem.vue
+++ b/src/components/widgets/camera/CameraItem.vue
@@ -212,15 +212,20 @@ export default class CameraItem extends Vue {
   setUrl () {
     if (!document.hidden) {
       const type = this.camera.service
+      const isCrowsnest = this.camera.isCrowsnestServed
       const baseUrl = this.camera.urlStream || this.camera.urlSnapshot || ''
       const hostUrl = new URL(document.URL)
       const url = new URL(baseUrl, hostUrl.origin)
 
       this.cameraHeight = this.camera.height || 720
 
+      if (isCrowsnest) {
+        this.cameraFullScreenUrl = url.toString().replace('/snapshot', '/stream')
+      }
+
       if (type === 'mjpegstreamer') {
         url.searchParams.append('cacheBust', this.refresh.toString())
-        if (!url.searchParams.get('action')?.startsWith('stream')) {
+        if (!isCrowsnest && !url.searchParams.get('action')?.startsWith('stream')) {
           url.searchParams.set('action', 'stream')
         }
         this.cameraUrl = url.toString()
@@ -232,7 +237,7 @@ export default class CameraItem extends Vue {
       if (type === 'mjpegstreamer-adaptive') {
         this.request_start_time = performance.now()
         url.searchParams.append('cacheBust', this.refresh.toString())
-        if (!url.searchParams.get('action')?.startsWith('snapshot')) {
+        if (!isCrowsnest && !url.searchParams.get('action')?.startsWith('snapshot')) {
           url.searchParams.set('action', 'snapshot')
         }
         this.cameraUrl = url.toString()

--- a/src/locales/de.yaml
+++ b/src/locales/de.yaml
@@ -455,10 +455,14 @@ app:
       auto_edit_extensions: Erweiterungen, die automatisch im Bearbeitungsmodus geöffnet werden
       auto_follow_on_file_load: Fortschritt beim Laden einer Datei automatisch folgen
       auto_load_on_print_start: Datei bei Druckstart automatisch laden
+      camera_crowsnest_served: Mit Crowsnest betrieben
       camera_flip_x: Horizontal spiegeln
       camera_flip_y: Vertikal spiegeln
+      camera_reachable: Erreichbar
+      camera_reachable_crowsnest: Erreichbar - mit Crowsnest betrieben
       camera_rotate_by: Rotieren um
       camera_stream_type: Art des Kamerastreams
+      camera_unreachable: Nicht erreichbar
       camera_url: Kamera-Url
       confirm_dirty_editor_close: Schließen des Editors mit ungespeicherten Änderungen bestätigen
       confirm_on_estop: Bestätigung bei Notaus anfordern

--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -467,14 +467,18 @@ app:
       auto_follow_on_file_load: Automatically follow progress on file load
       auto_load_on_print_start: Automatically load file on print start
       axes: Axes
+      camera_crowsnest_served: Served by Crowsnest
       camera_flip_x: Flip horizontally
       camera_flip_y: Flip vertically
       camera_fullscreen_action:
         title: Fullscreen action
         embed: Embed
         rawstream: Raw stream
+      camera_reachable: Reachable
+      camera_reachable_crowsnest: Reachable - served by Crowsnest
       camera_rotate_by: Rotate by
       camera_stream_type: Stream type
+      camera_unreachable: Unreachable
       camera_url: Camera Url
       card: Card
       collector: Collector

--- a/src/store/cameras/types.ts
+++ b/src/store/cameras/types.ts
@@ -26,6 +26,7 @@ export interface CameraConfigWithoutId extends MoonrakerWebcamConfig {
   height?: number; // deprecated
   aspectRatio?: string;
   targetFpsIdle?: number;
+  isCrowsnestServed?: boolean;
 }
 
 export interface CameraConfig extends CameraConfigWithoutId {


### PR DESCRIPTION
* Fixes support for opening Crowsnest-served webcams as fullscreen
* Adds auto-detection for crowsnest-served cameras
* Adds reachability check on URL change

Not sure if the new v-switch is necessary here, in theory auto detection of mjpeg-streamer vs crowsnest would work, but IMO setting it manually is cleaner.