### PR TITLE
feat: allow sorting text by version or prefix number

### DIFF
--- a/src/components/settings/GeneralSettings.vue
+++ b/src/components/settings/GeneralSettings.vue
@@ -66,6 +66,18 @@
 
       <v-divider />
 
+      <app-setting :title="$t('app.setting.label.text_sort_order')">
+        <v-select
+          v-model="textSortOrder"
+          filled
+          dense
+          hide-details="auto"
+          :items="availableTextSortOrders"
+        />
+      </app-setting>
+
+      <v-divider />
+
       <app-setting
         :title="$t('app.setting.label.confirm_on_estop')"
       >
@@ -251,6 +263,35 @@ export default class GeneralSettings extends Mixins(StateMixin) {
         value: key,
         text: `${date.toLocaleTimeString(entry.locale ?? this.$i18n.locale, entry.options)}${entry.suffix ?? ''}`
       }))
+  }
+
+  get textSortOrder () {
+    return this.$store.state.config.uiSettings.general.textSortOrder
+  }
+
+  set textSortOrder (value: boolean) {
+    this.$store.dispatch('config/saveByPath', {
+      path: 'uiSettings.general.textSortOrder',
+      value,
+      server: true
+    })
+  }
+
+  get availableTextSortOrders () {
+    return [
+      {
+        value: 'default',
+        text: this.$t('app.general.label.default')
+      },
+      {
+        value: 'numeric-prefix',
+        text: this.$t('app.general.label.numeric_prefix_sort')
+      },
+      {
+        value: 'version',
+        text: this.$t('app.general.label.version_sort')
+      }
+    ]
   }
 
   get confirmOnEstop () {

--- a/src/components/widgets/filesystem/FileSystemBrowser.vue
+++ b/src/components/widgets/filesystem/FileSystemBrowser.vue
@@ -13,7 +13,7 @@
       :disable-pagination="true"
       :loading="loading"
       :sort-desc="true"
-      :custom-sort="$filters.fileSystemSort"
+      :custom-sort="customSort"
       :search="search"
       :show-select="bulkActions"
       :no-data-text="$t('app.file_system.msg.not_found')"
@@ -345,6 +345,14 @@ export default class FileSystemBrowser extends Mixins(FilesMixin) {
     const thumbnailSize = this.$store.state.config.uiSettings.general.thumbnailSize
 
     return this.dense ? thumbnailSize / 2 : thumbnailSize
+  }
+
+  get textSortOrder () {
+    return this.$store.state.config.uiSettings.general.textSortOrder
+  }
+
+  customSort (items: FileBrowserEntry[], sortBy: string[], sortDesc: boolean[], locale: string) {
+    return this.$filters.fileSystemSort(items, sortBy, sortDesc, locale, this.textSortOrder)
   }
 
   mounted () {

--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -229,6 +229,7 @@ app:
       confirm: Confirm
       current_password: Current password
       current_user: Current user
+      default: Default
       disabled_while_printing: Disabled while printing
       edit_camera: Edit Camera
       edit_filter: Edit Filter
@@ -260,6 +261,7 @@ app:
       no_notifications: No notifications
       'on': 'On'
       'off': 'Off'
+      numeric_prefix_sort: Numeric Prefix sort
       password: Password
       partial_of_total: '%{partial} of %{total}'
       power: Power
@@ -297,6 +299,7 @@ app:
       username: Username
       variance: Variance
       velocity: Velocity
+      version_sort: Version sort
       visible: Visible
       z_offset: Z Offset
       unsaved_changes: Unsaved Changes
@@ -549,6 +552,7 @@ app:
       z_adjust_values: Z Adjust values
       date_format: Date format
       time_format: Time format
+      text_sort_order: Text Sort Order
       force_move_toggle_warning: Require confirm when activating FORCE_MOVE
       show_manual_probe_dialog_automatically: Show Manual Probe dialog automatically
       show_bed_screws_adjust_dialog_automatically: Show Bed Screws Adjust dialog automatically

--- a/src/store/config/state.ts
+++ b/src/store/config/state.ts
@@ -39,6 +39,7 @@ export const defaultState = (): ConfigState => {
         confirmOnSaveConfigAndRestart: true,
         dateFormat: 'iso',
         timeFormat: 'iso',
+        textSortOrder: 'default',
         showRateOfChange: false,
         showRelativeHumidity: true,
         showBarometricPressure: true,

--- a/src/store/config/types.ts
+++ b/src/store/config/types.ts
@@ -62,6 +62,7 @@ export interface GeneralConfig {
   confirmOnSaveConfigAndRestart: boolean;
   dateFormat: string;
   timeFormat: string;
+  textSortOrder: TextSortOrder;
   showRateOfChange: boolean;
   showRelativeHumidity: boolean;
   showBarometricPressure: boolean;
@@ -76,6 +77,8 @@ export interface GeneralConfig {
   enableDiagnostics: boolean;
   thumbnailSize: number;
 }
+
+export type TextSortOrder = 'default' | 'numeric-prefix' | 'version'
 
 export type CameraFullscreenAction = 'embed' | 'rawstream';
 

--- a/src/util/__tests__/version-string-compare.spec.ts
+++ b/src/util/__tests__/version-string-compare.spec.ts
@@ -1,0 +1,86 @@
+import versionStringCompare from '../version-string-compare'
+
+describe('naturalStringCompare', () => {
+  it.each([
+    [{ a: '1', b: '' }, 1],
+    [{ a: '1', b: '1' }, 0],
+    [{ a: '1', b: 'a' }, -1],
+    [{ a: 'a', b: 'a' }, 0],
+    [{ a: 'a1', b: 'a' }, 1],
+    [{ a: 'a1', b: 'a1' }, 0],
+    [{ a: 'a1', b: 'a2' }, -1],
+    [{ a: 'a10', b: 'a2' }, 1],
+    [{ a: 'a10a', b: 'a2' }, 1],
+    [{ a: 'a10', b: 'a2a' }, 1],
+    [{ a: 'a10a1', b: 'a10a10' }, -1],
+    [{ a: 'a1a', b: 'a2' }, -1]
+  ])('Expects natural comparison of "%s" to be %d', ({ a, b }, expected) => {
+    switch (expected) {
+      case -1:
+        expect(versionStringCompare(a, b)).toBeLessThan(0)
+        break
+      case 1:
+        expect(versionStringCompare(a, b)).toBeGreaterThan(0)
+        break
+      default:
+        expect(versionStringCompare(a, b)).toBe(0)
+        break
+    }
+  })
+
+  it('Can version sort files correctly', () => {
+    const input = [
+      'Untitled',
+      'Untitled.1gcode',
+      'Untitled.22.gcode',
+      'Untitled.2gcode',
+      'Untitled.gcode',
+      'Untitled2',
+      'Untitled22',
+      'Untitled22.gcode',
+      'Untitled22.1gcode',
+      'Untitled2a',
+      'Untitled3',
+      'Untitled_.gcode',
+      'Untitled_22',
+      'Untitled_22.gcode',
+      'Untitleda22',
+      'Untitleda22.gcode'
+    ]
+
+    expect(input.sort(versionStringCompare)).toEqual([
+      'Untitled',
+      'Untitled.gcode',
+      'Untitled2',
+      'Untitled2a',
+      'Untitled3',
+      'Untitled22',
+      'Untitled22.gcode',
+      'Untitled22.1gcode',
+      'Untitleda22',
+      'Untitleda22.gcode',
+      'Untitled.1gcode',
+      'Untitled.2gcode',
+      'Untitled.22.gcode',
+      'Untitled_.gcode',
+      'Untitled_22',
+      'Untitled_22.gcode'
+    ])
+  })
+
+  it('Can version sort tilde correctly', () => {
+    const input = [
+      'a',
+      '~',
+      '~~a',
+      '~~'
+    ]
+
+    expect(input.sort(versionStringCompare)).toEqual([
+      '~~',
+      '~~a',
+      '~',
+      'a'
+    ])
+  })
+})

--- a/src/util/version-string-compare.ts
+++ b/src/util/version-string-compare.ts
@@ -1,0 +1,111 @@
+// https://github.com/coreutils/gnulib/blob/master/lib/filevercmp.h
+// https://github.com/coreutils/gnulib/blob/master/lib/filevercmp.c
+
+const extensionRegExp = /((?:\.[A-Za-z~][A-Za-z0-9~]*)*)$/
+
+const charCode_0 = 0x30
+const charCode_9 = 0x39
+const charCode_A = 0x41
+const charCode_Z = 0x5A
+const charCode_a = 0x61
+const charCode_z = 0x7A
+const charCode_tilde = 0x7e
+
+const isDigit = (c: number) => c >= charCode_0 && c <= charCode_9
+const isAlpha = (c: number) => (c >= charCode_A && c <= charCode_Z) || (c >= charCode_a && c <= charCode_z)
+
+const stringToAsciiByteArray = (value: string) => {
+  const bytes = []
+  for (let index = 0; index < value.length; index++) {
+    const charCode = value.charCodeAt(index)
+    bytes.push(charCode & 0xFF)
+  }
+  return bytes
+}
+
+const order = (c: number): number => {
+  if (!c) {
+    return -1
+  } else if (isDigit(c)) {
+    return 0
+  } else if (isAlpha(c)) {
+    return c
+  } else if (c === charCode_tilde) {
+    return -2
+  } else {
+    return c + 256
+  }
+}
+
+const versionStringCompareHelper = (stringA: string, stringB: string) => {
+  const bufA = stringToAsciiByteArray(stringA)
+  const bufB = stringToAsciiByteArray(stringB)
+  const lenA = bufA.length
+  const lenB = bufB.length
+
+  if (lenA === 0 || lenB === 0) {
+    return lenA - lenB
+  }
+
+  let posA = 0
+  let posB = 0
+
+  while (posA < lenA && posB < lenB) {
+    let first_diff = 0
+
+    while ((posA < lenA && !isDigit(bufA[posA])) || (posB < lenB && !isDigit(bufB[posB]))) {
+      const a = order(bufA[posA])
+      const b = order(bufB[posB])
+      if (a !== b) {
+        return a - b
+      }
+      posA++
+      posB++
+    }
+
+    while (posA < lenA && bufA[posA] === charCode_0) {
+      posA++
+    }
+
+    while (posB < lenB && bufB[posB] === charCode_0) {
+      posB++
+    }
+
+    while (posA < lenA && posB < lenB && isDigit(bufA[posA]) && isDigit(bufB[posB])) {
+      if (!first_diff) {
+        first_diff = bufA[posA] - bufB[posB]
+      }
+      posA++
+      posB++
+    }
+
+    if (posA < lenA && isDigit(bufA[posA])) {
+      return 1
+    }
+
+    if (posB < lenB && isDigit(bufB[posB])) {
+      return -1
+    }
+
+    if (first_diff) {
+      return first_diff
+    }
+  }
+
+  return 0
+}
+
+const versionStringCompare = (stringA: string, stringB: string) => {
+  if (stringA === stringB) {
+    return 0
+  }
+
+  const nameA = stringA.replace(extensionRegExp, '')
+  const nameB = stringB.replace(extensionRegExp, '')
+
+  return nameA === nameB
+    ? versionStringCompareHelper(stringA, stringB)
+    : versionStringCompareHelper(nameA, nameB)
+}
+
+export default versionStringCompare


### PR DESCRIPTION
Allows user to select the type of sorting to apply on the file list between Default, Number Prefix sort, or Version sort.

![image](https://user-images.githubusercontent.com/85504/213326030-a3b594f2-f181-4191-a980-26c4af54e4c7.png)

Default is the current implementation, where we just `compare` from `Intl.Collator` for the current locale.

Number Prefix sort will check if the text has a number prefix (digits only) and if so, use that for sorting. When comparing 2 prefixes, if they are the same, then it will fallback to Default sort.

Version sort matches the type of sorting that `ls -v` or `sort -V` would use.

Example of version sorting:

![image](https://user-images.githubusercontent.com/85504/213479255-cc8fc6eb-589b-4b24-ad9e-bfc99fe6bf92.png)

Note: this does not apply to `number` type values, as those will just be compared directly (this includes dates stored as timestamps), so all the numeric values returned by Moonraker (like "filament", "filament width", or even "modified") will just be compared as regular numbers.

Fixes #966

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>