### PR TITLE
feat: Pressure Advance per extruder stepper

### DIFF
--- a/src/components/widgets/toolhead/ExtruderStats.vue
+++ b/src/components/widgets/toolhead/ExtruderStats.vue
@@ -70,10 +70,6 @@ import ToolheadMixin from '@/mixins/toolhead'
 
 @Component({})
 export default class ExtruderMoves extends Mixins(StateMixin, ToolheadMixin) {
-  get maxExtrudeLength (): number {
-    return this.activeExtruder?.max_extrude_only_distance || 50
-  }
-
   get filamentDiameter (): number {
     return this.activeExtruder?.filament_diameter || 1.75
   }

--- a/src/components/widgets/toolhead/PressureAdvanceAdjust.vue
+++ b/src/components/widgets/toolhead/PressureAdvanceAdjust.vue
@@ -7,12 +7,12 @@
       <app-slider
         :label="$t('app.general.label.pressure_advance')"
         suffix="s"
-        :value="activeExtruder.pressure_advance || 0"
+        :value="selectedExtruderStepper.pressure_advance || 0"
         :overridable="true"
-        :reset-value="activeExtruder.config_pressure_advance || 0"
+        :reset-value="selectedExtruderStepper.config_pressure_advance || 0"
         :disabled="!klippyReady"
         :locked="(!klippyReady || isMobile)"
-        :loading="hasWait($waits.onSetPressureAdvance)"
+        :loading="hasWait(`${$waits.onSetPressureAdvance}${selectedExtruderStepper.name ?? ''}`)"
         :min="0"
         :max="2"
         :step="0.0001"
@@ -26,12 +26,12 @@
       <app-slider
         :label="$t('app.general.label.smooth_time')"
         suffix="s"
-        :value="activeExtruder.smooth_time || 0"
+        :value="selectedExtruderStepper.smooth_time || 0"
         :overridable="false"
-        :reset-value="activeExtruder.config_smooth_time || 0"
+        :reset-value="selectedExtruderStepper.config_smooth_time || 0"
         :disabled="!klippyReady"
         :locked="(!klippyReady || isMobile)"
-        :loading="hasWait($waits.onSetPressureAdvance)"
+        :loading="hasWait(`${$waits.onSetPressureAdvance}${selectedExtruderStepper.name ?? ''}`)"
         :min="0"
         :max="0.2"
         :step="0.001"
@@ -42,18 +42,35 @@
 </template>
 
 <script lang="ts">
-import { Component, Mixins } from 'vue-property-decorator'
+import { Component, Mixins, Prop } from 'vue-property-decorator'
 import StateMixin from '@/mixins/state'
 import ToolheadMixin from '@/mixins/toolhead'
+import { ExtruderStepper } from '@/store/printer/types'
 
 @Component({})
 export default class PressureAdvanceAdjust extends Mixins(StateMixin, ToolheadMixin) {
+  @Prop({ type: Object, required: false })
+  readonly extruderStepper?: ExtruderStepper
+
+  get selectedExtruderStepper (): ExtruderStepper {
+    return this.extruderStepper ?? this.activeExtruder
+  }
+
   handleSetPressureAdvance (val: number) {
-    this.sendGcode('SET_PRESSURE_ADVANCE ADVANCE=' + val, this.$waits.onSetPressureAdvance)
+    this.sendSetPressureAdvance('ADVANCE', val)
   }
 
   handleSetSmoothTime (val: number) {
-    this.sendGcode('SET_PRESSURE_ADVANCE SMOOTH_TIME=' + val, this.$waits.onSetPressureAdvance)
+    this.sendSetPressureAdvance('SMOOTH_TIME', val)
+  }
+
+  sendSetPressureAdvance (arg: string, val: number) {
+    if (this.extruderStepper) {
+      const { name } = this.extruderStepper
+      this.sendGcode(`SET_PRESSURE_ADVANCE ${arg}=${val} EXTRUDER=${name}`, `${this.$waits.onSetPressureAdvance}${name}`)
+    } else {
+      this.sendGcode(`SET_PRESSURE_ADVANCE ${arg}=${val}`, this.$waits.onSetPressureAdvance)
+    }
   }
 
   get isMobile () {

--- a/src/components/widgets/toolhead/Toolhead.vue
+++ b/src/components/widgets/toolhead/Toolhead.vue
@@ -31,6 +31,35 @@
       <speed-and-flow-adjust />
       <pressure-advance-adjust v-if="showPressureAdvance" />
     </v-card-text>
+
+    <v-expansion-panels
+      accordion
+      multiple
+      flat
+    >
+      <v-expansion-panel
+        v-for="extruderStepper in extruderSteppers"
+        :key="`extruderStepper-${extruderStepper.name}`"
+      >
+        <v-divider />
+        <v-expansion-panel-header>
+          <template #actions>
+            <v-icon
+              small
+              class="my-1 mr-2"
+            >
+              $expand
+            </v-icon>
+          </template>
+          {{ $filters.startCase(extruderStepper.name) }}
+        </v-expansion-panel-header>
+        <v-expansion-panel-content>
+          <pressure-advance-adjust
+            :extruder-stepper="extruderStepper"
+          />
+        </v-expansion-panel-content>
+      </v-expansion-panel>
+    </v-expansion-panels>
   </div>
 </template>
 
@@ -45,6 +74,7 @@ import ZHeightAdjust from '@/components/widgets/toolhead/ZHeightAdjust.vue'
 import SpeedAndFlowAdjust from '@/components/widgets/toolhead/SpeedAndFlowAdjust.vue'
 import PressureAdvanceAdjust from '@/components/widgets/toolhead/PressureAdvanceAdjust.vue'
 import ExtruderStats from '@/components/widgets/toolhead/ExtruderStats.vue'
+import { ExtruderStepper } from '@/store/printer/types'
 
 @Component({
   components: {
@@ -61,6 +91,12 @@ import ExtruderStats from '@/components/widgets/toolhead/ExtruderStats.vue'
 export default class Toolhead extends Mixins(StateMixin) {
   get multipleExtruders () {
     return this.$store.getters['printer/getExtruders'].length > 1
+  }
+
+  get extruderSteppers () {
+    const extruderSteppers = this.$store.getters['printer/getExtruderSteppers'] as ExtruderStepper[]
+    return extruderSteppers
+      .filter(x => x.pressure_advance !== undefined)
   }
 
   get showPressureAdvance () {

--- a/src/store/printer/getters.ts
+++ b/src/store/printer/getters.ts
@@ -1,7 +1,7 @@
 import Vue from 'vue'
 import { GetterTree } from 'vuex'
 import { RootState } from '../types'
-import { PrinterState, Heater, Fan, Led, OutputPin, Sensor, RunoutSensor, Extruder, MCU, Endstop, Probe } from './types'
+import { PrinterState, Heater, Fan, Led, OutputPin, Sensor, RunoutSensor, Extruder, MCU, Endstop, Probe, ExtruderStepper } from './types'
 import { get } from 'lodash-es'
 import getKlipperType from '@/util/get-klipper-type'
 
@@ -288,6 +288,26 @@ export const getters: GetterTree<PrinterState, RootState> = {
       config_pressure_advance: c.pressure_advance,
       config_smooth_time: c.pressure_advance_smooth_time
     }
+  },
+
+  getExtruderSteppers: (state, getters) => {
+    const extruderSteppers: ExtruderStepper[] = []
+    for (const item in state.printer) {
+      const [type, name] = item.split(' ')
+
+      if (type === 'extruder_stepper') {
+        const e = state.printer[item]
+        const c = getters.getPrinterSettings(item)
+
+        extruderSteppers.push({
+          name,
+          ...e,
+          config_pressure_advance: c.pressure_advance,
+          config_smooth_time: c.pressure_advance_smooth_time
+        })
+      }
+    }
+    return extruderSteppers.sort((a, b) => a.name.localeCompare(b.name))
   },
 
   /**

--- a/src/store/printer/types.ts
+++ b/src/store/printer/types.ts
@@ -11,6 +11,14 @@ export interface Extruder {
   key: string;
 }
 
+export interface ExtruderStepper {
+  name: string;
+  pressure_advance: number;
+  smooth_time: number;
+  config_pressure_advance: number;
+  config_smooth_time: number;
+}
+
 export interface MCU {
   name: string;
   last_stats: MCUData;


### PR DESCRIPTION
The current Pressure Advance controls work fine when there is an `[extruder]` with a stepper attached, but when we have them separately (by using `[extruder_stepper]` entries), this would just not work as there is no "active extruder stepper" entity)

To fix this, we will now show the existing PA controls for active extruder if it has a stepper attached, and a new separate box with PA controls for each of the separate extruder steppers.

![image](https://user-images.githubusercontent.com/85504/216106717-c6b4da3d-2ad4-42ea-a51f-2dcaf3300b21.png)

These boxes are collapsible and by default they will load in collapsed state:

![image](https://user-images.githubusercontent.com/85504/216106847-091ed31e-7a55-48fb-937b-3a6f161eb7f9.png)

(Note: one can easily test this with a Docker container running [docker-klipper-simulavr](https://github.com/pedrolamas/docker-klipper-simulavr), just set the correct "dual stepper extruder" in the printer.cfg)

Fixes #681

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>