### PR TITLE
feat: Add support for gcode viewing on plotter-style devices

### DIFF
--- a/src/store/gcodePreview/getters.ts
+++ b/src/store/gcodePreview/getters.ts
@@ -48,7 +48,7 @@ export const getters: GetterTree<GcodePreviewState, RootState> = {
       ? (a: number, b: number) => Number.isNaN(a) || a < b
       : (a: number, b: number) => a !== b
 
-    moves.forEach((move, index) => {
+    moves.forEach((move: Move, index: number) => {
       if (move.z !== undefined && z !== move.z) {
         z = move.z
         zStart = index

--- a/src/store/gcodePreview/getters.ts
+++ b/src/store/gcodePreview/getters.ts
@@ -48,21 +48,31 @@ export const getters: GetterTree<GcodePreviewState, RootState> = {
       ? (a: number, b: number) => Number.isNaN(a) || a < b
       : (a: number, b: number) => a !== b
 
-    for (let index = 0; index < moves.length; index++) {
-      if (moves[index].z !== undefined && z !== moves[index].z) {
-        z = moves[index].z
+    moves.forEach((move, index) => {
+      if (move.z !== undefined && z !== move.z) {
+        z = move.z
         zStart = index
       }
 
-      if (moves[index].e > 0 && zCmp(zLast, z)) {
+      if (move.e > 0 && zCmp(zLast, z)) {
         zLast = z
 
         output.push({
           z,
           move: zStart,
-          filePosition: moves[index].filePosition
+          filePosition: move.filePosition
         })
       }
+    })
+
+    // If moves exist but there are no layers, add a single "default" layer at z=0
+    // This can happen for gcode that only contains travel moves (eg: 2d plotters without Z or E steppers)
+    if (output.length === 0 && moves.length > 0) {
+      output.push({
+        z: 0,
+        move: 0,
+        filePosition: moves[0].filePosition
+      })
     }
 
     return output

--- a/src/store/gcodePreview/getters.ts
+++ b/src/store/gcodePreview/getters.ts
@@ -54,7 +54,7 @@ export const getters: GetterTree<GcodePreviewState, RootState> = {
         zStart = index
       }
 
-      if (move.e > 0 && zCmp(zLast, z)) {
+      if (move.e && move.e > 0 && zCmp(zLast, z)) {
         zLast = z
 
         output.push({


### PR DESCRIPTION
Previously, the gcode viewer did not work if no extrusion moves were defined. This broke the viewer in cases where Klipper was being used on 2d plotters without a Z or extruder.

Signed-off-by: Kieran Eglin <kieran.eglin@gmail.com>