### PR TITLE
feat: save and restore editor view state

### DIFF
--- a/src/components/settings/FileEditorSettings.vue
+++ b/src/components/settings/FileEditorSettings.vue
@@ -38,6 +38,19 @@
       <v-divider />
 
       <app-setting
+        :title="$t('app.setting.label.save_and_restore_view_state')"
+      >
+        <v-switch
+          v-model="restoreViewState"
+          hide-details
+          class="mb-5"
+          @click.native.stop
+        />
+      </app-setting>
+
+      <v-divider />
+
+      <app-setting
         :title="$t('app.setting.label.show_code_lens')"
       >
         <v-switch
@@ -96,6 +109,18 @@ export default class FileEditorSettings extends Mixins(StateMixin) {
     this.$store.dispatch('config/saveByPath', {
       path: 'uiSettings.editor.autoEditExtensions',
       value: value.sort(),
+      server: true
+    })
+  }
+
+  get restoreViewState (): boolean {
+    return this.$store.state.config.uiSettings.editor.restoreViewState
+  }
+
+  set restoreViewState (value: boolean) {
+    this.$store.dispatch('config/saveByPath', {
+      path: 'uiSettings.editor.restoreViewState',
+      value,
       server: true
     })
   }

--- a/src/components/widgets/filesystem/FileEditor.vue
+++ b/src/components/widgets/filesystem/FileEditor.vue
@@ -19,6 +19,8 @@
 import { Component, Prop, Ref, Mixins } from 'vue-property-decorator'
 import BrowserMixin from '@/mixins/browser'
 import type * as Monaco from 'monaco-editor/esm/vs/editor/editor.api'
+import md5AsBase64 from '@/util/md5-as-base64'
+import { InstanceConfig } from '@/store/config/types'
 let monaco: typeof Monaco // dynamically imported
 
 @Component({})
