### PR TITLE
feat: add material type column to Spoolman dialog

### DIFF
--- a/src/components/widgets/spoolman/SpoolSelectionDialog.vue
+++ b/src/components/widgets/spoolman/SpoolSelectionDialog.vue
@@ -130,6 +130,7 @@
                     </div>
                   </div>
                 </td>
+                <td>{{ item.filament.material }}</td>
                 <td>{{ item.location }}</td>
                 <td>{{ item.comment }}</td>
                 <td>{{ item.last_used ? $filters.formatRelativeTimeToNow(item.last_used) : $tc('app.setting.label.never') }}</td>
@@ -259,6 +260,7 @@ export default class SpoolSelectionDialog extends Mixins(StateMixin, BrowserMixi
   get headers () {
     return [
       'filament_name',
+      'material',
       'location',
       'comment',
       'last_used'


### PR DESCRIPTION
Adds a new "Material" column to the Spoolman selection dialog.

![image](https://github.com/fluidd-core/fluidd/assets/85504/74a3e993-9867-4abf-8a44-90c442d2ae51)

Resolves #1143 