### PR TITLE
fix: assume untrusted user before config receival

### DIFF
--- a/src/mixins/files.ts
+++ b/src/mixins/files.ts
@@ -18,7 +18,7 @@ export default class FilesMixin extends Vue {
   get isTrustedUser () {
     const forceLogins = this.$store.getters['server/getConfig'].authorization.force_logins
 
-    return !forceLogins || this.$store.getters['auth/getCurrentUser']?.username === '_TRUSTED_USER_'
+    return forceLogins === false || this.$store.getters['auth/getCurrentUser']?.username === '_TRUSTED_USER_'
   }
 
   getThumbUrl (thumbnails: Thumbnail[], path: string, large: boolean, date?: number) {


### PR DESCRIPTION
Fixes a theme loading race condition on setups where FORCE_LOGINS is turned on, resulting in a 401.
Assumes FORCE_LOGINS is enabled when the configuration hasn't been received yet.