### PR TITLE
fix: only add parts with defined polygon

### DIFF
--- a/src/workers/parseGcode.ts
+++ b/src/workers/parseGcode.ts
@@ -101,21 +101,21 @@ const parseGcode = (gcode: string, sendProgress: (filePosition: number) => void)
             newLayerForNextMove = true
           }
           break
-        case 'EXCLUDE_OBJECT_DEFINE': {
-          const polygonData = JSON.parse(args.polygon) as [number, number][]
+        case 'EXCLUDE_OBJECT_DEFINE':
+          if ('polygon' in args && args.polygon) {
+            const polygonData = JSON.parse(args.polygon) as [number, number][]
 
-          const part: Part = {
-            polygon: polygonData
-              .map(([x, y]): Point => ({
-                x,
-                y
-              }))
+            const part: Part = {
+              polygon: polygonData
+                .map(([x, y]): Point => ({
+                  x,
+                  y
+                }))
+            }
+
+            parts.push(Object.freeze(part))
           }
-
-          parts.push(Object.freeze(part))
-
           break
-        }
       }
     } else if (type === 'gcode') {
       switch (command) {


### PR DESCRIPTION
Ideally, all `EXCLUDE_OBJECT_DEFINE` have a `POLYGON` parameter, but a bug in Cura has caused this to not be the case.

This fix ensures we only attempt to show parts with a defined polygon on the G-code Previewer.

Fixes #1068 