### PR TITLE
Do not crash for dynamically created macros with no config.

### DIFF
--- a/src/store/macros/getters.ts
+++ b/src/store/macros/getters.ts
@@ -14,7 +14,7 @@ export const getters: GetterTree<MacrosState, RootState> = {
       .map(key => {
         const lowerCaseKey = key.toLocaleLowerCase()
         const name = lowerCaseKey.split(' ', 2)[1]
-        const config = rootState.printer.printer.configfile.settings[lowerCaseKey]
+        const config = rootState.printer.printer.configfile.settings[lowerCaseKey] || {}
         const stored = state.stored.find(macro => macro.name === name)
         const variables = rootState.printer.printer[key]
 


### PR DESCRIPTION
I'm experimenting with auto-generated T0,T1... macros.
And fluidd just dies if macros do not have a printer config section.
This is a basic fix to avoid that.