### PR TITLE
fix: sort files names numerically when prefixed by numbers

### DIFF
--- a/src/plugins/filters.ts
+++ b/src/plugins/filters.ts
@@ -295,8 +295,13 @@ export const Filters = {
 
         [sortA, sortB] = [sortA, sortB].map(s => (s || '').toString().toLocaleLowerCase())
 
-        if (a.type === 'directory' || b.type === 'directory') {
+        if (a.type === 'directory' || b.type === 'directory' || a.type === 'file' || b.type === 'file') {
           if (a.type === b.type) {
+            if (isNaN(sortA) && isNaN(sortB) && /^\d+/.test(sortA) && /^\d+/.test(sortB)) {
+              // sort file names numerically when prefixed by numbers
+              return (parseInt(sortA.match(/^\d+/)) - parseInt(sortB.match(/^\d+/)))
+            }
+
             return stringCollator.compare(sortA, sortB)
           } else {
             return 0


### PR DESCRIPTION
Closes #966

Before
![image](https://user-images.githubusercontent.com/25269274/212562992-c58e6b9f-ae5c-4743-b9f8-cbf6109a6d97.png)


After
![image](https://user-images.githubusercontent.com/25269274/212562985-39b9d7e3-196f-4bfa-8c79-463e88c966f2.png)
