### PR TITLE
feat: updated tool extrusion settings to respect printer config

### DIFF
--- a/src/components/settings/ToolheadSettings.vue
+++ b/src/components/settings/ToolheadSettings.vue
@@ -58,7 +58,8 @@
           :rules="[
             $rules.required,
             $rules.numberValid,
-            $rules.numberGreaterThanOrEqual(1)
+            $rules.numberGreaterThanOrEqual(1),
+            $rules.numberLessThanOrEqual(maxExtrudeLength)
           ]"
           filled
           dense
@@ -77,7 +78,8 @@
           :rules="[
             $rules.required,
             $rules.numberValid,
-            $rules.numberGreaterThanOrEqual(1)
+            $rules.numberGreaterThanOrEqual(1),
+            $rules.numberLessThanOrEqual(maxExtrudeSpeed)
           ]"
           filled
           dense
@@ -244,14 +246,15 @@
 </template>
 
 <script lang="ts">
-import { Component, Ref, Vue } from 'vue-property-decorator'
+import { Component, Ref, Mixins } from 'vue-property-decorator'
 import { defaultState } from '@/store/config/state'
 import { VInput } from '@/types'
+import ToolheadMixin from '@/mixins/toolhead'
 
 @Component({
   components: {}
 })
-export default class ToolHeadSettings extends Vue {
+export default class ToolHeadSettings extends Mixins(ToolheadMixin) {
   @Ref('toolheadMoveDistances')
   readonly toolheadMoveDistancesElement!: VInput
 

--- a/src/components/widgets/toolhead/ExtruderMoves.vue
+++ b/src/components/widgets/toolhead/ExtruderMoves.vue
@@ -81,14 +81,6 @@ import ToolheadMixin from '@/mixins/toolhead'
 export default class ExtruderMoves extends Mixins(StateMixin, ToolheadMixin) {
   valid = true
 
-  get maxExtrudeSpeed () {
-    return this.activeExtruder?.max_extrude_only_velocity || 500
-  }
-
-  get maxExtrudeLength () {
-    return this.activeExtruder?.max_extrude_only_distance || 50
-  }
-
   get extrudeSpeed () {
     const extrudeSpeed = this.$store.state.config.uiSettings.toolhead.extrudeSpeed
 
@@ -123,16 +115,22 @@ export default class ExtruderMoves extends Mixins(StateMixin, ToolheadMixin) {
 
   sendRetractGcode (amount: number, rate: number, wait?: string) {
     if (this.valid) {
+      const safeAmount = Math.min(amount, this.maxExtrudeLength)
+      const safeRate = Math.min(rate, this.maxExtrudeSpeed)
+
       const gcode = `M83
-        G1 E-${amount} F${rate * 60}`
+        G1 E-${safeAmount} F${safeRate * 60}`
       this.sendGcode(gcode, wait)
     }
   }
 
   sendExtrudeGcode (amount: number, rate: number, wait?: string) {
     if (this.valid) {
+      const safeAmount = Math.min(amount, this.maxExtrudeLength)
+      const safeRate = Math.min(rate, this.maxExtrudeSpeed)
+
       const gcode = `M83
-        G1 E${amount} F${rate * 60}`
+        G1 E${safeAmount} F${safeRate * 60}`
       this.sendGcode(gcode, wait)
     }
   }

--- a/src/components/widgets/toolhead/ExtruderMoves.vue
+++ b/src/components/widgets/toolhead/ExtruderMoves.vue
@@ -1,5 +1,6 @@
 <template>
   <v-form
+    ref="form"
     v-model="valid"
     @submit.prevent
   >
@@ -9,10 +10,11 @@
         class="text-right"
       >
         <v-text-field
-          ref="lengthfield"
           v-model.number="extrudeLength"
           :disabled="!klippyReady"
           :rules="[
+            $rules.required,
+            $rules.numberValid,
             $rules.numberGreaterThanOrEqual(0.1),
             $rules.numberLessThanOrEqual(maxExtrudeLength)
           ]"
@@ -47,6 +49,8 @@
           v-model.number="extrudeSpeed"
           :disabled="!klippyReady"
           :rules="[
+            $rules.required,
+            $rules.numberValid,
             $rules.numberGreaterThanOrEqual(0.1),
             $rules.numberLessThanOrEqual(maxExtrudeSpeed)
           ]"
@@ -73,12 +77,16 @@
 </template>
 
 <script lang="ts">
-import { Component, Mixins } from 'vue-property-decorator'
+import { Component, Mixins, Ref } from 'vue-property-decorator'
 import StateMixin from '@/mixins/state'
 import ToolheadMixin from '@/mixins/toolhead'
+import { VForm } from '@/types'
 
 @Component({})
 export default class ExtruderMoves extends Mixins(StateMixin, ToolheadMixin) {
+  @Ref('form')
+  readonly form!: VForm
+
   valid = true
 
   get extrudeSpeed () {
@@ -115,24 +123,22 @@ export default class ExtruderMoves extends Mixins(StateMixin, ToolheadMixin) {
 
   sendRetractGcode (amount: number, rate: number, wait?: string) {
     if (this.valid) {
-      const safeAmount = Math.min(amount, this.maxExtrudeLength)
-      const safeRate = Math.min(rate, this.maxExtrudeSpeed)
-
       const gcode = `M83
-        G1 E-${safeAmount} F${safeRate * 60}`
+        G1 E-${amount} F${rate * 60}`
       this.sendGcode(gcode, wait)
     }
   }
 
   sendExtrudeGcode (amount: number, rate: number, wait?: string) {
     if (this.valid) {
-      const safeAmount = Math.min(amount, this.maxExtrudeLength)
-      const safeRate = Math.min(rate, this.maxExtrudeSpeed)
-
       const gcode = `M83
-        G1 E${safeAmount} F${safeRate * 60}`
+        G1 E${amount} F${rate * 60}`
       this.sendGcode(gcode, wait)
     }
+  }
+
+  mounted () {
+    this.form.validate()
   }
 }
 </script>

--- a/src/mixins/toolhead.ts
+++ b/src/mixins/toolhead.ts
@@ -8,10 +8,18 @@ export default class ToolheadMixin extends Vue {
   }
 
   get extruderReady () {
-    const extruder = this.$store.getters['printer/getActiveExtruder']
+    const extruder = this.activeExtruder
     return (extruder && extruder.temperature >= 0 && extruder.min_extrude_temp >= 0)
       ? (extruder.temperature >= extruder.min_extrude_temp)
       : false
+  }
+
+  get maxExtrudeSpeed () {
+    return this.activeExtruder?.max_extrude_only_velocity || 500
+  }
+
+  get maxExtrudeLength () {
+    return this.activeExtruder?.max_extrude_only_distance || 50
   }
 
   get allHomed (): boolean {


### PR DESCRIPTION
Fixes #1032

Updates the `ToolheadSettings` component to respect an extruder's `max_extrude_only_velocity` and `max_extrude_only_distance` when trying to update the default extrusion distance/speed values. Also adds a last-resort speed/distance check on extrusion/retraction commands

Signed-off-by: Kieran Eglin <kieran.eglin@gmail.com>