### PR TITLE
fix: use Lithuanian "lt" for ISO-8601 formats

### DIFF
--- a/src/globals.ts
+++ b/src/globals.ts
@@ -440,7 +440,7 @@ type DateTimeFormat = {
 
 export const DateFormats = Object.freeze<Record<string, DateTimeFormat>>({
   iso: {
-    locale: 'sv-SE',
+    locale: 'lt',
     options: { day: '2-digit', month: '2-digit', year: 'numeric' },
     suffix: ' (ISO 8601)'
   },
@@ -454,7 +454,7 @@ export const DateFormats = Object.freeze<Record<string, DateTimeFormat>>({
 
 export const TimeFormats = Object.freeze<Record<string, DateTimeFormat>>({
   iso: {
-    locale: 'sv-SE',
+    locale: 'lt',
     options: { hour: '2-digit', minute: '2-digit', hour12: false },
     suffix: ' (ISO 8601)'
   },

--- a/src/plugins/__tests__/filters.spec.ts
+++ b/src/plugins/__tests__/filters.spec.ts
@@ -54,4 +54,24 @@ describe('formatDateTime', () => {
       expect(Filters.formatRelativeTimeToDate(date, new Date())).toBe('3 days ago')
     })
   })
+
+  it('Formats as ISO8601 correctly', () => {
+    timeTravel('2022-11-19 14:32', () => {
+      const now = Date.now()
+
+      expect(Filters.formatAbsoluteDateTime(now)).toBe('14:32')
+
+      const fiveMins = Date.now() + (5 * 60 * 1000)
+
+      expect(Filters.formatAbsoluteDateTime(fiveMins)).toBe('14:37')
+
+      const tenHours = Date.now() + (10 * 60 * 60 * 1000)
+
+      expect(Filters.formatAbsoluteDateTime(tenHours)).toBe('11-20 00:32')
+
+      const oneYear = Date.now() + (365 * 24 * 60 * 60 * 1000)
+
+      expect(Filters.formatAbsoluteDateTime(oneYear)).toBe('2023-11-19 14:32')
+    })
+  })
 })


### PR DESCRIPTION
As there is no way to use `Date.prototype.toLocaleDateString()` with ISO-8601, we have been using "sv-SE", but apparently this doesn't not handle correctly when we ask to omit the year.

I've checked all the locales I could find and "lt" (Lithuania) matches all the cases I have tested, so let's use that one going forward!

Fixes #1058 