### PR TITLE
feat: adds support for extruder stepper enable

### DIFF
--- a/src/components/widgets/toolhead/ExtruderStepperSync.vue
+++ b/src/components/widgets/toolhead/ExtruderStepperSync.vue
@@ -17,6 +17,18 @@
         item-text="name"
         @change="sendSyncExtruderMotion"
       />
+    </v-col><v-col
+      v-if="extruderStepper.enabled !== undefined"
+      cols="12"
+      sm="6"
+    >
+      <app-switch
+        :value="extruderStepper.enabled"
+        :label="$t('app.general.label.stepper_enabled')"
+        :disabled="!klippyReady || printerPrinting"
+        :loading="hasWait(`${$waits.onStepperEnable}${extruderStepper.name}`)"
+        @change="sendSetStepperEnable"
+      />
     </v-col>
   </v-row>
 </template>
@@ -37,6 +49,10 @@ export default class ExtruderStepperSync extends Mixins(StateMixin) {
 
   sendSyncExtruderMotion (value: string | null) {
     this.sendGcode(`SYNC_EXTRUDER_MOTION EXTRUDER=${this.extruderStepper.name} MOTION_QUEUE=${value ?? ''}`, `${this.$waits.onSyncExtruder}${this.extruderStepper.name}`)
+  }
+
+  sendSetStepperEnable (value: boolean) {
+    this.sendGcode(`SET_STEPPER_ENABLE STEPPER="${this.extruderStepper.key}" ENABLE=${+value}`, `${this.$waits.onStepperEnable}${this.extruderStepper.name}`)
   }
 }
 </script>

--- a/src/components/widgets/toolhead/ExtruderSteppers.vue
+++ b/src/components/widgets/toolhead/ExtruderSteppers.vue
@@ -30,7 +30,7 @@
               v-else
               key="1"
             >
-              {{ extruderStepper.prettyName }} <span class="secondary--text">[ {{ extruderStepper.motion_queue_pretty_name }} ]</span>
+              {{ extruderStepper.prettyName }} <span class="secondary--text">[ {{ extruderStepper.description }} ]</span>
             </span>
           </v-fade-transition>
         </template>
@@ -67,10 +67,16 @@ export default class ExtruderSteppers extends Vue {
     const extruderSteppers = this.$store.getters['printer/getExtruderSteppers'] as ExtruderStepper[]
 
     return extruderSteppers
-      .map(x => ({
-        ...x,
-        motion_queue_pretty_name: extruders.find(y => y.key === x.motion_queue)?.name ?? this.$t('app.setting.label.none')
-      }))
+      .map(x => {
+        const motionQueueName = extruders.find(y => y.key === x.motion_queue)?.name ?? this.$t('app.setting.label.none')
+        const enabledDesc = x.enabled !== undefined && this.$t(`app.general.label.${x.enabled ? 'on' : 'off'}`)
+        const description = enabledDesc ? `${motionQueueName}, ${enabledDesc}` : motionQueueName
+
+        return {
+          ...x,
+          description
+        }
+      })
   }
 }
 </script>

--- a/src/globals.ts
+++ b/src/globals.ts
@@ -405,7 +405,8 @@ export const Waits = Object.freeze({
   onQueryEndstops: 'onQueryEndstops',
   onQueryProbe: 'onQueryProbe',
   onVersionRefresh: 'onVersionRefresh',
-  onSyncExtruder: 'onSyncExtruder'
+  onSyncExtruder: 'onSyncExtruder',
+  onStepperEnable: 'onStepperEnable'
 })
 
 export const SupportedLocales = Object.freeze([

--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -282,6 +282,7 @@ app:
       smooth_time: Smooth Time
       speed: Speed
       sqv: Square Corner Velocity
+      stepper_enabled: Stepper Enabled
       synced_extruder: Synced Extruder
       thumbnail_size: Thumbnail Size
       total: Total

--- a/src/store/printer/getters.ts
+++ b/src/store/printer/getters.ts
@@ -298,6 +298,8 @@ export const getters: GetterTree<PrinterState, RootState> = {
         extruderSteppers.push({
           name,
           prettyName: Vue.$filters.startCase(name),
+          key: item,
+          enabled: state.printer.stepper_enable?.steppers[item],
           ...e,
           config_pressure_advance: c.pressure_advance,
           config_smooth_time: c.pressure_advance_smooth_time

--- a/src/store/printer/types.ts
+++ b/src/store/printer/types.ts
@@ -14,6 +14,8 @@ export interface Extruder {
 export interface ExtruderStepper {
   name: string;
   prettyName: string;
+  key: string;
+  enabled?: boolean;
   pressure_advance: number;
   smooth_time: number;
   motion_queue?: string | null;


### PR DESCRIPTION
Adds support to enable/disable individual extruder steppers (only shown with latest Klipper where `stepper_enable` status object is provided)

## Collapsed

![image](https://user-images.githubusercontent.com/85504/218542038-91cdbc11-2e8e-4a75-8cb5-ce9016b20bdf.png)

## Expanded

![image](https://user-images.githubusercontent.com/85504/218542350-d7888d94-ad16-4527-98d3-46884421d101.png)

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>