### PR TITLE
feat(timelapse): add new park positions

### DIFF
--- a/src/components/settings/timelapse/subsettings/CustomParkPositionSettings.vue
+++ b/src/components/settings/timelapse/subsettings/CustomParkPositionSettings.vue
@@ -1,52 +1,56 @@
 <template>
   <div>
-    <v-divider />
-    <app-setting
-      :title="$t('app.timelapse.setting.park_custom_pos_x')"
-      :sub-title="subtitleIfBlocked(getCustomParkPosBlocked('x'))"
-    >
-      <v-text-field
-        ref="parkPosXElement"
-        :value="parkPosX"
-        :rules="[
-          $rules.required,
-          $rules.numberValid,
-          $rules.numberGreaterThanOrEqual(printerMinX),
-          $rules.numberLessThanOrEqual(printerMaxX)
-        ]"
-        :disabled="getCustomParkPosBlocked('x')"
-        hide-details="auto"
-        filled
-        dense
-        single-line
-        suffix="mm"
-        @change="setParkPosX"
-      />
-    </app-setting>
+    <template v-if="['custom', 'x_only'].includes(parkpos)">
+      <v-divider />
+      <app-setting
+        :title="$t('app.timelapse.setting.park_custom_pos_x')"
+        :sub-title="subtitleIfBlocked(getCustomParkPosBlocked('x'))"
+      >
+        <v-text-field
+          ref="parkPosXElement"
+          :value="parkPosX"
+          :rules="[
+            $rules.required,
+            $rules.numberValid,
+            $rules.numberGreaterThanOrEqual(printerMinX),
+            $rules.numberLessThanOrEqual(printerMaxX)
+          ]"
+          :disabled="getCustomParkPosBlocked('x')"
+          hide-details="auto"
+          filled
+          dense
+          single-line
+          suffix="mm"
+          @change="setParkPosX"
+        />
+      </app-setting>
+    </template>
 
-    <v-divider />
-    <app-setting
-      :title="$t('app.timelapse.setting.park_custom_pos_y')"
-      :sub-title="subtitleIfBlocked(getCustomParkPosBlocked('y'))"
-    >
-      <v-text-field
-        ref="parkPosYElement"
-        :value="parkPosY"
-        :rules="[
-          $rules.required,
-          $rules.numberValid,
-          $rules.numberGreaterThanOrEqual(printerMinY),
-          $rules.numberLessThanOrEqual(printerMaxY)
-        ]"
-        :disabled="getCustomParkPosBlocked('y')"
-        hide-details="auto"
-        filled
-        dense
-        single-line
-        suffix="mm"
-        @change="setParkPosY"
-      />
-    </app-setting>
+    <template v-if="['custom', 'y_only'].includes(parkpos)">
+      <v-divider />
+      <app-setting
+        :title="$t('app.timelapse.setting.park_custom_pos_y')"
+        :sub-title="subtitleIfBlocked(getCustomParkPosBlocked('y'))"
+      >
+        <v-text-field
+          ref="parkPosYElement"
+          :value="parkPosY"
+          :rules="[
+            $rules.required,
+            $rules.numberValid,
+            $rules.numberGreaterThanOrEqual(printerMinY),
+            $rules.numberLessThanOrEqual(printerMaxY)
+          ]"
+          :disabled="getCustomParkPosBlocked('y')"
+          hide-details="auto"
+          filled
+          dense
+          single-line
+          suffix="mm"
+          @change="setParkPosY"
+        />
+      </app-setting>
+    </template>
   </div>
 </template>
 

--- a/src/components/settings/timelapse/subsettings/ToolheadParkingSettings.vue
+++ b/src/components/settings/timelapse/subsettings/ToolheadParkingSettings.vue
@@ -78,7 +78,7 @@
         />
       </app-setting>
 
-      <custom-park-position-settings v-if="parkpos === 'custom'" />
+      <custom-park-position-settings v-if="['custom', 'x_only', 'y_only'].includes(parkpos)" />
 
       <v-divider />
       <app-setting
@@ -148,7 +148,7 @@ export default class LayerMacroSettings extends Mixins(StateMixin) {
   readonly parkPosDZElement?: VInput
 
   get parkPositions (): {text: string, value: ParkPosition}[] {
-    const values: ParkPosition[] = ['front_left', 'front_right', 'center', 'back_left', 'back_right', 'custom']
+    const values: ParkPosition[] = ['front_left', 'front_right', 'center', 'back_left', 'back_right', 'x_only', 'y_only', 'custom']
 
     return values.map(value => ({ text: this.$tc(`app.timelapse.setting.parkpos.${value}`), value }))
   }

--- a/src/locales/de.yaml
+++ b/src/locales/de.yaml
@@ -699,6 +699,8 @@ app:
         center: Mitte
         back_left: Hinten links
         back_right: Hinten rechts
+        x_only: Nur X bewegen
+        y_only: Nur Y bewegen
       previewimage: Vorschaubild erzeugen
       saveframes: Einzelbilder speichern
       stream_delay_compensation: Verzögerungs-Kompensation

--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -727,6 +727,8 @@ app:
         center: Center
         back_left: Back Left
         back_right: Back Right
+        x_only: Move X only
+        y_only: Move Y only
       previewimage: Generate Thumbnail
       saveframes: Save Frames
       stream_delay_compensation: Delay Compensation

--- a/src/store/timelapse/types.ts
+++ b/src/store/timelapse/types.ts
@@ -64,7 +64,7 @@ export interface TimelapseWritableSettings {
 }
 
 export type TimelapseMode = 'layermacro' | 'hyperlapse';
-export type ParkPosition = 'custom' | 'front_left' | 'front_right' | 'center' | 'back_left' | 'back_right';
+export type ParkPosition = 'custom' | 'front_left' | 'front_right' | 'center' | 'back_left' | 'back_right' | 'x_only' | 'y_only';
 
 export interface RenderSettings {
   frameRate: number;


### PR DESCRIPTION
Adds support for [mainsail-crew/moonraker-timelapse#96](https://github.com/mainsail-crew/moonraker-timelapse/pull/96) by adding X_ONLY and Y_ONLY park position options