### PR TITLE
chore: refactor isMobile to use mixin

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -21,7 +21,7 @@
     />
 
     <v-btn
-      v-if="isMobile && authenticated && socketConnected"
+      v-if="isMobileViewport && authenticated && socketConnected"
       x-small
       fab
       fixed
@@ -86,6 +86,7 @@ import { Component, Mixins, Watch } from 'vue-property-decorator'
 import { EventBus, FlashMessage } from '@/eventBus'
 import StateMixin from '@/mixins/state'
 import FilesMixin from '@/mixins/files'
+import BrowserMixin from '@/mixins/browser'
 import { LinkPropertyHref } from 'vue-meta'
 import FileSystemDownloadDialog from '@/components/widgets/filesystem/FileSystemDownloadDialog.vue'
 
@@ -106,7 +107,7 @@ import FileSystemDownloadDialog from '@/components/widgets/filesystem/FileSystem
     FileSystemDownloadDialog
   }
 })
-export default class App extends Mixins(StateMixin, FilesMixin) {
+export default class App extends Mixins(StateMixin, FilesMixin, BrowserMixin) {
   toolsdrawer: boolean | null = null
   navdrawer: boolean | null = null
   showUpdateUI = false
@@ -140,10 +141,6 @@ export default class App extends Mixins(StateMixin, FilesMixin) {
     let progress = this.$store.getters['printer/getPrintProgress']
     progress = (progress * 100).toFixed()
     return progress
-  }
-
-  get isMobile () {
-    return this.$vuetify.breakpoint.mobile
   }
 
   get pageTitle () {

--- a/src/components/layout/AppBar.vue
+++ b/src/components/layout/AppBar.vue
@@ -7,7 +7,7 @@
     :height="$globals.HEADER_HEIGHT"
   >
     <router-link
-      v-show="!isMobileUserAgent"
+      v-show="!isMobileViewport"
       to="/"
       class="toolbar-logo"
     >
@@ -16,7 +16,7 @@
 
     <div class="toolbar-title">
       <app-btn
-        v-if="isMobileUserAgent"
+        v-if="isMobileViewport"
         fab
         small
         :elevation="0"
@@ -49,7 +49,7 @@
         />
       </div>
 
-      <div v-if="socketConnected && !isMobileUserAgent && authenticated">
+      <div v-if="socketConnected && !isMobileViewport && authenticated">
         <v-tooltip bottom>
           <template #activator="{ on, attrs }">
             <app-btn

--- a/src/components/layout/AppBar.vue
+++ b/src/components/layout/AppBar.vue
@@ -7,7 +7,7 @@
     :height="$globals.HEADER_HEIGHT"
   >
     <router-link
-      v-show="!isMobile"
+      v-show="!isMobileUserAgent"
       to="/"
       class="toolbar-logo"
     >
@@ -16,7 +16,7 @@
 
     <div class="toolbar-title">
       <app-btn
-        v-if="isMobile"
+        v-if="isMobileUserAgent"
         fab
         small
         :elevation="0"
@@ -49,7 +49,7 @@
         />
       </div>
 
-      <div v-if="socketConnected && !isMobile && authenticated">
+      <div v-if="socketConnected && !isMobileUserAgent && authenticated">
         <v-tooltip bottom>
           <template #activator="{ on, attrs }">
             <app-btn
@@ -192,6 +192,7 @@ import { defaultState } from '@/store/layout/state'
 import StateMixin from '@/mixins/state'
 import ServicesMixin from '@/mixins/services'
 import FilesMixin from '@/mixins/files'
+import BrowserMixin from '@/mixins/browser'
 import { SocketActions } from '@/api/socketActions'
 import { OutputPin } from '@/store/printer/types'
 import { Device } from '@/store/power/types'
@@ -204,7 +205,7 @@ import { Device } from '@/store/power/types'
     AppUploadAndPrintBtn
   }
 })
