### PR TITLE
feat(ui): show content of release_info

### DIFF
--- a/src/components/widgets/system/SystemOverviewCard.vue
+++ b/src/components/widgets/system/SystemOverviewCard.vue
@@ -35,7 +35,7 @@
               <th>{{ $t('app.system_info.label.operating_system') }}</th>
               <td>{{ distribution.name }}</td>
             </tr>
-            <tr v-if="distribution.release_info.name">
+            <tr v-if="distribution.release_info?.name">
               <th>{{ $t('app.system_info.label.distribution_name') }}</th>
               <td>
                 {{ distribution.release_info.name }} {{ distribution.release_info.version_id }}

--- a/src/components/widgets/system/SystemOverviewCard.vue
+++ b/src/components/widgets/system/SystemOverviewCard.vue
@@ -7,15 +7,15 @@
       <v-col>
         <v-simple-table dense>
           <tbody>
-            <tr>
+            <tr v-if="printerInfo.hostname">
               <th>{{ $t('app.system_info.label.hostname') }}</th>
               <td>{{ printerInfo.hostname }}</td>
             </tr>
-            <tr>
+            <tr v-if="cpuInfo.model">
               <th>{{ $t('app.system_info.label.model') }}</th>
               <td>{{ cpuInfo.model }}</td>
             </tr>
-            <tr>
+            <tr v-if="cpuInfo.cpu_desc">
               <th>{{ $t('app.system_info.label.cpu_desc') }}</th>
               <td>{{ cpuInfo.cpu_desc }}</td>
             </tr>
@@ -23,25 +23,31 @@
               <th>{{ $t('app.system_info.label.total_memory') }}</th>
               <td>{{ $filters.getReadableFileSizeString(cpuInfo.total_memory * 1000) }}</td>
             </tr>
-            <tr>
+            <tr v-if="cpuInfo.hardware_desc">
               <th>{{ $t('app.system_info.label.hardware_desc') }}</th>
               <td>{{ cpuInfo.hardware_desc }}</td>
             </tr>
-            <tr>
+            <tr v-if="cpuInfo.bits && cpuInfo.processor && cpuInfo.cpu_count">
               <th>{{ $t('app.system_info.label.processor_desc') }}</th>
               <td>{{ cpuInfo.bits }} {{ cpuInfo.processor }} with {{ cpuInfo.cpu_count }} cores</td>
             </tr>
-            <tr>
-              <th>{{ $t('app.system_info.label.distribution_name') }}</th>
+            <tr v-if="distribution.name">
+              <th>{{ $t('app.system_info.label.operating_system') }}</th>
               <td>{{ distribution.name }}</td>
             </tr>
-            <tr>
-              <th>{{ $t('app.system_info.label.distribution_codename') }}</th>
-              <td>{{ distribution.codename }}</td>
+            <tr v-if="distribution.release_info.name">
+              <th>{{ $t('app.system_info.label.distribution_name') }}</th>
+              <td>
+                {{ distribution.release_info.name }} {{ distribution.release_info.version_id }}
+              </td>
             </tr>
-            <tr>
+            <tr v-if="distribution.like">
               <th>{{ $t('app.system_info.label.distribution_like') }}</th>
               <td>{{ distribution.like }}</td>
+            </tr>
+            <tr v-if="distribution.codename">
+              <th>{{ $t('app.system_info.label.distribution_codename') }}</th>
+              <td>{{ distribution.codename }}</td>
             </tr>
           </tbody>
         </v-simple-table>

--- a/src/locales/de.yaml
+++ b/src/locales/de.yaml
@@ -578,7 +578,7 @@ app:
       capacity: Gesamtgröße
       cpu_desc: CPU-Beschreibung
       distribution_codename: Codename
-      distribution_like: Distribution wie
+      distribution_like: Distribution basiert auf
       distribution_name: Distribution
       frequency: Frequenz
       hardware_desc: Hardwarebeschreibung
@@ -600,6 +600,7 @@ app:
       system_memory: Systemspeicher
       system_utilization: Auslastung
       total_memory: Gesamtspeicherplatz
+      operating_system: Betriebssystem
       version: Version
   tool:
     btn:

--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -608,6 +608,7 @@ app:
       system_memory: System Memory
       system_utilization: System Utilization
       total_memory: Total Memory
+      operating_system: Operating System
       version: Version
   tool:
     btn:

--- a/src/store/server/types.ts
+++ b/src/store/server/types.ts
@@ -97,6 +97,14 @@ export interface DistroInfo {
   version_parts: DistroVersionParts;
   like: string;
   codename: string;
+  release_info: ReleaseInfo;
+}
+
+export interface ReleaseInfo {
+  codename?: string;
+  id?: string;
+  name?: string;
+  version_id?: string;
 }
 
 export interface DistroVersionParts {

--- a/src/store/server/types.ts
+++ b/src/store/server/types.ts
@@ -97,7 +97,7 @@ export interface DistroInfo {
   version_parts: DistroVersionParts;
   like: string;
   codename: string;
-  release_info: ReleaseInfo;
+  release_info?: ReleaseInfo;
 }
 
 export interface ReleaseInfo {


### PR DESCRIPTION
This PR allows the showing of additional information about the distribution.
It also hides elements that are not available

<img width="685" alt="screenshot" src="https://user-images.githubusercontent.com/44060099/214155095-766caf82-2910-4652-973b-c287ea5217f3.png">

<img width="685" alt="screenshot" src="https://user-images.githubusercontent.com/44060099/214155101-ce246678-5af2-4397-b7ed-53789d7d9af8.png">
 

Signed-off-by: Kerim Bilgic <pfusch3d@gmail.com>