### PR TITLE
fix: add legacy bed mesh profiles from config

### DIFF
--- a/src/store/mesh/getters.ts
+++ b/src/store/mesh/getters.ts
@@ -1,5 +1,5 @@
 import { GetterTree } from 'vuex'
-import { BedMeshProfile, MeshState, AppMeshes, KlipperBedMesh } from './types'
+import { BedMeshProfile, MeshState, AppMeshes, KlipperBedMesh, KlipperBedMeshProfile, LegacyKlipperBedMeshProfile } from './types'
 import { RootState } from '../types'
 import { transformMesh } from '@/util/transform-mesh'
 
@@ -12,11 +12,48 @@ export const getters: GetterTree<MeshState, RootState> = {
     return rootGetters['printer/getPrinterSettings']('bed_mesh') !== undefined
   },
 
+  getLegacyBedMeshProfiles: (state, getters, rootState, rootGetters) => {
+    const klipperProfiles = {} as Record<string, KlipperBedMeshProfile>
+
+    const config = rootGetters['printer/getPrinterConfig']()
+    const meshProfileKeys = Object.keys(config)
+      .filter(key => key.startsWith('bed_mesh '))
+
+    for (const key of meshProfileKeys) {
+      const name = key.split(' ').splice(1).join(' ')
+      const legacyKlipperProfile = config[key] as LegacyKlipperBedMeshProfile
+
+      const profile: KlipperBedMeshProfile = {
+        points: legacyKlipperProfile.points.split('\n')
+          .filter(x => x.length)
+          .map(x => x.split(',').map(Number)),
+        mesh_params: {
+          algo: legacyKlipperProfile.algo,
+          max_x: +legacyKlipperProfile.max_x,
+          max_y: +legacyKlipperProfile.max_y,
+          mesh_x_pps: +legacyKlipperProfile.mesh_x_pps,
+          mesh_y_pps: +legacyKlipperProfile.mesh_y_pps,
+          min_x: +legacyKlipperProfile.min_x,
+          min_y: +legacyKlipperProfile.min_y,
+          tension: +legacyKlipperProfile.tension,
+          x_count: +legacyKlipperProfile.x_count,
+          y_count: +legacyKlipperProfile.y_count
+        }
+      }
+
+      klipperProfiles[name] = profile
+    }
+
+    return klipperProfiles
+  },
+
   getBedMeshProfiles: (state, getters, rootState) => {
     const profiles: BedMeshProfile[] = []
     const bedMesh = rootState.printer.printer.bed_mesh as KlipperBedMesh
 
-    for (const [name, profile] of Object.entries(bedMesh.profiles)) {
+    const klipperProfiles = bedMesh.profiles ?? getters.getLegacyBedMeshProfiles as Record<string, KlipperBedMeshProfile>
+
+    for (const [name, profile] of Object.entries(klipperProfiles)) {
       const points = profile.points.flatMap(x => x)
       const min = Math.min(...points)
       const max = Math.max(...points)

--- a/src/store/mesh/types.ts
+++ b/src/store/mesh/types.ts
@@ -15,7 +15,22 @@ export interface KlipperBedMesh {
   mesh_max?: number[];
   probed_matrix?: number[][];
   mesh_matrix?: number[][];
-  profiles: Record<string, KlipperBedMeshProfile>
+  profiles?: Record<string, KlipperBedMeshProfile>
+}
+
+export interface LegacyKlipperBedMeshProfile {
+  version: string;
+  points: string;
+  algo: string;
+  max_x: string;
+  max_y: string;
+  mesh_x_pps: string;
+  mesh_y_pps: string;
+  min_x: string;
+  min_y: string;
+  tension: string;
+  x_count: string;
+  y_count: string;
 }
 
 export interface KlipperBedMeshProfile {

--- a/src/store/printer/state.ts
+++ b/src/store/printer/state.ts
@@ -9,8 +9,7 @@ export const defaultState = (): PrinterState => {
     printer: {
       endstops: {},
       bed_mesh: {
-        profile_name: '',
-        profiles: []
+        profile_name: ''
       },
       heaters: {
         available_heaters: [],


### PR DESCRIPTION
Since v1.23.3, the bed mesh profiles are listed directly from the `bed_mesh` status object, however this only works with https://github.com/Klipper3d/klipper/commit/8b0c6fcb089769f70ecbb11cc3793dcd61f445dd or above.

Before v1.23.3, the bed mesh profiles were listed from the printer config entries, so this PR fixes the issue by adding back this "legacy" behavior when the `bed_mesh` status object doesn't have the profiles.

Fixes #1075