### PR TITLE
refactor: file system improvements

### DIFF
--- a/src/components/widgets/filesystem/FileSystemBrowser.vue
+++ b/src/components/widgets/filesystem/FileSystemBrowser.vue
@@ -69,7 +69,7 @@
               <img
                 v-else
                 :style="{'max-width': `${thumbnailSize}px`, 'max-height': `${thumbnailSize}px`}"
-                :src="getThumbUrl(item.thumbnails, item.path, thumbnailSize > 16, item.modified)"
+                :src="getThumbUrl(item.thumbnails, root, item.path, thumbnailSize > 16, item.modified)"
               >
             </v-layout>
           </td>

--- a/src/components/widgets/filesystem/FileSystemContextMenu.vue
+++ b/src/components/widgets/filesystem/FileSystemContextMenu.vue
@@ -154,7 +154,7 @@
           >
             <img
               class="mx-2"
-              :src="getThumbUrl(file.thumbnails, file.path, true, file.modified)"
+              :src="getThumbUrl(file.thumbnails, root, file.path, true, file.modified)"
               :height="150"
             >
           </v-btn>

--- a/src/components/widgets/filesystem/FileSystemFilterMenu.vue
+++ b/src/components/widgets/filesystem/FileSystemFilterMenu.vue
@@ -68,7 +68,7 @@
 </template>
 
 <script lang="ts">
