### PR TITLE
fix: use current origin for relative camera URLs

### DIFF
--- a/src/mixins/camera.ts
+++ b/src/mixins/camera.ts
@@ -88,7 +88,7 @@ export default class CameraMixin extends Vue {
   }
 
   buildAbsoluteUrl (url: string) {
-    const { origin } = new URL(this.apiUrl)
+    const { origin } = new URL(document.URL)
 
     return new URL(url, origin)
   }


### PR DESCRIPTION
During the camera refactor work, a bug was introduced where the relative camera URL would use the API origin as base when in fact it should be using the current browsing document origin (as it was before)

This PR reverts to the old (correct) behavior.

Fixes #1144