### PR TITLE
fix: don't show gcode load dialog if canceled

### DIFF
--- a/src/components/widgets/filesystem/FileSystem.vue
+++ b/src/components/widgets/filesystem/FileSystem.vue
@@ -691,7 +691,9 @@ export default class FileSystem extends Mixins(StateMixin, FilesMixin, ServicesM
   async handlePreviewGcode (file: AppFile | AppFileWithMeta) {
     this.getGcode(file)
       .then(response => response?.data)
-      .then((gcode) => {
+      .then(gcode => {
+        if (!gcode) return
+
         if (this.$router.currentRoute.path !== '/' || !this.$store.getters['layout/isEnabledInCurrentLayout']('gcode-preview-card')) {
           this.$router.push({ path: '/preview' })
         }

--- a/src/components/widgets/gcode-preview/GcodePreviewCard.vue
+++ b/src/components/widgets/gcode-preview/GcodePreviewCard.vue
@@ -315,6 +315,8 @@ export default class GcodePreviewCard extends Mixins(StateMixin, FilesMixin, Bro
     this.getGcode(file)
       .then(response => response?.data)
       .then(gcode => {
+        if (!gcode) return
+
         this.$store.dispatch('gcodePreview/loadGcode', {
           file,
           gcode

--- a/src/mixins/files.ts
+++ b/src/mixins/files.ts
@@ -87,7 +87,7 @@ export default class FilesMixin extends Vue {
       this.$store.dispatch('files/createFileTransferCancelTokenSource')
 
       const path = file.path ? `gcodes/${file.path}` : 'gcodes'
-      return await this.getFile(file.filename, path, file.size, {
+      return await this.getFile<string>(file.filename, path, file.size, {
         responseType: 'text',
         transformResponse: [v => v],
         cancelToken: this.cancelTokenSource.token
@@ -100,7 +100,7 @@ export default class FilesMixin extends Vue {
    * @param filename The filename to retrieve
    * @param path The path to the file
    */
-  async getFile (filename: string, path: string, size = 0, options?: AxiosRequestConfig) {
+  async getFile<T = any> (filename: string, path: string, size = 0, options?: AxiosRequestConfig) {
     // Sort out the filepath
     const filepath = path ? `${path}/${filename}` : filename
 
@@ -148,7 +148,7 @@ export default class FilesMixin extends Vue {
       }
     }
 
-    return await httpClientActions.serverFilesGet(filepath, o)
+    return await httpClientActions.serverFilesGet<T>(filepath, o)
   }
 
   /**


### PR DESCRIPTION
Do not show gcode load dialog if operation has been cancelled.

Fixes #1127