-import { FileFilterType, FileRoot } from '@/store/files/types'
+import { FileFilterType } from '@/store/files/types'
 import { Component, Vue, Prop } from 'vue-property-decorator'
 
 type FileFilterEntry = {
@@ -84,7 +84,7 @@ type FileFilter = FileFilterEntry & {
 @Component({})
 export default class FileSystemFilterMenu extends Vue {
   @Prop({ type: String, required: true })
-  readonly root!: FileRoot
+  readonly root!: string
 
   @Prop({ type: Boolean, default: false })
   readonly disabled!: boolean

--- a/src/components/widgets/filesystem/FileSystemGoToFileDialog.vue
+++ b/src/components/widgets/filesystem/FileSystemGoToFileDialog.vue
@@ -47,11 +47,11 @@
 <script lang="ts">
 import { Component, Mixins, Prop, VModel, Watch } from 'vue-property-decorator'
 import { SocketActions } from '@/api/socketActions'
-import { RootFile } from '@/store/files/types'
+import { MoonrakerRootFile } from '@/store/files/types'
 import getFilePaths from '@/util/get-file-paths'
 import StateMixin from '@/mixins/state'
 
-type File = RootFile &{
+type File = MoonrakerRootFile &{
   filename: string
   filepath: string
   rootPath: string
@@ -68,8 +68,8 @@ export default class FileSystemGoToFileDialog extends Mixins(StateMixin) {
   search = ''
   loaded = false
 
-  get rootFiles (): RootFile[] {
-    return this.$store.getters['files/getRootFiles'](this.root) as RootFile[]
+  get rootFiles (): MoonrakerRootFile[] {
+    return this.$store.getters['files/getRootFiles'](this.root) as MoonrakerRootFile[]
   }
 
   get matchedFiles (): File[] {

--- a/src/components/widgets/history/JobHistory.vue
+++ b/src/components/widgets/history/JobHistory.vue
@@ -85,7 +85,7 @@
         <img
           v-else
           class="mr-2 file-icon-thumb"
-          :src="getThumbUrl(item.metadata.thumbnails, getFilePaths(item.filename).path, false, item.metadata.modified)"
+          :src="getThumbUrl(item.metadata.thumbnails, 'gcodes', getFilePaths(item.filename).path, false, item.metadata.modified)"
           :width="24"
           @error="handleJobThumbnailError(item)"
         >

--- a/src/components/widgets/status/ReprintTab.vue
+++ b/src/components/widgets/status/ReprintTab.vue
@@ -40,7 +40,7 @@
             <img
               v-else
               class="mr-2 file-icon-thumb"
-              :src="getThumbUrl(item.metadata.thumbnails, getFilePaths(item.filename).path, false, item.metadata.modified)"
+              :src="getThumbUrl(item.metadata.thumbnails, 'gcodes', getFilePaths(item.filename).path, false, item.metadata.modified)"
               :width="24"
               @error="handleJobThumbnailError(item)"
             >

--- a/src/components/widgets/status/StatusTab.vue
+++ b/src/components/widgets/status/StatusTab.vue
@@ -290,7 +290,7 @@ export default class StatusTab extends Mixins(StateMixin, FilesMixin) {
       this.current_file &&
       this.current_file.thumbnails
     ) {
-      const url = this.getThumbUrl(this.current_file.thumbnails, this.current_file.path, true, this.current_file.modified)
+      const url = this.getThumbUrl(this.current_file.thumbnails, 'gcodes', this.current_file.path, true, this.current_file.modified)
       return url
     }
   }

--- a/src/mixins/files.ts
+++ b/src/mixins/files.ts
@@ -21,9 +21,9 @@ export default class FilesMixin extends Vue {
     return forceLogins === false || this.$store.getters['auth/getCurrentUser']?.username === '_TRUSTED_USER_'
   }
 
-  getThumbUrl (thumbnails: Thumbnail[], path: string, large: boolean, date?: number) {
+  getThumbUrl (thumbnails: Thumbnail[], root: string, path: string, large: boolean, date?: number) {
     if (thumbnails.length) {
-      const thumb = this.getThumb(thumbnails, path, large, date)
+      const thumb = this.getThumb(thumbnails, root, path, large, date)
 
       if (thumb) {
         return thumb.absolute_path || thumb.data || ''
@@ -32,7 +32,7 @@ export default class FilesMixin extends Vue {
     return ''
   }
 
-  getThumb (thumbnails: Thumbnail[], path: string, large = true, date?: number) {
+  getThumb (thumbnails: Thumbnail[], root: string, path: string, large = true, date?: number) {
     if (thumbnails.length) {
       let thumb: Thumbnail | undefined
       if (thumbnails) {
@@ -43,7 +43,7 @@ export default class FilesMixin extends Vue {
         }
         if (thumb) {
           if (thumb.relative_path && thumb.relative_path.length > 0) {
-            const filepath = path ? `gcodes/${path}` : 'gcodes'
+            const filepath = path ? `${root}/${path}` : root
 
             return {
               ...thumb,

--- a/src/store/config/getters.ts
+++ b/src/store/config/getters.ts
@@ -6,7 +6,7 @@ import { Heater, Fan } from '../printer/types'
 import tinycolor from '@ctrl/tinycolor'
 import { AppTableHeader } from '@/types'
 import { AppTablePartialHeader } from '@/types/tableheaders'
-import { RootFile } from '../files/types'
+import { MoonrakerRootFile } from '../files/types'
 import md5 from 'md5'
 
 export const getters: GetterTree<ConfigState, RootState> = {
@@ -99,7 +99,7 @@ export const getters: GetterTree<ConfigState, RootState> = {
   },
 
   getCustomThemeFile: (state, getters, rootState, rootGetters) => (filename: string, extensions: string[]) => {
-    const files = rootGetters['files/getRootFiles']('config') as RootFile[]
+    const files = rootGetters['files/getRootFiles']('config') as MoonrakerRootFile[] | undefined
 
     if (files) {
       for (const extension of extensions) {

--- a/src/store/config/types.ts
+++ b/src/store/config/types.ts
@@ -1,6 +1,6 @@
 import { AppTablePartialHeader } from '@/types/tableheaders'
 import { VuetifyThemeItem } from 'vuetify/types/services/theme'
-import { FileFilterType, FileRoot } from '../files/types'
+import { FileFilterType } from '../files/types'
 
 export interface ConfigState {
   [key: string]: any;
@@ -186,5 +186,5 @@ export interface GcodePreviewConfig {
 }
 
 export interface FileSystemConfig {
-  activeFilters: Partial<Record<FileRoot, FileFilterType[]>>
+  activeFilters: Partial<Record<string, FileFilterType[]>>
 }

--- a/src/store/files/actions.ts
+++ b/src/store/files/actions.ts
@@ -1,12 +1,11 @@
 import { ActionTree } from 'vuex'
 import axios from 'axios'
-import { FilesState, KlipperFile, AppDirectory, FileChangeSocketResponse, FileUpdate, AppFileWithMeta, KlipperFileWithMeta, DiskUsage, FileBrowserEntry, KlipperDir } from './types'
+import { FilesState, KlipperFile, KlipperDir, FileChangeSocketResponse, FileUpdate, KlipperFileWithMeta, DiskUsage } from './types'
 import { RootState } from '../types'
 import formatAsFile from '@/util/format-as-file'
 import getFilePaths from '@/util/get-file-paths'
 import { SocketActions } from '@/api/socketActions'
 import { Globals } from '@/globals'
-import { HistoryItem } from '../history/types'
 
 export const actions: ActionTree<FilesState, RootState> = {
   /**
@@ -16,94 +15,38 @@ export const actions: ActionTree<FilesState, RootState> = {
     commit('setReset')
   },
 
-  async onServerFilesGetDirectory ({ commit, rootState }, payload: { disk_usage: DiskUsage; files: (KlipperFile | KlipperFileWithMeta)[]; dirs: KlipperDir[]; __request__: any }) {
-    const path = payload.__request__.params.path
-    const root = payload.__request__.params.root
-    const pathNoRoot = path.length > root.length
-      ? path.substring(root.length + 1)
-      : path.substring(root.length)
+  async onServerFilesGetDirectory ({ commit }, payload: { disk_usage: DiskUsage; files: (KlipperFile | KlipperFileWithMeta)[]; dirs: KlipperDir[]; __request__: any }) {
+    const { disk_usage, files, dirs, __request__: request } = payload
+    const { path } = request.params
 
-    const items: FileBrowserEntry[] = []
+    const filteredDirs = dirs
+      .filter(file =>
+        !Globals.FILTERED_FILES_PREFIX.some(e => file.dirname.startsWith(e)) &&
+        !Globals.FILTERED_FILES_EXTENSION.some(e => file.dirname.endsWith(e))
+      )
 
-    if (path && path.indexOf('/') >= 0) {
-      items.push({
-        type: 'directory',
-        dirname: '..',
-        name: '..',
-        size: 0,
-        modified: 0
-      } satisfies AppDirectory)
-    }
-
-    if (payload.dirs) {
-      payload.dirs.forEach((dir) => {
-        if (
-          !Globals.FILTERED_FILES_PREFIX.some(e => dir.dirname.startsWith(e)) &&
-          !Globals.FILTERED_FILES_EXTENSION.some(e => dir.dirname.endsWith(e))
-        ) {
-          items.push({
-            ...dir,
-            type: 'directory',
-            name: dir.dirname,
-            modified: new Date(dir.modified).getTime()
-          } satisfies AppDirectory)
-        }
-      })
-    }
-
-    if (payload.files) {
-      payload.files.forEach((file) => {
-        if (
-          !Globals.FILTERED_FILES_PREFIX.some(e => file.filename.startsWith(e)) &&
-          !Globals.FILTERED_FILES_EXTENSION.some(e => file.filename.endsWith(e))
-        ) {
-          let history = {} as HistoryItem
-          if (file.job_id) {
-            const h = rootState.history.jobs.find(job => job.job_id === file.job_id)
-            if (h) history = h
-          }
-          items.push({
-            ...file,
-            type: 'file',
-            name: file.filename,
-            extension: file.filename.split('.').pop() || '',
-            modified: new Date(file.modified).getTime(),
-            path: (pathNoRoot === '/') ? '' : pathNoRoot,
-            history
-          } satisfies AppFileWithMeta)
-        }
-      })
-    }
-    commit('setDiskUsage', payload.disk_usage)
-    commit('setServerFilesGetDirectory', { root, directory: { path, items } })
+    commit('setDiskUsage', disk_usage)
+    commit('setServerFilesGetDirectory', { path, content: { files, dirs: filteredDirs } })
   },
 
   async onServerFilesListRoot ({ commit }, payload) {
-    const root = payload.__request__.params.root
+    const { root } = payload.__request__.params
 
-    commit('setServerFilesListRoot', { root, files: payload })
+    commit('setServerFilesListRoot', { root, files: [...payload] })
   },
 
   /**
    * If we request the metadata (a file..) then we load and update here.
    */
-  async onFileMetaData ({ commit, rootState, rootGetters }, payload: KlipperFile | KlipperFileWithMeta) {
+  async onFileMetaData ({ commit, rootState }, payload: KlipperFile | KlipperFileWithMeta) {
     const root = 'gcodes' // We'd only ever load metadata for gcode files.
     const paths = getFilePaths(payload.filename, root)
-    let file = formatAsFile(root, payload)
+    const file = formatAsFile(root, payload)
     const filepath = (file.path) ? `${file.path}/${file.filename}` : `${file.filename}`
 
     // If this is an update to the currently printing file, then push it to
     // current_file.
     if (filepath === rootState.printer.printer.print_stats.filename) {
-      // Find an completed history item for this file, if it exists.
-      const history = rootGetters['history/getHistoryByFilename'](filepath)
-      if (history) {
-        file = {
-          ...file,
-          history
-        }
-      }
       commit('printer/setSocketNotify', { key: 'current_file', payload: file }, { root: true })
     }
 
@@ -148,7 +91,7 @@ export const actions: ActionTree<FilesState, RootState> = {
   async notifyCreateFile ({ commit, dispatch, rootState }, payload: FileChangeSocketResponse) {
     const root = payload.item.root
     const file = formatAsFile(root, payload.item)
-    if (file.extension === 'gcode') {
+    if (root === 'gcodes' && file.extension === 'gcode') {
       // If the file in the gcode preview is the same as the one being updated, then reset gcode preview
       const gcodePreviewFile = rootState.gcodePreview.file
       if (gcodePreviewFile && gcodePreviewFile.path === file.path && gcodePreviewFile.filename === file.filename) {

--- a/src/store/files/getters.ts
+++ b/src/store/files/getters.ts
@@ -1,18 +1,90 @@
 import { GetterTree } from 'vuex'
-import { AppFile, AppFileWithMeta, FileRoot, Files, FilesState } from './types'
+import { AppDirectory, AppFile, AppFileWithMeta, FileBrowserEntry, FilesState } from './types'
 import { RootState } from '../types'
+import { HistoryItem } from '../history/types'
 
 export const getters: GetterTree<FilesState, RootState> = {
   /**
    * Returns a directory of files and sub-directories.
    */
-  getDirectory: (state) => (root: FileRoot, path: string) => {
-    const dir = state[root]?.find(o => o.path === path)
+  getDirectory: (state, getters, rootState) => (path: string) => {
+    const pathContent = state.pathFiles[path]
 
-    return dir
+    if (pathContent) {
+      const items: FileBrowserEntry[] = []
+
+      const [root, ...restOfPath] = path.split('/')
+      const pathNoRoot = restOfPath.join('/')
+
+      if (pathNoRoot !== '') {
+        const item: AppDirectory = {
+          type: 'directory',
+          name: '..',
+          dirname: '..',
+          modified: 0,
+          size: 0
+        }
+
+        items.push(item)
+      }
+
+      for (const dir of pathContent.dirs) {
+        const item: AppDirectory = {
+          ...dir,
+          type: 'directory',
+          name: dir.dirname,
+          modified: new Date(dir.modified).getTime()
+        }
+
+        items.push(item)
+      }
+
+      // If root is timelapse, then add thumbnails data to files
+
+      const timelapseThumbnailFiles = root === 'timelapse'
+        ? new Set(pathContent.files
+          .map(file => file.filename)
+          .filter(filename => filename.endsWith('.jpg')))
+        : undefined
+
+      for (const file of pathContent.files) {
+        const history = (file.job_id && rootState.history.jobs.find(job => job.job_id === file.job_id)) || {} as HistoryItem
+
+        const item: AppFileWithMeta = {
+          ...file,
+          type: 'file',
+          name: file.filename,
+          extension: file.filename.split('.').pop() || '',
+          path: pathNoRoot,
+          modified: new Date(file.modified).getTime(),
+          history
+        }
+
+        if (timelapseThumbnailFiles && item.extension !== 'jpg') {
+          const expectedThumbnailFile = `${item.filename.slice(0, -(item.extension.length + 1))}.jpg`
+
+          if (timelapseThumbnailFiles.has(expectedThumbnailFile)) {
+            item.thumbnails = [
+              {
+                // we have no data regarding the thumbnail other than it's URL, but setting it is mandatory...
+                data: '',
+                height: 0,
+                width: 0,
+                size: 0,
+                relative_path: expectedThumbnailFile
+              }
+            ]
+          }
+        }
+
+        items.push(item)
+      }
+
+      return items
+    }
   },
 
-  getRootFiles: (state) => (root: FileRoot) => {
+  getRootFiles: (state) => (root: string) => {
     return state.rootFiles[root]
   },
 
@@ -26,7 +98,7 @@ export const getters: GetterTree<FilesState, RootState> = {
   /**
    * Returns the properties of a root.
    */
-  getRootProperties: () => (root: FileRoot) => {
+  getRootProperties: () => (root: string) => {
     switch (root) {
       case 'gcodes':
         return {
@@ -106,12 +178,23 @@ export const getters: GetterTree<FilesState, RootState> = {
   /**
    * Returns a specific file.
    */
-  getFile: (state, getters) => (root: FileRoot, path: string, filename: string) => {
-    const dir = getters.getDirectory(root, path) as Files | undefined
+  getFile: (state) => (root: string, path: string, filename: string) => {
+    const pathContent = state.pathFiles[path]
 
-    const file = dir?.items?.find((item): item is AppFile | AppFileWithMeta => item.type === 'file' && item.filename === filename)
+    const file = pathContent?.files.find(file => file.filename === filename)
 
-    return file
+    if (file) {
+      const item: AppFile = {
+        ...file,
+        type: 'file',
+        name: file.filename,
+        extension: file.filename.split('.').pop() || '',
+        path,
+        modified: new Date(file.modified).getDate()
+      }
+
+      return item
+    }
   },
 
   /**

--- a/src/store/files/state.ts
+++ b/src/store/files/state.ts
@@ -11,20 +11,8 @@ export const defaultState = (): FilesState => {
       used: 0,
       free: 0
     },
-    rootFiles: {
-      gcodes: [],
-      config: [],
-      config_examples: [],
-      docs: [],
-      logs: [],
-      timelapse: []
-    },
-    gcodes: [],
-    config: [],
-    config_examples: [],
-    docs: [],
-    logs: [],
-    timelapse: []
+    rootFiles: {},
+    pathFiles: {}
   }
 }
 

--- a/src/store/files/types.ts
+++ b/src/store/files/types.ts
@@ -8,16 +8,10 @@ export interface FilesState {
   uploads: FilesUpload[];
   download: FileDownload | null;
   fileTransferCancelTokenSource: CancelTokenSource | null;
-  currentPaths: CurrentPaths;
+  currentPaths: Record<string, string>;
   disk_usage: DiskUsage;
-  rootFiles: RootFiles;
-
-  gcodes: Files[];
-  config: Files[];
-  config_examples: Files[];
-  docs: Files[];
-  logs: Files[];
-  timelapse: Files[]; // may be null, but will never be accessed when feature is unsupported
+  rootFiles: Record<string, MoonrakerRootFile[] | undefined>;
+  pathFiles: Record<string, MoonrakerPathContent | undefined>;
 }
 
 export interface DiskUsage {
@@ -26,21 +20,9 @@ export interface DiskUsage {
   free: number;
 }
 
-export interface CurrentPaths {
-  [root: string]: string;
-}
-
-export interface Files {
-  path: string;
-  items: FileBrowserEntry[];
-}
-
-export interface AppFile extends KlipperFile {
-  type: 'file';
-  name: string;
-  extension: string;
-  path: string;
-  modified: number;
+export interface MoonrakerPathContent {
+  files: (KlipperFile | KlipperFileWithMeta) []
+  dirs: KlipperDir[]
 }
 
 export interface KlipperFile {
@@ -52,6 +34,9 @@ export interface KlipperFile {
   job_id?: string | null;
 }
 
+export interface KlipperFileWithMeta extends KlipperFile, KlipperFileMeta {
+}
+
 export interface KlipperDir {
   dirname: string;
   modified: number | string;
@@ -59,10 +44,17 @@ export interface KlipperDir {
   permissions?: '' | 'r' | 'rw';
 }
 
+export interface AppFile extends KlipperFile {
+  type: 'file';
+  name: string;
+  extension: string;
+  path: string;
+  modified: number;
+}
+
 export interface AppFileWithMeta extends AppFile, KlipperFileMeta {
   history: HistoryItem;
 }
-export interface KlipperFileWithMeta extends KlipperFile, KlipperFileMeta {}
 
 export interface AppDirectory extends KlipperDir {
   type: 'directory';
@@ -95,7 +87,7 @@ export interface FilePaths {
 
 export interface FileUpdate {
   paths: FilePaths;
-  file: Partial<AppFile | AppFileWithMeta> & { filename: string; };
+  file: Partial<KlipperFile | KlipperFileWithMeta> & { filename: string; };
   root: string;
 }
 
@@ -115,8 +107,6 @@ export interface FilesUpload extends FileDownload {
 
 export type FileFilterType = 'print_start_time' | 'hidden_files' | 'klipper_backup_files' | 'rolled_log_files'
 
-export type FileRoot = 'gcodes' | 'config' | 'config_examples' | 'docs' | 'logs' | 'timelapse'
-
 export type FileBrowserEntry = AppFile | AppFileWithMeta | AppDirectory
 
 export interface FilePreviewState {
@@ -128,16 +118,7 @@ export interface FilePreviewState {
   width?: number;
 }
 
-export interface RootFiles {
-  gcodes: RootFile[];
-  config: RootFile[];
-  config_examples: RootFile[];
-  docs: RootFile[];
-  logs: RootFile[];
-  timelapse: RootFile[];
-}
-
-export interface RootFile {
+export interface MoonrakerRootFile {
   path: string;
   modified: number;
   size: number;

--- a/src/store/history/actions.ts
+++ b/src/store/history/actions.ts
@@ -47,13 +47,9 @@ export const actions: ActionTree<HistoryState, RootState> = {
   /**
    * Update the store with history
    */
-  async onHistoryList ({ commit, rootGetters }, payload) {
+  async onHistoryList ({ commit }, payload) {
     if (payload) {
       commit('setHistoryList', payload)
-
-      if (rootGetters['files/isRootAvailable']('gcodes')) {
-        SocketActions.serverFilesGetDirectory('gcodes', 'gcodes')
-      }
     }
   },
 

--- a/src/util/get-file-paths.ts
+++ b/src/util/get-file-paths.ts
@@ -11,7 +11,7 @@ import {
 export default (filePath: string, root: string): FilePaths => {
   let path = filePath.substr(0, filePath.lastIndexOf('/'))
   path = (path && path.startsWith(root))
-    ? path.substring(root.length)
+    ? path.substring(root.length + 1)
     : path
   return {
     filename: filePath.split('/').pop() || '',

--- a/src/util/merge-file-update.ts
+++ b/src/util/merge-file-update.ts
@@ -1,11 +1,11 @@
 import getFilePaths from './get-file-paths'
-import { AppFile } from '@/store/files/types'
+import { KlipperFile } from '@/store/files/types'
 
 /**
  * File Updates come in with the filename representing the filepath,
  * so we need to strip the path to reflect what we store.
  */
-const mergeFileUpdate = <T extends AppFile>(root: string, existing: T, updates: Partial<T> & { filename: string; }): T => {
+const mergeFileUpdate = <T extends KlipperFile>(root: string, existing: T, updates: Partial<T> & { filename: string; }): T => {
   const paths = getFilePaths(updates.filename, root)
   updates.filename = paths.filename
   return { ...existing, ...updates }


### PR DESCRIPTION
This is a big refactor of the way the file system is managed by Fluidd.

There are a couple of reasons for this refactor:

- store only keeps the raw data we received from moonraker
- do not store history with files in store and instead retrieve that in getters
- provide timelapse files metadata directly in store getters
- make timelapse file operations (move/delete) more constrained
- allow thumbnails in all roots (and not just on "gcodes")
- remove the need to refresh "gcodes" when we store the history state
- ...

I've been writing and testing these changes for a few weeks now and I believe them to be stable.

Assuming this is all working fine, the only downside to it is that we now do some work in the file getters that previously was done only once and stored that in state, but I did not perceive any major performance impact from this change (tested both on desktop and mobile).