### PR TITLE
fix: remove obsolete check to create directory

### DIFF
--- a/src/components/widgets/filesystem/FileSystemAddMenu.vue
+++ b/src/components/widgets/filesystem/FileSystemAddMenu.vue
@@ -92,7 +92,6 @@
       </v-list-item>
 
       <v-list-item
-        v-if="canCreateDirectory"
         :disabled="disabled"
         @click="$emit('add-dir')"
       >
@@ -145,10 +144,6 @@ export default class FileSystemAddMenu extends Mixins(StateMixin) {
 
   get accepts () {
     return this.rootProperties.accepts.join(',')
-  }
-
-  get canCreateDirectory () {
-    return this.rootProperties.canCreateDirectory
   }
 
   get printerReady () {


### PR DESCRIPTION
The check for `canCreateDirectory` has been moved to the upper level, but the old check was still lingering around - this PR removes that obsolete check.

Fixes #1140 