@@ -35,11 +37,24 @@ export default class FileEditor extends Mixins(BrowserMixin) {
   @Prop({ type: Boolean, default: true })
   readonly codeLens!: boolean
 
+  @Prop({ type: String, required: true })
+  readonly path!: string
+
   @Ref('monaco-editor')
   readonly monacoEditor!: HTMLElement
 
+  viewStateHash: string | null = null
+
   // Our editor, once init'd.
   editor: Monaco.editor.IStandaloneCodeEditor | null = null
+
+  get restoreViewState (): boolean {
+    return this.$store.state.config.uiSettings.editor.restoreViewState
+  }
+
+  get activeInstance (): InstanceConfig {
+    return this.$store.getters['config/getCurrentInstance'] as InstanceConfig
+  }
 
   async mounted () {
     // Init the editor.
@@ -75,16 +90,31 @@ export default class FileEditor extends Mixins(BrowserMixin) {
       rulers: (this.isMobileViewport) ? [80, 120] : []
     })
 
+    const filename = this.path ? `${this.path}/${this.filename}` : this.filename
+    const apiFileUrl = `${this.activeInstance.apiUrl}/server/files/${filename}`
+
     // Define the model. The filename will map to the supported languages.
     const model = monaco.editor.createModel(
       this.value,
       undefined,
-      monaco.Uri.file(this.filename)
+      monaco.Uri.file(filename)
     )
     this.editor.setModel(model)
 
+    if (this.restoreViewState) {
+      this.viewStateHash = 'monaco.' + md5AsBase64(apiFileUrl)
+
+      if (this.viewStateHash in localStorage) {
+        const viewState = JSON.parse(localStorage[this.viewStateHash])
+
+        this.editor.restoreViewState(viewState)
+      }
+    }
+
     // Focus the editor.
-    this.editor.focus()
+    this.$nextTick(() => {
+      this.editor?.focus()
+    })
 
     this.$emit('ready')
     this.editor.onDidChangeModelContent(event => {
@@ -102,6 +132,14 @@ export default class FileEditor extends Mixins(BrowserMixin) {
 
   // Ensure we dispose of our models and editor.
   destroyed () {
+    if (this.restoreViewState && this.viewStateHash) {
+      const viewState = this.editor?.saveViewState()
+
+      if (viewState) {
+        localStorage[this.viewStateHash] = JSON.stringify(viewState)
+      }
+    }
+
     if (monaco) monaco.editor.getModels().forEach(model => model.dispose())
     if (this.editor) this.editor.dispose()
   }

--- a/src/components/widgets/filesystem/FileEditorDialog.vue
+++ b/src/components/widgets/filesystem/FileEditorDialog.vue
@@ -99,6 +99,7 @@
         v-if="contents !== undefined && !useTextOnlyEditor"
         ref="editor"
         v-model="updatedContent"
+        :path="path"
         :filename="filename"
         :readonly="readonly"
         :code-lens="codeLens"
@@ -136,6 +137,9 @@ export default class FileEditorDialog extends Mixins(StateMixin, BrowserMixin) {
 
   @Prop({ type: String, required: true })
   readonly root!: string
+
+  @Prop({ type: String, required: true })
+  readonly path!: string
 
   @Prop({ type: String, required: true })
   readonly filename!: string

--- a/src/components/widgets/filesystem/FileSystem.vue
+++ b/src/components/widgets/filesystem/FileSystem.vue
@@ -84,6 +84,7 @@
       :filename="fileEditorDialogState.filename"
       :loading="fileEditorDialogState.loading"
       :readonly="fileEditorDialogState.readonly"
+      :path="currentPath"
       :root="currentRoot"
       @save="handleSaveFileChanges"
     />

--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -552,6 +552,7 @@ app:
       reset: Reset settings
       retraction_icon_size: Retraction Icon Size
       right_y: Right Y-Axis
+      save_and_restore_view_state: Save and restore view state
       show_animations: Show animations
       show_barometric_pressure: Show barometric pressure
       show_code_lens: Show CodeLens

--- a/src/store/config/state.ts
+++ b/src/store/config/state.ts
@@ -69,6 +69,7 @@ export const defaultState = (): ConfigState => {
       editor: {
         confirmDirtyEditorClose: true,
         autoEditExtensions: ['.cfg', '.conf', '.ini', '.log', '.md', '.sh', '.txt'],
+        restoreViewState: true,
         codeLens: true
       },
       dashboard: {

--- a/src/store/config/types.ts
+++ b/src/store/config/types.ts
@@ -109,6 +109,7 @@ export interface SupportedThemeLogo {
 export interface EditorConfig {
   confirmDirtyEditorClose: boolean;
   autoEditExtensions: string[];
+  restoreViewState: boolean,
   codeLens: boolean;
 }
 

--- a/src/store/files/getters.ts
+++ b/src/store/files/getters.ts
@@ -148,7 +148,7 @@ export const getters: GetterTree<FilesState, RootState> = {
           canView: true,
           canPrint: false,
           canConfigure: false,
-          filterTypes: ['rolled_log_files']
+          filterTypes: ['hidden_files', 'rolled_log_files']
         }
       case 'timelapse':
         return {

--- a/src/util/md5-as-base64.ts
+++ b/src/util/md5-as-base64.ts
@@ -1,0 +1,9 @@
+import md5 from 'md5'
+
+const md5AsBase64 = (text: string) => {
+  const hash = md5(text, { asString: true })
+
+  return btoa(hash)
+}
+
+export default md5AsBase64


### PR DESCRIPTION
This PR adds a new Monaco Editor option to "Save and restore view state" (defaults to enabled)

With this option enabled, any file that the user opens will have the current view state (scroll position, selected areas, folds/unfolded regions, ...) stored in the browser local storage when the user closes the editor, and restored when the user re-opens the file.


https://github.com/fluidd-core/fluidd/assets/85504/872b5f70-4632-47bc-ace3-6ac30b9f85a6

To ensure there are no collisions between multi-instances, roots, paths, and filenames, this is the process to generate the state key:

- Create the "get file" Moonraker API URL (so that will be `<moonraker_base_url>/server/files/<root>/<path>/<filename>`)
- Generate an MD5 of this url and encode in Base64 (makes a smaller string)
- Prepend "monaco."

Fixes #1092