### PR TITLE
fix: add API check before doing job queue reset

### DIFF
--- a/src/components/widgets/job-queue/JobQueueBrowser.vue
+++ b/src/components/widgets/job-queue/JobQueueBrowser.vue
@@ -115,7 +115,12 @@ export default class JobQueueBrowser extends Mixins(StateMixin) {
     const movedItem = filenames.splice(event.oldIndex, 1)[0]
     filenames.splice(event.newIndex, 0, movedItem)
 
-    SocketActions.serverJobQueuePostJob(filenames, true)
+    if (this.$store.getters['server/getIsMinApiVersion']('1.1.0')) {
+      SocketActions.serverJobQueuePostJob(filenames, true)
+    } else {
+      SocketActions.serverJobQueueDeleteJobs(['all'])
+      SocketActions.serverJobQueuePostJob(filenames)
+    }
   }
 }
 </script>


### PR DESCRIPTION
Only try to use the `reset` Boolean parameter in the POST endpoint of the `job_queue` component if the Moonraker API version is 1.1.0 or above.

If not, first call the DELETE with "all" to clear the job queue.

Fixes #1073