### PR TITLE
fix: allow ignoring min_extrude_temp for load/unload filament macros

### DIFF
--- a/src/components/widgets/toolhead/ToolheadCard.vue
+++ b/src/components/widgets/toolhead/ToolheadCard.vue
@@ -212,36 +212,46 @@ export default class ToolheadCard extends Mixins(StateMixin, ToolheadMixin) {
     return this.$store.getters['macros/getMacros'] as Macro[]
   }
 
-  get availableTools () {
-    const macros = this.macros
-    const macroNames = new Set(macros
-      .map(macro => macro.name))
+  get loadFilamentMacro (): Macro | undefined {
+    const [loadFilamentMacro] = this.macros
+      .filter(macro => ['load_filament', 'm701'].includes(macro.name))
+      .sort(macro => macro.name === 'load_filament' ? -1 : 1)
 
+    return loadFilamentMacro
+  }
+
+  get unloadFilamentMacro (): Macro | undefined {
+    const [unloadFilamentMacro] = this.macros
+      .filter(macro => ['unload_filament', 'm702'].includes(macro.name))
+      .sort(macro => macro.name === 'unload_filament' ? -1 : 1)
+
+    return unloadFilamentMacro
+  }
+
+  get availableTools () {
     const tools: Tool[] = []
 
-    if (macroNames.has('load_filament')) {
+    const loadFilamentMacro = this.loadFilamentMacro
+
+    if (loadFilamentMacro) {
+      const ignoreMinExtrudeTemp = loadFilamentMacro.variables?.ignore_min_extrude_temp ?? false
+
       tools.push({
-        name: 'LOAD_FILAMENT',
-        disabled: !this.extruderReady
-      })
-    } else if (macroNames.has('m701')) {
-      tools.push({
-        name: 'M701',
-        label: 'M701 (Load Filament)',
-        disabled: !this.extruderReady
+        name: loadFilamentMacro.name.toUpperCase(),
+        label: loadFilamentMacro.name === 'm701' ? 'M701 (Load Filament)' : undefined,
+        disabled: !(ignoreMinExtrudeTemp || this.extruderReady)
       })
     }
 
-    if (macroNames.has('unload_filament')) {
+    const unloadFilamentMacro = this.unloadFilamentMacro
+
+    if (unloadFilamentMacro) {
+      const ignoreMinExtrudeTemp = unloadFilamentMacro.variables?.ignore_min_extrude_temp ?? false
+
       tools.push({
-        name: 'UNLOAD_FILAMENT',
-        disabled: !this.extruderReady
-      })
-    } else if (macroNames.has('m702')) {
-      tools.push({
-        name: 'M702',
-        label: 'M702 (Unload Filament)',
-        disabled: !this.extruderReady
+        name: unloadFilamentMacro.name.toUpperCase(),
+        label: unloadFilamentMacro.name === 'm702' ? 'M702 (Unload Filament)' : undefined,
+        disabled: !(ignoreMinExtrudeTemp || this.extruderReady)
       })
     }
 


### PR DESCRIPTION
We currently disable the `LOAD_FILAMENT`, `UNLOAD_FILAMENT`, `M701` and `M702` if the extruder temperature is not above `min_extrude_temp`.

But some users have code on these macros to raise the extruder temperature before it performs any extruder movement, thus it makes sense to keep these options enabled.

So per macro, if we add a `ignore_min_extrude_temp` variable and set that to `true`, then we will not disable the tool in case that.

Here's a configuration example for this variable:

```ini
[gcode_macro LOAD_FILAMENT]
variable_ignore_min_extrude_temp: True
gcode:
  ...
```

Fixes #1095