### PR TITLE
feat: adds Go To File dialog

### DIFF
--- a/components.d.ts
+++ b/components.d.ts
@@ -132,5 +132,6 @@ declare module 'vue' {
     VToolbarItems: typeof import('vuetify/lib')['VToolbarItems']
     VToolbarTitle: typeof import('vuetify/lib')['VToolbarTitle']
     VTooltip: typeof import('vuetify/lib')['VTooltip']
+    VVirtualScroll: typeof import('vuetify/lib')['VVirtualScroll']
   }
 }

--- a/src/components/widgets/filesystem/FileSystem.vue
+++ b/src/components/widgets/filesystem/FileSystem.vue
@@ -26,6 +26,7 @@
       @add-dir="handleAddDirDialog"
       @upload="handleUpload"
       @filter="handleFilter"
+      @go-to-file="handleGoToFileDialog"
     />
 
     <file-system-bulk-actions
@@ -120,9 +121,12 @@
       @remove="handleRemove"
     />
 
-    <!-- <pre>roots: {{ availableRoots }}</pre>
-    <pre>currentRoot: {{ currentRoot }}<br />currentPath: {{ currentPath }}<br />visiblePath: {{ visiblePath }}</pre>
-    <pre>dragState: {{ dragState }}</pre> -->
+    <file-system-go-to-file-dialog
+      v-if="goToFileDialogOpen"
+      v-model="goToFileDialogOpen"
+      :root="currentRoot"
+      @path-change="loadFiles"
+    />
   </v-card>
 </template>
 
@@ -149,6 +153,7 @@ import FileSystemContextMenu from './FileSystemContextMenu.vue'
 import FileEditorDialog from './FileEditorDialog.vue'
 import FileNameDialog from './FileNameDialog.vue'
 import FileSystemUploadDialog from './FileSystemUploadDialog.vue'
+import FileSystemGoToFileDialog from './FileSystemGoToFileDialog.vue'
 import FilePreviewDialog from './FilePreviewDialog.vue'
 import { AppTableHeader } from '@/types'
 import { FileWithPath, getFilesFromDataTransfer } from '@/util/file-system-entry'
@@ -168,6 +173,7 @@ import { FileWithPath, getFilesFromDataTransfer } from '@/util/file-system-entry
     FileEditorDialog,
     FileNameDialog,
     FileSystemUploadDialog,
+    FileSystemGoToFileDialog,
     FilePreviewDialog
   }
 })
@@ -258,6 +264,8 @@ export default class FileSystem extends Mixins(StateMixin, FilesMixin, ServicesM
     filename: '',
     src: ''
   }
