### PR TITLE
feat: show live speed while printing

### DIFF
--- a/src/components/widgets/toolhead/ToolheadPosition.vue
+++ b/src/components/widgets/toolhead/ToolheadPosition.vue
@@ -118,7 +118,7 @@
         cols="auto"
         class="secondary--text text--lighten-1"
       >
-        {{ $t('app.general.label.requested_speed') }}
+        {{ $t('app.general.label.requested_speed') }} [ {{ liveVelocity.toFixed(2) }} mm/s ]
       </v-col>
       <v-col
         cols="auto"
@@ -149,6 +149,10 @@ export default class ToolheadPosition extends Mixins(StateMixin, ToolheadMixin) 
 
   get livePosition () {
     return this.$store.state.printer.printer.motion_report.live_position
+  }
+
+  get liveVelocity () {
+    return this.$store.state.printer.printer.motion_report.live_velocity
   }
 
   get useGcodeCoords () {


### PR DESCRIPTION
Adds live speed to the Tool panel

![image](https://user-images.githubusercontent.com/85504/215063287-868b0344-c2c6-499a-bc11-6b9227488ca3.png)

Using the same style as in the live coordinates, we would just add the live speed to the "Speed" label, as shown on the above image.

Fixes #1018

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>