### PR TITLE
feat: setting to disable automatic gcode loading on mobile

### DIFF
--- a/src/components/settings/GcodePreviewSettings.vue
+++ b/src/components/settings/GcodePreviewSettings.vue
@@ -131,6 +131,18 @@
 
       <v-divider />
 
+      <app-setting :title="$t('app.setting.label.auto_load_mobile_on_print_start')">
+        <v-switch
+          v-model="autoLoadMobileOnPrintStart"
+          hide-details
+          class="mb-5"
+          @click.native.stop
+          :disabled="!autoLoadOnPrintStart"
+        />
+      </app-setting>
+
+      <v-divider />
+
       <app-setting :title="$t('app.setting.label.auto_follow_on_file_load')">
         <v-switch
           v-model="autoFollowOnFileLoad"
@@ -267,6 +279,18 @@ export default class GcodePreviewSettings extends Vue {
   set autoLoadOnPrintStart (value: boolean) {
     this.$store.dispatch('config/saveByPath', {
       path: 'uiSettings.gcodePreview.autoLoadOnPrintStart',
+      value,
+      server: true
+    })
+  }
+
+  get autoLoadMobileOnPrintStart () {
+    return this.$store.state.config.uiSettings.gcodePreview.autoLoadMobileOnPrintStart
+  }
+
+  set autoLoadMobileOnPrintStart (value: boolean) {
+    this.$store.dispatch('config/saveByPath', {
+      path: 'uiSettings.gcodePreview.autoLoadMobileOnPrintStart',
       value,
       server: true
     })

--- a/src/components/settings/GcodePreviewSettings.vue
+++ b/src/components/settings/GcodePreviewSettings.vue
@@ -131,12 +131,14 @@
 
       <v-divider />
 
-      <app-setting :title="$t('app.setting.label.auto_load_mobile_on_print_start')">
+      <app-setting
+        v-if="autoLoadOnPrintStart"
+        :title="$t('app.setting.label.auto_load_mobile_on_print_start')"
+      >
         <v-switch
           v-model="autoLoadMobileOnPrintStart"
           hide-details
           class="mb-5"
-          :disabled="!autoLoadOnPrintStart"
           @click.native.stop
         />
       </app-setting>

--- a/src/components/settings/GcodePreviewSettings.vue
+++ b/src/components/settings/GcodePreviewSettings.vue
@@ -136,8 +136,8 @@
           v-model="autoLoadMobileOnPrintStart"
           hide-details
           class="mb-5"
-          @click.native.stop
           :disabled="!autoLoadOnPrintStart"
+          @click.native.stop
         />
       </app-setting>
 

--- a/src/components/settings/GcodePreviewSettings.vue
+++ b/src/components/settings/GcodePreviewSettings.vue
@@ -282,6 +282,10 @@ export default class GcodePreviewSettings extends Vue {
       value,
       server: true
     })
+
+    if (!value) {
+      this.autoLoadMobileOnPrintStart = false
+    }
   }
 
   get autoLoadMobileOnPrintStart () {

--- a/src/components/settings/GcodePreviewSettings.vue
+++ b/src/components/settings/GcodePreviewSettings.vue
@@ -129,19 +129,18 @@
         />
       </app-setting>
 
-      <v-divider />
+      <template v-if="autoLoadOnPrintStart">
+        <v-divider />
 
-      <app-setting
-        v-if="autoLoadOnPrintStart"
-        :title="$t('app.setting.label.auto_load_mobile_on_print_start')"
-      >
-        <v-switch
-          v-model="autoLoadMobileOnPrintStart"
-          hide-details
-          class="mb-5"
-          @click.native.stop
-        />
-      </app-setting>
+        <app-setting :title="$t('app.setting.label.auto_load_mobile_on_print_start')">
+          <v-switch
+            v-model="autoLoadMobileOnPrintStart"
+            hide-details
+            class="mb-5"
+            @click.native.stop
+          />
+        </app-setting>
+      </template>
 
       <v-divider />
 

--- a/src/components/widgets/gcode-preview/GcodePreviewCard.vue
+++ b/src/components/widgets/gcode-preview/GcodePreviewCard.vue
@@ -355,6 +355,10 @@ export default class GcodePreviewCard extends Mixins(StateMixin, FilesMixin) {
   }
 
   get autoLoadOnPrintStart () {
+    if (this.isMobile) {
+      return this.$store.state.config.uiSettings.gcodePreview.autoLoadMobileOnPrintStart
+    }
+
     return this.$store.state.config.uiSettings.gcodePreview.autoLoadOnPrintStart
   }
 

--- a/src/locales/de.yaml
+++ b/src/locales/de.yaml
@@ -455,6 +455,7 @@ app:
       auto_edit_extensions: Erweiterungen, die automatisch im Bearbeitungsmodus geöffnet werden
       auto_follow_on_file_load: Fortschritt beim Laden einer Datei automatisch folgen
       auto_load_on_print_start: Datei bei Druckstart automatisch laden
+      auto_load_mobile_on_print_start: Datei bei Druckstart auch auf mobilen Geräten laden
       camera_flip_x: Horizontal spiegeln
       camera_flip_y: Vertikal spiegeln
       camera_rotate_by: Rotieren um

--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -471,6 +471,7 @@ app:
       auto_edit_extensions: Extensions to automatically open in edit mode
       auto_follow_on_file_load: Automatically follow progress on file load
       auto_load_on_print_start: Automatically load file on print start
+      auto_load_mobile_on_print_start: Automatically load file on mobile devices
       axes: Axes
       camera_flip_x: Flip horizontally
       camera_flip_y: Flip vertically

--- a/src/store/config/state.ts
+++ b/src/store/config/state.ts
@@ -118,6 +118,7 @@ export const defaultState = (): ConfigState => {
         showAnimations: true,
         groupLowerLayers: false,
         autoLoadOnPrintStart: false,
+        autoLoadMobileOnPrintStart: false,
         autoFollowOnFileLoad: true,
         autoZoom: false,
         flip: {

--- a/src/store/config/types.ts
+++ b/src/store/config/types.ts
@@ -175,6 +175,7 @@ export interface GcodePreviewConfig {
   showAnimations: boolean;
   groupLowerLayers: boolean;
   autoLoadOnPrintStart: boolean;
+  autoLoadMobileOnPrintStart: boolean;
   autoFollowOnFileLoad: boolean;
   autoZoom: boolean;
   flip: {


### PR DESCRIPTION
Works toward #934.

Automatic gcode loading works well on computers, but on mobile browsers it can take away control for several seconds, especially on remote connections. This PR adds a new setting to allow different loading behaviours on mobile vs. desktop.

Note: the label text could definitely use an editorial review.

Signed-off-by: Kieran Eglin <kieran.eglin@gmail.com>

![Screen Shot 2023-02-04 at 9 36 00 AM](https://user-images.githubusercontent.com/569917/216781537-74ff62a5-06b0-435f-a930-4e2852c1574d.jpg)
![Screen Shot 2023-02-04 at 9 36 04 AM](https://user-images.githubusercontent.com/569917/216781538-56b6aa27-426d-4396-a996-91b6c294c904.jpg)