+
+  goToFileDialogOpen = false
 
   @Watch('filePreviewState.open')
   onFilePreviewStateChanged (value: boolean) {
@@ -624,6 +632,11 @@ export default class FileSystem extends Mixins(StateMixin, FilesMixin, ServicesM
       value: '',
       handler: this.handleAddDir
     }
+  }
+
+  handleGoToFileDialog () {
+    if (this.disabled) return
+    this.goToFileDialogOpen = true
   }
 
   handleFileOpenDialog (file: AppFile) {

--- a/src/components/widgets/filesystem/FileSystemAddMenu.vue
+++ b/src/components/widgets/filesystem/FileSystemAddMenu.vue
@@ -128,7 +128,7 @@ import { getFilesWithPathFromHTMLInputElement } from '@/util/file-system-entry'
 import { Component, Vue, Prop, Ref } from 'vue-property-decorator'
 
 @Component({})
-export default class FileSystemMenu extends Vue {
+export default class FileSystemAddMenu extends Vue {
   @Prop({ type: String, required: true })
   readonly root!: string
 

--- a/src/components/widgets/filesystem/FileSystemBulkActions.vue
+++ b/src/components/widgets/filesystem/FileSystemBulkActions.vue
@@ -72,15 +72,8 @@
 <script lang="ts">
 import { Component, Mixins, Prop } from 'vue-property-decorator'
 import StatesMixin from '@/mixins/state'
-import FileSystemMenu from './FileSystemMenu.vue'
-import FileSystemFilterMenu from './FileSystemFilterMenu.vue'
 
-@Component({
-  components: {
-    FileSystemMenu,
-    FileSystemFilterMenu
-  }
-})
+@Component({})
 export default class FileSystemBulkActions extends Mixins(StatesMixin) {
   @Prop({ type: String, required: true })
   readonly root!: string

--- a/src/components/widgets/filesystem/FileSystemGoToFileDialog.vue
+++ b/src/components/widgets/filesystem/FileSystemGoToFileDialog.vue
@@ -1,0 +1,121 @@
+<template>
+  <app-dialog
+    v-model="open"
+    :title="$t('app.file_system.title.go_to_file')"
+    no-actions
+    max-width="800"
+  >
+    <v-card-actions>
+      <v-text-field
+        v-model="search"
+        :loading="loading"
+        outlined
+        hide-details
+        dense
+        autofocus
+        class="mx-2"
+      />
+    </v-card-actions>
+    <v-card-text>
+      <v-simple-table>
+        <tbody>
+          <template v-for="file in matchedFiles">
+            <tr
+              :key="file.path"
+              @click="handleFileClick(file)"
+            >
+              <td>{{ file.path }}</td>
+            </tr>
+          </template>
+        </tbody>
+      </v-simple-table>
+    </v-card-text>
+  </app-dialog>
+</template>
+
+<script lang="ts">
+import { Component, Mixins, Prop, VModel, Watch } from 'vue-property-decorator'
+import { SocketActions } from '@/api/socketActions'
+import { RootFile } from '@/store/files/types'
+import getFilePaths from '@/util/get-file-paths'
+import StateMixin from '@/mixins/state'
+
+type File = RootFile &{
+  filename: string
+  filepath: string
+  rootPath: string
+}
+
+@Component({})
+export default class FileSystemGoToFileDialog extends Mixins(StateMixin) {
+  @VModel({ type: Boolean, required: true })
+    open!: boolean
+
+  @Prop({ type: String, required: true })
+  readonly root!: string
+
+  search = ''
+  loaded = false
+
+  get rootFiles (): RootFile[] {
+    return this.$store.getters['files/getRootFiles'](this.root) as RootFile[]
+  }
+
+  get matchedRootFiles (): RootFile[] {
+    if (!this.loaded) {
+      return []
+    }
+
+    const search = this.search
+      .split('')
+      .join('.*')
+    const searchRegExp = new RegExp(search, 'i')
+
+    return this.rootFiles
+      .filter(rootFile => searchRegExp.exec(rootFile.path))
+  }
+
+  get matchedFiles () {
+    return this.matchedRootFiles
+      .slice(0, 100)
+      .map(rootFile => {
+        const { filename, rootPath, path: filepath } = getFilePaths(rootFile.path, this.root)
+
+        const file: File = ({
+          ...rootFile,
+          filename,
+          filepath,
+          rootPath
+        })
+
+        return file
+      })
+  }
+
+  get loading (): boolean {
+    return this.hasWait(`${this.$waits.onFileSystem}${this.root}`) as boolean
+  }
+
+  @Watch('loading')
+  onLoading (value: boolean) {
+    this.loaded = !value
+  }
+
+  handleFileClick (file: File) {
+    this.$emit('path-change', file.rootPath)
+    this.open = false
+  }
+
+  mounted () {
+    this.loaded = false
+    SocketActions.serverFilesListRoot(this.root)
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+:deep(.v-data-table td) {
+  cursor: pointer;
+  user-select: none;
+}
+</style>

--- a/src/components/widgets/filesystem/FileSystemGoToFileDialog.vue
+++ b/src/components/widgets/filesystem/FileSystemGoToFileDialog.vue
@@ -16,20 +16,31 @@
         class="mx-2"
       />
     </v-card-actions>
-    <v-card-text>
-      <v-simple-table>
-        <tbody>
-          <template v-for="file in matchedFiles">
-            <tr
-              :key="file.path"
-              @click="handleFileClick(file)"
-            >
-              <td>{{ file.path }}</td>
-            </tr>
-          </template>
-        </tbody>
-      </v-simple-table>
-    </v-card-text>
+
+    <v-divider />
+
+    <v-virtual-scroll
+      :items="matchedFiles"
+      bench="30"
+      item-height="40"
+    >
+      <template #default="{ item }">
+        <v-list-item
+          :key="item.path"
+          dense
+          class="v-list-item--link"
+          @click="handleFileClick(item)"
+        >
+          <v-list-item-content>
+            <v-list-item-title class="text-body-2 font-weight-regular">
+              {{ item.path }}
+            </v-list-item-title>
+          </v-list-item-content>
+        </v-list-item>
+
+        <v-divider />
+      </template>
+    </v-virtual-scroll>
   </app-dialog>
 </template>
 
@@ -61,7 +72,7 @@ export default class FileSystemGoToFileDialog extends Mixins(StateMixin) {
     return this.$store.getters['files/getRootFiles'](this.root) as RootFile[]
   }
 
-  get matchedRootFiles (): RootFile[] {
+  get matchedFiles (): File[] {
     if (!this.loaded) {
       return []
     }
@@ -73,11 +84,6 @@ export default class FileSystemGoToFileDialog extends Mixins(StateMixin) {
 
     return this.rootFiles
       .filter(rootFile => searchRegExp.exec(rootFile.path))
-  }
-
-  get matchedFiles () {
-    return this.matchedRootFiles
-      .slice(0, 100)
       .map(rootFile => {
         const { filename, rootPath, path: filepath } = getFilePaths(rootFile.path, this.root)
 
@@ -112,10 +118,3 @@ export default class FileSystemGoToFileDialog extends Mixins(StateMixin) {
   }
 }
 </script>
-
-<style lang="scss" scoped>
-:deep(.v-data-table td) {
-  cursor: pointer;
-  user-select: none;
-}
-</style>

--- a/src/components/widgets/filesystem/FileSystemToolbar.vue
+++ b/src/components/widgets/filesystem/FileSystemToolbar.vue
@@ -80,6 +80,25 @@
       :headers="headers"
     />
 
+    <div>
+      <v-tooltip bottom>
+        <template #activator="{ on, attrs }">
+          <v-btn
+            v-bind="attrs"
+            :disabled="disabled"
+            fab
+            small
+            text
+            @click="$emit('go-to-file')"
+            v-on="on"
+          >
+            <v-icon>$magnify</v-icon>
+          </v-btn>
+        </template>
+        <span>{{ $t('app.general.btn.go_to_file') }}</span>
+      </v-tooltip>
+    </div>
+
     <file-system-filter-menu
       v-if="hasFilterTypes"
       :root="root"
@@ -87,7 +106,7 @@
       @change="$emit('filter', $event)"
     />
 
-    <file-system-menu
+    <file-system-add-menu
       v-if="!readonly || canCreateDirectory"
       :root="root"
       :disabled="disabled"
@@ -96,22 +115,24 @@
       @upload="handleUpload"
     />
 
-    <v-tooltip bottom>
-      <template #activator="{ on, attrs }">
-        <v-btn
-          v-bind="attrs"
-          :disabled="disabled"
-          fab
-          small
-          text
-          @click="$emit('refresh')"
-          v-on="on"
-        >
-          <v-icon>$refresh</v-icon>
-        </v-btn>
-      </template>
-      <span>{{ $t('app.general.btn.refresh') }}</span>
-    </v-tooltip>
+    <div>
+      <v-tooltip bottom>
+        <template #activator="{ on, attrs }">
+          <v-btn
+            v-bind="attrs"
+            :disabled="disabled"
+            fab
+            small
+            text
+            @click="$emit('refresh')"
+            v-on="on"
+          >
+            <v-icon>$refresh</v-icon>
+          </v-btn>
+        </template>
+        <span>{{ $t('app.general.btn.refresh') }}</span>
+      </v-tooltip>
+    </div>
 
     <div
       style="max-width: 160px;"
@@ -149,13 +170,13 @@
 <script lang="ts">
 import { Component, Prop, Mixins } from 'vue-property-decorator'
 import StatesMixin from '@/mixins/state'
-import FileSystemMenu from './FileSystemMenu.vue'
+import FileSystemAddMenu from './FileSystemAddMenu.vue'
 import FileSystemFilterMenu from './FileSystemFilterMenu.vue'
 import { AppTableHeader } from '@/types'
 
 @Component({
   components: {
-    FileSystemMenu,
+    FileSystemAddMenu,
     FileSystemFilterMenu
   }
 })

--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -96,6 +96,7 @@ app:
       add_file: Add File
       command_palette: Command Palette
       download_file: Retrieving file
+      go_to_file: Go to file
       rename_dir: Rename Directory
       rename_file: Rename File
       upload_file: Uploading file | Uploading files
@@ -155,6 +156,7 @@ app:
       extrude: Extrude
       filter: Filter
       forgot_password: Forgotten your password?
+      go_to_file: Go to file
       heaters_off: Heaters off
       job_queue: Job Queue
       load_all: Load all

--- a/src/mixins/state.ts
+++ b/src/mixins/state.ts
@@ -75,22 +75,22 @@ export default class StateMixin extends Vue {
    * Indicates if we have a valid wait(s).
    * Supports a single string or a list of.
    */
-  hasWait (wait: string | string[]) {
-    return this.$store.getters['wait/hasWait'](wait)
+  hasWait (wait: string | string[]): boolean {
+    return this.$store.getters['wait/hasWait'](wait) as boolean
   }
 
   /**
    * Indicates if we have any waits.
    */
-  get hasWaits () {
-    return this.$store.getters['wait/hasWaits']
+  get hasWaits (): boolean {
+    return this.$store.getters['wait/hasWaits'] as boolean
   }
 
   /**
    * Indicates if we have any waits prefixed by.
    */
-  hasWaitsBy (prefix: string) {
-    return this.$store.getters['wait/hasWaitsBy'](prefix)
+  hasWaitsBy (prefix: string): boolean {
+    return this.$store.getters['wait/hasWaitsBy'](prefix) as boolean
   }
 
   /**


### PR DESCRIPTION
Adds a new "Go To File" dialog that allow listing and searching all the files in a single root.

![image](https://user-images.githubusercontent.com/85504/227788176-5f96f4d7-78d8-42fb-a91f-fc34d9dfb03d.png)

![image](https://user-images.githubusercontent.com/85504/227960698-edf4ecae-298a-4c3c-8d41-793a1a740c41.png)

A virtual scroll is in use so one can quickly scroll through all the files at once!

Resolves #976