-export default class AppBar extends Mixins(StateMixin, ServicesMixin, FilesMixin) {
+export default class AppBar extends Mixins(StateMixin, ServicesMixin, FilesMixin, BrowserMixin) {
   menu = false
   userPasswordDialogOpen = false
   pendingChangesDialogOpen = false
@@ -239,10 +240,6 @@ export default class AppBar extends Mixins(StateMixin, ServicesMixin, FilesMixin
 
   get theme () {
     return this.$store.getters['config/getTheme']
-  }
-
-  get isMobile () {
-    return this.$vuetify.breakpoint.mobile
   }
 
   get inLayout (): boolean {

--- a/src/components/layout/AppNavDrawer.vue
+++ b/src/components/layout/AppNavDrawer.vue
@@ -17,7 +17,7 @@
         :value="open"
       >
         <div
-          v-show="isMobile"
+          v-show="isMobileUserAgent"
           :style="`height: ${$globals.HEADER_HEIGHT}px;`"
           class="app-icon"
         >
@@ -125,9 +125,10 @@
 import { Component, Mixins, VModel } from 'vue-property-decorator'
 
 import StateMixin from '@/mixins/state'
+import BrowserMixin from '@/mixins/browser'
 
 @Component({})
-export default class AppNavDrawer extends Mixins(StateMixin) {
+export default class AppNavDrawer extends Mixins(StateMixin, BrowserMixin) {
   @VModel({ type: Boolean, default: true })
     open!: boolean
 
@@ -157,10 +158,6 @@ export default class AppNavDrawer extends Mixins(StateMixin) {
 
   get showSubNavigation () {
     return this.hasSubNavigation && this.socketConnected && this.authenticated
-  }
-
-  get isMobile () {
-    return this.$vuetify.breakpoint.mobile
   }
 }
 </script>

--- a/src/components/layout/AppNavDrawer.vue
+++ b/src/components/layout/AppNavDrawer.vue
@@ -17,7 +17,7 @@
         :value="open"
       >
         <div
-          v-show="isMobileUserAgent"
+          v-show="isMobileViewport"
           :style="`height: ${$globals.HEADER_HEIGHT}px;`"
           class="app-icon"
         >

--- a/src/components/layout/AppNotificationMenu.vue
+++ b/src/components/layout/AppNotificationMenu.vue
@@ -3,7 +3,7 @@
     v-model="menu"
     offset-y
     left
-    :max-width="(isMobile) ? 220 : 420"
+    :max-width="(isMobileViewport) ? 220 : 420"
     :close-on-content-click="false"
     :close-delay="300"
   >
@@ -154,7 +154,8 @@
 <script lang="ts">
 import { AppNotification } from '@/store/notifications/types'
 import isSetAppBadgeSupported from '@/util/is-set-app-badge-supported'
-import { Component, Vue, Watch } from 'vue-property-decorator'
+import { Component, Watch, Mixins } from 'vue-property-decorator'
+import BrowserMixin from '@/mixins/browser'
 import AppAnnouncementDismissMenu from './AppAnnouncementDismissMenu.vue'
 
 @Component({
@@ -162,7 +163,7 @@ import AppAnnouncementDismissMenu from './AppAnnouncementDismissMenu.vue'
     AppAnnouncementDismissMenu
   }
 })
-export default class AppNotificationMenu extends Vue {
+export default class AppNotificationMenu extends Mixins(BrowserMixin) {
   menu = false
 
   get notifications (): AppNotification[] {
@@ -205,10 +206,6 @@ export default class AppNotificationMenu extends Vue {
   get badgeColor () {
     if (this.color === 'transparent') return 'info'
     return this.color
-  }
-
-  get isMobile () {
-    return this.$vuetify.breakpoint.mobile
   }
 
   /**

--- a/src/components/ui/AppChart.vue
+++ b/src/components/ui/AppChart.vue
@@ -42,10 +42,6 @@ export default class AppChart extends Vue {
 
   ready = false
 
-  get isMobile () {
-    return this.$vuetify.breakpoint.mobile
-  }
-
   get isDark () {
     return this.$store.state.config.uiSettings.theme.isDark
   }

--- a/src/components/ui/AppNamedSlider.vue
+++ b/src/components/ui/AppNamedSlider.vue
@@ -35,7 +35,7 @@
         >
           <template #prepend>
             <v-btn
-              v-if="isMobile"
+              v-if="isMobileViewport"
               icon
               small
               :disabled="disabled"
@@ -89,11 +89,12 @@
 </template>
 
 <script lang="ts">
-import { Component, Prop, Watch, Vue, Ref, VModel } from 'vue-property-decorator'
+import { Component, Prop, Watch, Ref, VModel, Mixins } from 'vue-property-decorator'
 import { VForm } from '@/types'
+import BrowserMixin from '@/mixins/browser'
 
 @Component({})
-export default class AppNamedSlider extends Vue {
+export default class AppNamedSlider extends Mixins(BrowserMixin) {
   @VModel({ type: Number })
     inputValue!: number
 
@@ -177,11 +178,6 @@ export default class AppNamedSlider extends Vue {
   internalMax = 0
   overridden = false
   hasFocus = false
-
-  // If the parent updates the value.
-  get isMobile () {
-    return this.$vuetify.breakpoint.mobile
-  }
 
   get textRules () {
     // Apply a min and max rule as per the slider.

--- a/src/components/ui/AppNavItem.vue
+++ b/src/components/ui/AppNavItem.vue
@@ -1,7 +1,7 @@
 <template>
   <v-tooltip
     right
-    :disabled="isMobile"
+    :disabled="isMobileViewport"
   >
     <template #activator="{ attrs, on }">
       <v-list-item
@@ -24,7 +24,7 @@
     <span><slot /></span>
   </v-tooltip>
 
-  <!-- <v-tooltip right :disabled="isMobile">
+  <!-- <v-tooltip right :disabled="isMobileViewport">
     <template v-slot:activator="{ attrs, on }">
       <router-link
         :to="to"
@@ -51,9 +51,10 @@
 import { Component, Mixins, Prop } from 'vue-property-decorator'
 
 import StateMixin from '@/mixins/state'
+import BrowserMixin from '@/mixins/browser'
 
 @Component({})
-export default class AppNavItem extends Mixins(StateMixin) {
+export default class AppNavItem extends Mixins(StateMixin, BrowserMixin) {
   @Prop({ type: String })
   readonly title!: string
 
@@ -65,10 +66,6 @@ export default class AppNavItem extends Mixins(StateMixin) {
 
   @Prop({ type: String })
   readonly icon!: string
-
-  get isMobile () {
-    return this.$vuetify.breakpoint.mobile
-  }
 }
 
 </script>

--- a/src/components/widgets/bedmesh/BedMeshCard.vue
+++ b/src/components/widgets/bedmesh/BedMeshCard.vue
@@ -29,7 +29,7 @@
         :options="options"
         :data="series"
         :graphics="graphics"
-        :height="(isMobile) ? '225px' : '525px'"
+        :height="(isMobileViewport) ? '225px' : '525px'"
       />
 
       <span v-else>{{ $t('app.bedmesh.msg.not_loaded') }}</span>
@@ -42,13 +42,14 @@ import { Component, Mixins, Prop } from 'vue-property-decorator'
 import EChartsBedMesh from './BedMeshChart.vue'
 import StateMixin from '@/mixins/state'
 import ToolheadMixin from '@/mixins/toolhead'
+import BrowserMixin from '@/mixins/browser'
 
 @Component({
   components: {
     EChartsBedMesh
   }
 })
-export default class BedMeshCard extends Mixins(StateMixin, ToolheadMixin) {
+export default class BedMeshCard extends Mixins(StateMixin, ToolheadMixin, BrowserMixin) {
   @Prop({ type: Boolean, default: false })
   readonly fullScreen!: boolean
 
@@ -180,10 +181,6 @@ export default class BedMeshCard extends Mixins(StateMixin, ToolheadMixin) {
   // The current processed mesh data, if any.
   get mesh () {
     return this.$store.getters['mesh/getCurrentMeshData']
-  }
-
-  get isMobile () {
-    return this.$vuetify.breakpoint.mobile
   }
 }
 </script>

--- a/src/components/widgets/bedmesh/BedMeshChart.vue
+++ b/src/components/widgets/bedmesh/BedMeshChart.vue
@@ -18,12 +18,13 @@
 </template>
 
 <script lang='ts'>
-import { Vue, Component, Prop, Watch, Ref } from 'vue-property-decorator'
+import { Component, Prop, Watch, Ref, Mixins } from 'vue-property-decorator'
 import type { ECharts, EChartsOption, GraphicComponentOption } from 'echarts'
 import { merge, cloneDeepWith } from 'lodash-es'
+import BrowserMixin from '@/mixins/browser'
 
 @Component({})
-export default class EChartsBedMesh extends Vue {
+export default class EChartsBedMesh extends Mixins(BrowserMixin) {
   @Prop({ type: Array, required: true, default: {} })
   readonly data!: []
 
@@ -65,14 +66,14 @@ export default class EChartsBedMesh extends Vue {
     // If options includes series data, rip it out so we can merge it with
     // the given series in our initial options.
     const darkMode = this.$store.state.config.uiSettings.theme.isDark
-    const fontSize = (this.isMobile) ? 14 : 16
+    const fontSize = (this.isMobileViewport) ? 14 : 16
     let labelBackground = 'rgba(10,10,10,0.90)'
     const opacity = 0.10
     let fontColor = 'rgba(255,255,255,0.25)'
     let lineColor = '#ffffff'
     const visualMap = {
-      itemWidth: (this.isMobile) ? 15 : 25,
-      itemHeight: (this.isMobile) ? 140 : 280
+      itemWidth: (this.isMobileViewport) ? 15 : 25,
+      itemHeight: (this.isMobileViewport) ? 140 : 280
     }
     if (!darkMode) {
       labelBackground = 'rgba(255,255,255,0.90)'
@@ -202,10 +203,6 @@ export default class EChartsBedMesh extends Vue {
     // Merge the default options with the given prop.
     merge(opts, this.options)
     return opts
-  }
-
-  get isMobile () {
-    return this.$vuetify.breakpoint.mobile
   }
 
   tooltipFormatter (params: any) {

--- a/src/components/widgets/diagnostics/DiagnosticsCard.vue
+++ b/src/components/widgets/diagnostics/DiagnosticsCard.vue
@@ -32,12 +32,13 @@
 </template>
 
 <script lang="ts">
-import { Component, Vue, Prop } from 'vue-property-decorator'
+import { Component, Prop, Mixins } from 'vue-property-decorator'
 import { DiagnosticsCardConfig } from '@/store/diagnostics/types'
 import { EChartsOption } from 'echarts'
+import BrowserMixin from '@/mixins/browser'
 
 @Component({})
-export default class DiagnosticsCard extends Vue {
+export default class DiagnosticsCard extends Mixins(BrowserMixin) {
   @Prop({ type: Object, required: true })
   readonly config!: DiagnosticsCardConfig
 
@@ -45,16 +46,11 @@ export default class DiagnosticsCard extends Vue {
     return this.$store.state.charts.diagnostics || []
   }
 
-  get isMobile () {
-    return this.$vuetify.breakpoint.mobile
-  }
-
   get options () {
     const isDark = this.$store.state.config.uiSettings.theme.isDark
-    const isMobile = this.isMobile
 
     const fontColor = (isDark) ? 'rgba(255,255,255,0.65)' : 'rgba(0,0,0,0.45)'
-    const fontSize = (isMobile) ? 13 : 14
+    const fontSize = (this.isMobileViewport) ? 13 : 14
 
     const lineStyle = {
       color: (isDark) ? '#ffffff' : '#000000',
@@ -66,14 +62,14 @@ export default class DiagnosticsCard extends Vue {
       opacity: 0.5
     }
 
-    let right = (this.isMobile) ? 15 : 20
-    if (this.config.axes.length > 1) right = (this.isMobile) ? 35 : 45
+    let right = (this.isMobileViewport) ? 15 : 20
+    if (this.config.axes.length > 1) right = (this.isMobileViewport) ? 35 : 45
 
     const grid = {
       top: 20,
-      left: (this.isMobile) ? 35 : 45,
+      left: (this.isMobileViewport) ? 35 : 45,
       right,
-      bottom: (this.isMobile) ? 52 : 38
+      bottom: (this.isMobileViewport) ? 52 : 38
     }
 
     const tooltip = {
@@ -160,7 +156,7 @@ export default class DiagnosticsCard extends Vue {
           color: tooltip.textStyle.color,
           fontSize,
           formatter: '{H}:{mm}',
-          rotate: (this.isMobile) ? 45 : 0
+          rotate: (this.isMobileViewport) ? 45 : 0
         },
         axisPointer: {
           label: {

--- a/src/components/widgets/filesystem/FileEditor.vue
+++ b/src/components/widgets/filesystem/FileEditor.vue
@@ -16,12 +16,13 @@
 </template>
 
 <script lang="ts">
-import { Vue, Component, Prop, Ref } from 'vue-property-decorator'
+import { Component, Prop, Ref, Mixins } from 'vue-property-decorator'
+import BrowserMixin from '@/mixins/browser'
 import type * as Monaco from 'monaco-editor/esm/vs/editor/editor.api'
 let monaco: typeof Monaco // dynamically imported
 
 @Component({})
-export default class FileEditor extends Vue {
+export default class FileEditor extends Mixins(BrowserMixin) {
   @Prop({ type: String, required: true })
   readonly value!: string
 
@@ -39,10 +40,6 @@ export default class FileEditor extends Vue {
 
   // Our editor, once init'd.
   editor: Monaco.editor.IStandaloneCodeEditor | null = null
-
-  get isMobile () {
-    return this.$vuetify.breakpoint.mobile
-  }
 
   async mounted () {
     // Init the editor.
@@ -73,9 +70,9 @@ export default class FileEditor extends Vue {
         useShadows: false
       },
       minimap: {
-        enabled: (!this.isMobile)
+        enabled: (!this.isMobileViewport)
       },
-      rulers: (this.isMobile) ? [80, 120] : []
+      rulers: (this.isMobileViewport) ? [80, 120] : []
     })
 
     // Define the model. The filename will map to the supported languages.

--- a/src/components/widgets/filesystem/FileEditorDialog.vue
+++ b/src/components/widgets/filesystem/FileEditorDialog.vue
@@ -119,9 +119,9 @@
 <script lang="ts">
 import { Component, Mixins, Prop, Ref, VModel } from 'vue-property-decorator'
 import StateMixin from '@/mixins/state'
+import BrowserMixin from '@/mixins/browser'
 import FileEditor from './FileEditor.vue'
 import FileEditorTextOnly from './FileEditorTextOnly.vue'
-import isMobile from '@/util/is-mobile'
 import isWebAssemblySupported from '@/util/is-web-assembly-supported'
 
 @Component({
@@ -130,7 +130,7 @@ import isWebAssemblySupported from '@/util/is-web-assembly-supported'
     FileEditorTextOnly
   }
 })
-export default class FileEditorDialog extends Mixins(StateMixin) {
+export default class FileEditorDialog extends Mixins(StateMixin, BrowserMixin) {
   @VModel({ type: Boolean, required: true })
     open!: boolean
 
@@ -164,16 +164,12 @@ export default class FileEditorDialog extends Mixins(StateMixin) {
     )
   }
 
-  get isMobile () {
-    return isMobile()
-  }
-
   get isWebAssemblySupported () {
     return isWebAssemblySupported()
   }
 
   get useTextOnlyEditor () {
-    return this.isMobile || !this.isWebAssemblySupported
+    return this.isMobileUserAgent || !this.isWebAssemblySupported
   }
 
   get isUploading (): boolean {

--- a/src/components/widgets/gcode-preview/GcodePreview.vue
+++ b/src/components/widgets/gcode-preview/GcodePreview.vue
@@ -270,6 +270,7 @@
 <script lang="ts">
 import { Component, Mixins, Prop, Ref, Watch } from 'vue-property-decorator'
 import StateMixin from '@/mixins/state'
+import BrowserMixin from '@/mixins/browser'
 import panzoom, { PanZoom } from 'panzoom'
 import { BBox, LayerNr, LayerPaths } from '@/store/gcodePreview/types'
 import { GcodePreviewConfig } from '@/store/config/types'
@@ -284,7 +285,7 @@ import { AppFile } from '@/store/files/types'
     GcodePreviewButton
   }
 })
-export default class GcodePreview extends Mixins(StateMixin) {
+export default class GcodePreview extends Mixins(StateMixin, BrowserMixin) {
   @Prop({ type: Boolean, default: true })
   readonly disabled!: boolean
 
@@ -327,10 +328,6 @@ export default class GcodePreview extends Mixins(StateMixin) {
 
   get filePosition (): number {
     return this.$store.state.printer.printer.virtual_sdcard.file_position
-  }
-
-  get isMobile (): boolean {
-    return this.$vuetify.breakpoint.mobile
   }
 
   get extrusionLineWidth () {
@@ -574,7 +571,7 @@ export default class GcodePreview extends Mixins(StateMixin) {
 
   @Watch('focused')
   onFocusedChanged (value: boolean) {
-    if (this.panzoom && !this.isMobile) {
+    if (this.panzoom && !this.isMobileViewport) {
       if (value) {
         this.panzoom.resume()
       } else {
@@ -613,7 +610,7 @@ export default class GcodePreview extends Mixins(StateMixin) {
   }
 
   keepFocus () {
-    if (!this.isMobile) {
+    if (!this.isMobileViewport) {
       this.container.focus()
     }
   }

--- a/src/components/widgets/gcode-preview/GcodePreviewButton.vue
+++ b/src/components/widgets/gcode-preview/GcodePreviewButton.vue
@@ -8,7 +8,7 @@
         tabindex="-1"
         :disabled="disabled"
         :color="property ? 'primary' : undefined"
-        :retain-focus-on-click="!isMobile"
+        :retain-focus-on-click="!isMobileViewport"
         v-on="on"
         @click="property = !property"
       >
@@ -20,10 +20,11 @@
 </template>
 
 <script lang="ts">
-import { Component, Prop, Vue } from 'vue-property-decorator'
+import { Component, Prop, Mixins } from 'vue-property-decorator'
+import BrowserMixin from '@/mixins/browser'
 
 @Component({})
-export default class GcodePreviewButton extends Vue {
+export default class GcodePreviewButton extends Mixins(BrowserMixin) {
   @Prop({ type: String, required: true })
   readonly name!: string
 
@@ -35,10 +36,6 @@ export default class GcodePreviewButton extends Vue {
 
   @Prop({ type: Boolean, default: false })
   readonly disabled!: boolean
-
-  get isMobile (): boolean {
-    return this.$vuetify.breakpoint.mobile
-  }
 
   get property () {
     return this.$store.getters['gcodePreview/getViewerOption'](this.name)

--- a/src/components/widgets/gcode-preview/GcodePreviewCard.vue
+++ b/src/components/widgets/gcode-preview/GcodePreviewCard.vue
@@ -53,7 +53,7 @@
                 :min="(!fileLoaded) ? 0 : 1"
                 :max="layerCount"
                 :disabled="!fileLoaded"
-                :locked="isMobile"
+                :locked="isMobileViewport"
                 @input="setCurrentLayer($event - 1)"
               />
             </v-col>
@@ -66,7 +66,7 @@
                 :min="0"
                 :max="currentLayerMoveRange.max - currentLayerMoveRange.min"
                 :disabled="!fileLoaded"
-                :locked="isMobile"
+                :locked="isMobileViewport"
                 @input="setMoveProgress($event + currentLayerMoveRange.min)"
               />
             </v-col>
@@ -132,6 +132,7 @@
 import { Component, Mixins, Prop, Ref, Watch } from 'vue-property-decorator'
 import StateMixin from '@/mixins/state'
 import FilesMixin from '@/mixins/files'
+import BrowserMixin from '@/mixins/browser'
 import GcodePreview from './GcodePreview.vue'
 import GcodePreviewParserProgressDialog from './GcodePreviewParserProgressDialog.vue'
 import { AppFile } from '@/store/files/types'
@@ -143,7 +144,7 @@ import { MinMax } from '@/store/gcodePreview/types'
     GcodePreview
   }
 })
-export default class GcodePreviewCard extends Mixins(StateMixin, FilesMixin) {
+export default class GcodePreviewCard extends Mixins(StateMixin, FilesMixin, BrowserMixin) {
   @Prop({ type: Boolean, default: false })
   readonly menuCollapsed!: boolean
 
@@ -238,10 +239,6 @@ export default class GcodePreviewCard extends Mixins(StateMixin, FilesMixin) {
 
   get fileLoaded (): boolean {
     return this.$store.getters['gcodePreview/getMoves'].length > 0
-  }
-
-  get isMobile (): boolean {
-    return this.$vuetify.breakpoint.mobile
   }
 
   get parserProgress (): number {
@@ -352,7 +349,7 @@ export default class GcodePreviewCard extends Mixins(StateMixin, FilesMixin) {
   }
 
   get autoLoadOnPrintStart () {
-    if (this.isMobile) {
+    if (this.isMobileViewport) {
       return this.$store.state.config.uiSettings.gcodePreview.autoLoadMobileOnPrintStart
     }
 

--- a/src/components/widgets/limits/PrinterLimits.vue
+++ b/src/components/widgets/limits/PrinterLimits.vue
@@ -17,7 +17,7 @@
             :max="velocity.max"
             :disabled="!klippyReady"
             overridable
-            :locked="isMobile"
+            :locked="isMobileViewport"
             :loading="hasWait($waits.onSetVelocity)"
             suffix="mm/s"
             @submit="setVelocity"
@@ -38,7 +38,7 @@
             :step="0.1"
             :disabled="!klippyReady"
             overridable
-            :locked="isMobile"
+            :locked="isMobileViewport"
             :loading="hasWait($waits.onSetSCV)"
             suffix="mm/s"
             @submit="setSCV"
@@ -61,7 +61,7 @@
             :max="accel.max"
             :disabled="!klippyReady"
             overridable
-            :locked="isMobile"
+            :locked="isMobileViewport"
             :loading="hasWait($waits.onSetAcceleration)"
             suffix="mm/s²"
             @submit="setAcceleration"
@@ -81,7 +81,7 @@
             :max="decel.max"
             :disabled="!klippyReady"
             overridable
-            :locked="isMobile"
+            :locked="isMobileViewport"
             :loading="hasWait($waits.onSetDeceleration)"
             suffix="mm/s²"
             @submit="setDeceleration"
@@ -95,9 +95,10 @@
 <script lang="ts">
 import { Component, Mixins } from 'vue-property-decorator'
 import StateMixin from '@/mixins/state'
+import BrowserMixin from '@/mixins/browser'
 
 @Component({})
-export default class PrinterLimits extends Mixins(StateMixin) {
+export default class PrinterLimits extends Mixins(StateMixin, BrowserMixin) {
   get velocity () {
     const max = this.$store.getters['printer/getPrinterSettings']('printer.max_velocity')
     return {
@@ -128,10 +129,6 @@ export default class PrinterLimits extends Mixins(StateMixin) {
       current: this.$store.state.printer.printer.toolhead.square_corner_velocity,
       max
     }
-  }
-
-  get isMobile () {
-    return this.$vuetify.breakpoint.mobile
   }
 
   setVelocity (val: number) {

--- a/src/components/widgets/outputs/OutputFan.vue
+++ b/src/components/widgets/outputs/OutputFan.vue
@@ -10,7 +10,7 @@
         customRules.minFan
       ]"
       :disabled="!klippyReady"
-      :locked="isMobile"
+      :locked="isMobileViewport"
       :loading="hasWait(`${$waits.onSetFanSpeed}${fan.name}`)"
       @submit="handleChange"
     />
@@ -42,9 +42,10 @@
 import { Component, Mixins, Prop } from 'vue-property-decorator'
 import { Fan } from '@/store/printer/types'
 import StateMixin from '@/mixins/state'
+import BrowserMixin from '@/mixins/browser'
 
 @Component({})
-export default class OutputFan extends Mixins(StateMixin) {
+export default class OutputFan extends Mixins(StateMixin, BrowserMixin) {
   @Prop({ type: Object, required: true })
   readonly fan!: Fan
 
@@ -76,10 +77,6 @@ export default class OutputFan extends Mixins(StateMixin) {
     return (this.fan.rpm)
       ? this.fan.rpm.toFixed() + ' rpm'
       : undefined
-  }
-
-  get isMobile () {
-    return this.$vuetify.breakpoint.mobile
   }
 
   get customRules () {

--- a/src/components/widgets/outputs/OutputLed.vue
+++ b/src/components/widgets/outputs/OutputLed.vue
@@ -90,10 +90,6 @@ export default class OutputLed extends Mixins(StateMixin) {
     return color.hexString
   }
 
-  get isMobile () {
-    return this.$vuetify.breakpoint.mobile
-  }
-
   handleColorChange (value: { channel: string; color: IroColor }) {
     const selectedColor = value.color.rgb
 

--- a/src/components/widgets/outputs/OutputPin.vue
+++ b/src/components/widgets/outputs/OutputPin.vue
@@ -10,7 +10,7 @@
       :value="(pin.value * pin.scale) / 1"
       :reset-value="pin.config.value || 0"
       :disabled="!klippyReady"
-      :locked="isMobile"
+      :locked="isMobileViewport"
       :loading="hasWait(`${$waits.onSetOutputPin}${pin.name}`)"
       @submit="setValue"
     />
@@ -29,10 +29,11 @@
 <script lang="ts">
 import { Component, Mixins, Prop } from 'vue-property-decorator'
 import StateMixin from '@/mixins/state'
+import BrowserMixin from '@/mixins/browser'
 import { OutputPin as IOutputPin } from '@/store/printer/types'
 
 @Component({})
-export default class OutputPin extends Mixins(StateMixin) {
+export default class OutputPin extends Mixins(StateMixin, BrowserMixin) {
   @Prop({ type: Object, required: true })
   readonly pin!: IOutputPin
 
@@ -41,10 +42,6 @@ export default class OutputPin extends Mixins(StateMixin) {
       target = (target) ? this.pin.scale : 0
     }
     this.sendGcode(`SET_PIN PIN=${this.pin.name} VALUE=${target}`, `${this.$waits.onSetOutputPin}${this.pin.name}`)
-  }
-
-  get isMobile () {
-    return this.$vuetify.breakpoint.mobile
   }
 }
 </script>

--- a/src/components/widgets/retract/Retract.vue
+++ b/src/components/widgets/retract/Retract.vue
@@ -18,7 +18,7 @@
           :step="0.01"
           overridable
           :disabled="!klippyReady"
-          :locked="isMobile"
+          :locked="isMobileViewport"
           :loading="hasWait($waits.onSetRetractLength)"
           @submit="setRetractLength"
         />
@@ -40,7 +40,7 @@
           :step="0.01"
           overridable
           :disabled="!klippyReady"
-          :locked="isMobile"
+          :locked="isMobileViewport"
           :loading="hasWait($waits.onSetUnretractExtraLength)"
           @submit="setUnRetractExtraLength"
         />
@@ -64,7 +64,7 @@
           :max="retract_speed_max"
           overridable
           :disabled="!klippyReady"
-          :locked="isMobile"
+          :locked="isMobileViewport"
           :loading="hasWait($waits.onSetRetractSpeed)"
           @submit="setRetractSpeed"
         />
@@ -86,7 +86,7 @@
           :max="unretract_speed_max"
           overridable
           :disabled="!klippyReady"
-          :locked="isMobile"
+          :locked="isMobileViewport"
           :loading="hasWait($waits.onSetUnretractSpeed)"
           @submit="setUnretractSpeed"
         />
@@ -98,9 +98,10 @@
 <script lang="ts">
 import { Component, Mixins } from 'vue-property-decorator'
 import StateMixin from '@/mixins/state'
+import BrowserMixin from '@/mixins/browser'
 
 @Component({})
-export default class Retract extends Mixins(StateMixin) {
+export default class Retract extends Mixins(StateMixin, BrowserMixin) {
   get retract_length () {
     return this.$store.state.printer.printer.firmware_retraction.retract_length
   }
@@ -139,10 +140,6 @@ export default class Retract extends Mixins(StateMixin) {
 
   get defaults () {
     return this.$store.getters['printer/getPrinterSettings']('firmware_retraction') || {}
-  }
-
-  get isMobile () {
-    return this.$vuetify.breakpoint.mobile
   }
 
   setRetractLength (val: number) {

--- a/src/components/widgets/thermals/TemperatureCard.vue
+++ b/src/components/widgets/thermals/TemperatureCard.vue
@@ -76,7 +76,7 @@
 
       <thermal-chart
         ref="thermalchart"
-        :height="(isMobile) ? '180px' : '260px'"
+        :height="(isMobileViewport) ? '180px' : '260px'"
       />
     </template>
   </collapsable-card>
@@ -85,6 +85,7 @@
 <script lang="ts">
 import { Component, Mixins, Prop, Ref } from 'vue-property-decorator'
 import StateMixin from '@/mixins/state'
+import BrowserMixin from '@/mixins/browser'
 import { Fan, Heater } from '@/store/printer/types'
 
 import ThermalChart from '@/components/widgets/thermals/ThermalChart.vue'
@@ -99,7 +100,7 @@ import { TemperaturePreset } from '@/store/config/types'
     TemperaturePresetsMenu
   }
 })
-export default class TemperatureCard extends Mixins(StateMixin) {
+export default class TemperatureCard extends Mixins(StateMixin, BrowserMixin) {
   @Prop({ type: Boolean, default: false })
   readonly menuCollapsed!: boolean
 
@@ -180,10 +181,6 @@ export default class TemperatureCard extends Mixins(StateMixin) {
       value,
       server: true
     })
-  }
-
-  get isMobile () {
-    return this.$vuetify.breakpoint.mobile
   }
 
   handleApplyPreset (preset: TemperaturePreset) {

--- a/src/components/widgets/thermals/ThermalChart.vue
+++ b/src/components/widgets/thermals/ThermalChart.vue
@@ -16,12 +16,13 @@
 </template>
 
 <script lang='ts'>
-import { Vue, Component, Watch, Prop, Ref } from 'vue-property-decorator'
+import { Component, Watch, Prop, Ref, Mixins } from 'vue-property-decorator'
 import type { ECharts, EChartsOption } from 'echarts'
 import getKlipperType from '@/util/get-klipper-type'
+import BrowserMixin from '@/mixins/browser'
 
 @Component({})
-export default class ThermalChart extends Vue {
+export default class ThermalChart extends Mixins(BrowserMixin) {
   @Prop({ type: String, default: '100%' })
   readonly height!: string
 
@@ -35,9 +36,9 @@ export default class ThermalChart extends Vue {
   handleLegendSelectChange (e: { name: string; type: string; selected: {[index: string]: boolean } }) {
     this.$store.dispatch('charts/saveSelectedLegends', e.selected)
 
-    let right = (this.isMobile) ? 15 : 20
+    let right = (this.isMobileViewport) ? 15 : 20
     if (this.showPowerAxis(e.selected)) {
-      right = (this.isMobile) ? 25 : 45
+      right = (this.isMobileViewport) ? 25 : 45
     }
 
     if (
@@ -99,10 +100,9 @@ export default class ThermalChart extends Vue {
 
   get options () {
     const isDark = this.$store.state.config.uiSettings.theme.isDark
-    const isMobile = this.isMobile
 
     const fontColor = (isDark) ? 'rgba(255,255,255,0.65)' : 'rgba(0,0,0,0.45)'
-    const fontSize = (isMobile) ? 13 : 14
+    const fontSize = (this.isMobileViewport) ? 13 : 14
 
     const lineStyle = {
       color: (isDark) ? '#ffffff' : '#000000',
@@ -114,15 +114,15 @@ export default class ThermalChart extends Vue {
       opacity: 0.5
     }
 
-    let right = (this.isMobile) ? 15 : 20
+    let right = (this.isMobileViewport) ? 15 : 20
     if (this.showPowerAxis(this.initialSelected)) {
-      right = (this.isMobile) ? 35 : 45
+      right = (this.isMobileViewport) ? 35 : 45
     }
     const grid = {
       top: 20,
-      left: (this.isMobile) ? 35 : 45,
+      left: (this.isMobileViewport) ? 35 : 45,
       right,
-      bottom: (this.isMobile) ? 52 : 38
+      bottom: (this.isMobileViewport) ? 52 : 38
     }
 
     const tooltip = {
@@ -220,7 +220,7 @@ export default class ThermalChart extends Vue {
           color: tooltip.textStyle.color,
           fontSize,
           formatter: '{H}:{mm}',
-          rotate: (this.isMobile) ? 45 : 0
+          rotate: (this.isMobileViewport) ? 45 : 0
         },
         axisPointer: {
           label: {
@@ -292,7 +292,7 @@ export default class ThermalChart extends Vue {
 
   createSeries (label: string, key: string) {
     // Grab the color
-    const color = Vue.$colorset.next(getKlipperType(key), key)
+    const color = this.$colorset.next(getKlipperType(key), key)
 
     // Base properties
     const series: any = {
@@ -377,10 +377,6 @@ export default class ThermalChart extends Vue {
     const obj: { [index: string]: any } = { top: -10 }
     obj[['left', 'right'][+(pos[0] < size.viewSize[0] / 2)]] = 10
     return obj
-  }
-
-  get isMobile () {
-    return this.$vuetify.breakpoint.mobile
   }
 
   xAxisPointerFormatter (params: any) {

--- a/src/components/widgets/toolhead/PressureAdvanceAdjust.vue
+++ b/src/components/widgets/toolhead/PressureAdvanceAdjust.vue
@@ -11,7 +11,7 @@
         overridable
         :reset-value="selectedExtruderStepper.config_pressure_advance || 0"
         :disabled="!klippyReady"
-        :locked="isMobile"
+        :locked="isMobileViewport"
         :loading="hasWait(`${$waits.onSetPressureAdvance}${selectedExtruderStepper.name ?? ''}`)"
         :min="0"
         :max="2"
@@ -29,7 +29,7 @@
         :value="selectedExtruderStepper.smooth_time || 0"
         :reset-value="selectedExtruderStepper.config_smooth_time || 0"
         :disabled="!klippyReady"
-        :locked="isMobile"
+        :locked="isMobileViewport"
         :loading="hasWait(`${$waits.onSetPressureAdvance}${selectedExtruderStepper.name ?? ''}`)"
         :min="0"
         :max="0.2"
@@ -44,10 +44,11 @@
 import { Component, Mixins, Prop } from 'vue-property-decorator'
 import StateMixin from '@/mixins/state'
 import ToolheadMixin from '@/mixins/toolhead'
+import BrowserMixin from '@/mixins/browser'
 import { ExtruderStepper } from '@/store/printer/types'
 
 @Component({})
-export default class PressureAdvanceAdjust extends Mixins(StateMixin, ToolheadMixin) {
+export default class PressureAdvanceAdjust extends Mixins(StateMixin, ToolheadMixin, BrowserMixin) {
   @Prop({ type: Object, required: false })
   readonly extruderStepper?: ExtruderStepper
 
@@ -70,10 +71,6 @@ export default class PressureAdvanceAdjust extends Mixins(StateMixin, ToolheadMi
     } else {
       this.sendGcode(`SET_PRESSURE_ADVANCE ${arg}=${val}`, this.$waits.onSetPressureAdvance)
     }
-  }
-
-  get isMobile () {
-    return this.$vuetify.breakpoint.mobile
   }
 }
 </script>

--- a/src/components/widgets/toolhead/SpeedAndFlowAdjust.vue
+++ b/src/components/widgets/toolhead/SpeedAndFlowAdjust.vue
@@ -12,7 +12,7 @@
         :reset-value="100"
         :disabled="!klippyReady"
         :loading="hasWait($waits.onSetSpeed)"
-        :locked="isMobile"
+        :locked="isMobileViewport"
         :min="1"
         :max="200"
         @submit="handleSetSpeed"
@@ -30,7 +30,7 @@
         :reset-value="100"
         :disabled="!klippyReady"
         :loading="hasWait($waits.onSetFlow)"
-        :locked="isMobile"
+        :locked="isMobileViewport"
         :min="1"
         :max="200"
         @submit="handleSetFlow"
@@ -42,9 +42,10 @@
 <script lang="ts">
 import { Component, Mixins } from 'vue-property-decorator'
 import StateMixin from '@/mixins/state'
+import BrowserMixin from '@/mixins/browser'
 
 @Component({})
-export default class SpeedAndFlowAdjust extends Mixins(StateMixin) {
+export default class SpeedAndFlowAdjust extends Mixins(StateMixin, BrowserMixin) {
   get flow () {
     return Math.round(this.$store.state.printer.printer.gcode_move.extrude_factor * 100) || 100
   }
@@ -59,10 +60,6 @@ export default class SpeedAndFlowAdjust extends Mixins(StateMixin) {
 
   handleSetSpeed (val: number) {
     this.sendGcode(`M220 S${val}`, this.$waits.onSetSpeed)
-  }
-
-  get isMobile () {
-    return this.$vuetify.breakpoint.mobile
   }
 }
 </script>

--- a/src/mixins/browser.ts
+++ b/src/mixins/browser.ts
@@ -1,0 +1,15 @@
+import Vue from 'vue'
+import { Component } from 'vue-property-decorator'
+
+@Component
+export default class BrowserMixin extends Vue {
+  get isMobileViewport () {
+    return this.$vuetify.breakpoint.mobile
+  }
+
+  get isMobileUserAgent () {
+    const mobileUARegex = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i
+
+    return (navigator as any).userAgentData?.mobile ?? mobileUARegex.test(navigator.userAgent)
+  }
+}

--- a/src/mixins/browser.ts
+++ b/src/mixins/browser.ts
@@ -1,5 +1,4 @@
-import Vue from 'vue'
-import { Component } from 'vue-property-decorator'
+import { Vue, Component } from 'vue-property-decorator'
 
 @Component
 export default class BrowserMixin extends Vue {

--- a/src/util/is-mobile.ts
+++ b/src/util/is-mobile.ts
@@ -1,5 +1,0 @@
-const isMobile = () => {
-  return (navigator as any).userAgentData?.mobile ?? /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)
-}
-
-export default isMobile


### PR DESCRIPTION
Works toward (but does not resolve) #1044

This replaces the often-redefined `isMobile` component getter with a mixin. Since there was previously two mechanisms for detecting mobile (more commonly through viewport size but sometimes through user agent), I've also renamed `isMobile` to better reflect what we're actually checking for.

After this I'll make the change to fully resolve the issue above, but I didn't want to clutter up this PR.

Signed-off-by: Kieran Eglin <kieran.eglin@gmail.com>