### PR TITLE
feat(spoolman): QR code scanning support

### DIFF
--- a/docs/features/spoolman.md
+++ b/docs/features/spoolman.md
@@ -22,11 +22,9 @@ Fluidd offers support for the [Spoolman](https://github.com/Donkie/Spoolman) fil
 ### Print start
 On print start, Fluidd will show a modal asking you to select the spool you want to use for printing.
 The modal shows all available (i.e. not archived) spools.
-<!-- TODO uncomment when QR scanning is available
 A spool can either be selected by selecting it directly, or by scanning an associated QR code using an attached webcam.
 
 ![screenshot](/assets/images/spoolman-scan-spool.png)
--->
 
 Automatically opening the spool selection modal can be disabled from the Fluidd settings.
 

--- a/src/components/settings/SpoolmanSettings.vue
+++ b/src/components/settings/SpoolmanSettings.vue
@@ -33,6 +33,17 @@
       </app-setting>
 
       <v-divider />
+      <app-setting
+        :title="$t('app.spoolman.setting.auto_select_spool_on_match')"
+      >
+        <v-switch
+          v-model="autoSelectSpoolOnMatch"
+          hide-details
+          class="mt-0 mb-4"
+        />
+      </app-setting>
+
+      <v-divider />
       <app-setting :title="$t('app.setting.label.reset')">
         <app-btn
           outlined
@@ -84,6 +95,18 @@ export default class SpoolmanSettings extends Mixins(StateMixin) {
   set autoOpenQRDetectionCameraId (value: string) {
     this.$store.dispatch('config/saveByPath', {
       path: 'uiSettings.spoolman.autoOpenQRDetectionCamera',
+      value,
+      server: true
+    })
+  }
+
+  get autoSelectSpoolOnMatch () {
+    return this.$store.state.config.uiSettings.spoolman.autoSelectSpoolOnMatch
+  }
+
+  set autoSelectSpoolOnMatch (value: boolean) {
+    this.$store.dispatch('config/saveByPath', {
+      path: 'uiSettings.spoolman.autoSelectSpoolOnMatch',
       value,
       server: true
     })

--- a/src/components/settings/SpoolmanSettings.vue
+++ b/src/components/settings/SpoolmanSettings.vue
@@ -34,6 +34,17 @@
 
       <v-divider />
       <app-setting
+        :title="$t('app.spoolman.setting.prefer_device_camera')"
+      >
+        <v-switch
+          v-model="preferDeviceCamera"
+          hide-details
+          class="mt-0 mb-4"
+        />
+      </app-setting>
+
+      <v-divider />
+      <app-setting
         :title="$t('app.spoolman.setting.auto_select_spool_on_match')"
       >
         <v-switch
@@ -95,6 +106,18 @@ export default class SpoolmanSettings extends Mixins(StateMixin) {
   set autoOpenQRDetectionCameraId (value: string) {
     this.$store.dispatch('config/saveByPath', {
       path: 'uiSettings.spoolman.autoOpenQRDetectionCamera',
+      value,
+      server: true
+    })
+  }
+
+  get preferDeviceCamera () {
+    return this.$store.state.config.uiSettings.spoolman.preferDeviceCamera
+  }
+
+  set preferDeviceCamera (value: boolean) {
+    this.$store.dispatch('config/saveByPath', {
+      path: 'uiSettings.spoolman.preferDeviceCamera',
       value,
       server: true
     })

--- a/src/components/settings/SpoolmanSettings.vue
+++ b/src/components/settings/SpoolmanSettings.vue
@@ -18,7 +18,6 @@
         />
       </app-setting>
 
-      <!-- TODO uncomment when QR scanning is available
       <v-divider />
       <app-setting
         :title="$tc('app.spoolman.setting.auto_open_qr_camera')"
@@ -32,7 +31,6 @@
           :items="supportedCameras"
         />
       </app-setting>
-      -->
 
       <v-divider />
       <app-setting :title="$t('app.setting.label.reset')">

--- a/src/components/widgets/camera/CameraItem.vue
+++ b/src/components/widgets/camera/CameraItem.vue
@@ -12,6 +12,7 @@
         class="camera-image"
         @raw-camera-url="rawCameraUrl = $event"
         @frames-per-second="framesPerSecond = $event"
+        @playback="setupFrameEvents()"
       />
     </template>
     <div v-else>
@@ -32,7 +33,7 @@
     </div>
 
     <div
-      v-if="!fullscreen && (fullscreenMode === 'embed' || !rawCameraUrl)"
+      v-if="!fullscreen && (fullscreenMode === 'embed' || !rawCameraUrl) && camera.service !== 'device'"
       class="camera-fullscreen"
     >
       <a :href="`/#/camera/${camera.id}`">
@@ -75,7 +76,11 @@ export default class CameraItem extends Vue {
   framesPerSecond : string | null = null
 
   mounted () {
-    if (this.$listeners?.frame) {
+    this.setupFrameEvents()
+  }
+
+  setupFrameEvents () {
+    if (this.$listeners?.frame && this.componentInstance) {
       if (this.componentInstance.streamingElement instanceof HTMLImageElement) {
         this.componentInstance.streamingElement.addEventListener('load', () => this.handleFrame())
       } else if (this.componentInstance.streamingElement instanceof HTMLVideoElement) {

--- a/src/components/widgets/camera/services/DeviceCamera.vue
+++ b/src/components/widgets/camera/services/DeviceCamera.vue
@@ -3,7 +3,6 @@
     ref="streamingElement"
     autoplay
     muted
-    crossorigin="anonymous"
     :style="cameraStyle"
   />
 </template>

--- a/src/components/widgets/camera/services/DeviceCamera.vue
+++ b/src/components/widgets/camera/services/DeviceCamera.vue
@@ -1,0 +1,30 @@
+<template>
+  <video
+    ref="streamingElement"
+    autoplay
+    muted
+    crossorigin="anonymous"
+    :style="cameraStyle"
+  />
+</template>
+
+<script lang="ts">
+import { Component, Ref, Mixins } from 'vue-property-decorator'
+import CameraMixin from '@/mixins/camera'
+
+@Component({})
+export default class DeviceCamera extends Mixins(CameraMixin) {
+  @Ref('streamingElement')
+  readonly cameraVideo!: HTMLVideoElement
+
+  startPlayback () {
+    navigator.mediaDevices.getUserMedia({ video: true })
+      .then(stream => (this.cameraVideo.srcObject = stream))
+      .then(() => this.$emit('playback'))
+  }
+
+  stopPlayback () {
+    this.cameraVideo.srcObject = null
+  }
+}
+</script>

--- a/src/components/widgets/spoolman/QRReader.vue
+++ b/src/components/widgets/spoolman/QRReader.vue
@@ -35,7 +35,7 @@ import BrowserMixin from '@/mixins/browser'
 })
 export default class QRReader extends Mixins(StateMixin, BrowserMixin) {
   dataPatterns = [
-    /web\+spoomnan:s-(\d+)/,
+    /web\+spoolman:s-(\d+)/,
     /\/spool\/show\/(\d+)\/?/
   ]
 

--- a/src/components/widgets/spoolman/QRReader.vue
+++ b/src/components/widgets/spoolman/QRReader.vue
@@ -16,6 +16,7 @@
       <CameraItem
         :camera="camera"
         :embedded="true"
+        crossorigin="anonymous"
         @frame="handlePrinterCameraFrame"
       />
     </v-card-text>

--- a/src/components/widgets/spoolman/QRReader.vue
+++ b/src/components/widgets/spoolman/QRReader.vue
@@ -42,8 +42,6 @@ export default class QRReader extends Mixins(StateMixin, BrowserMixin) {
   statusMessage = 'info.howto'
   lastScanTimestamp = Date.now()
   processing = false
-
-  video!: HTMLVideoElement | HTMLImageElement
   context!: CanvasRenderingContext2D
 
   @VModel({ type: String, default: null })
@@ -53,6 +51,9 @@ export default class QRReader extends Mixins(StateMixin, BrowserMixin) {
     canvas!: HTMLCanvasElement
 
   get camera () {
+    if (this.source === 'device') {
+      return { name: this.$t('app.spoolman.label.device_camera'), service: 'device' }
+    }
     return this.$store.getters['cameras/getCameraById'](this.source)
   }
 
@@ -92,6 +93,12 @@ export default class QRReader extends Mixins(StateMixin, BrowserMixin) {
     } else {
       this.canvas.width = image.naturalWidth
       this.canvas.height = image.naturalHeight
+    }
+
+    if (!this.canvas.width || !this.canvas.height) {
+      // no image drawn yet
+      this.processing = false
+      return
     }
 
     try {

--- a/src/components/widgets/spoolman/QRReader.vue
+++ b/src/components/widgets/spoolman/QRReader.vue
@@ -108,7 +108,11 @@ export default class QRReader extends Mixins(StateMixin, BrowserMixin) {
       if (result.data) { this.handleCodeFound(result.data) }
     } catch (err) {
       if (err instanceof DOMException) {
-        this.statusMessage = 'error.no_image_data'
+        if (err.name === 'SecurityError') {
+          this.statusMessage = 'error.cors'
+        } else {
+          this.statusMessage = 'error.no_image_data'
+        }
       }
 
       // no QR code found

--- a/src/components/widgets/spoolman/QRReader.vue
+++ b/src/components/widgets/spoolman/QRReader.vue
@@ -34,7 +34,11 @@ import BrowserMixin from '@/mixins/browser'
   components: { CameraItem }
 })
 export default class QRReader extends Mixins(StateMixin, BrowserMixin) {
-  dataPatterns = [/\/spool\/show\/(\d+)\/?/]
+  dataPatterns = [
+    /web\+spoomnan:s-(\d+)/,
+    /\/spool\/show\/(\d+)\/?/
+  ]
+
   statusMessage = 'info.howto'
   lastScanTimestamp = Date.now()
   processing = false

--- a/src/components/widgets/spoolman/SpoolSelectionDialog.vue
+++ b/src/components/widgets/spoolman/SpoolSelectionDialog.vue
@@ -323,6 +323,10 @@ export default class SpoolSelectionDialog extends Mixins(StateMixin, BrowserMixi
       // clear filter if selected spool isn't in filter results
       this.search = ''
     }
+
+    if (this.$store.state.config.uiSettings.spoolman.autoSelectSpoolOnMatch) {
+      this.handleSelectSpool()
+    }
   }
 
   async handleSelectSpool () {

--- a/src/components/widgets/spoolman/SpoolSelectionDialog.vue
+++ b/src/components/widgets/spoolman/SpoolSelectionDialog.vue
@@ -128,6 +128,7 @@
                     </div>
                   </div>
                 </td>
+                <td>{{ item.id }}</td>
                 <td>{{ item.filament.material }}</td>
                 <td>{{ item.location }}</td>
                 <td>{{ item.comment }}</td>
@@ -269,6 +270,7 @@ export default class SpoolSelectionDialog extends Mixins(StateMixin, BrowserMixi
   get headers () {
     return [
       'filament_name',
+      'id',
       'material',
       'location',
       'comment',

--- a/src/components/widgets/spoolman/SpoolSelectionDialog.vue
+++ b/src/components/widgets/spoolman/SpoolSelectionDialog.vue
@@ -18,7 +18,6 @@
 
           <v-spacer />
 
-          <!-- TODO uncomment when QR scanning is available
           <v-menu
             v-if="cameras.length > 1"
             v-model="cameraSelectionMenuOpen"
@@ -74,7 +73,6 @@
               {{ $t('app.spoolman.btn.scan_code') }}
             </template>
           </app-btn>
-          -->
 
           <v-text-field
             v-model="search"

--- a/src/locales/de.yaml
+++ b/src/locales/de.yaml
@@ -740,6 +740,10 @@ app:
         code_not_recognized: Dieser Code sieht nicht nach einem kompatiblen QR-Code aus.
         invalid_spool_id: Die Spulen-ID in diesem QR-Code ist ungültig.
       error:
+        cors: >-
+          Es ist ein Fehler beim Abrufen des Kamerabilds aufgetreten.
+          Bitte stellen Sie sicher, dass Ihr Kameraserver CORS-Zugriff erlaubt.
+          Please make sure your webcam server allows CORS access.
         spool_not_existant: Die von Ihnen gescannte Spule existiert nicht in der Datenbank.
         no_image_data: >-
           Es ist ein Fehler beim Abrufen des Kamerabilds aufgetreten.

--- a/src/locales/de.yaml
+++ b/src/locales/de.yaml
@@ -706,6 +706,7 @@ app:
     label:
       change_spool: Suple wechseln
       comment: Kommentar
+      device_camera: Gerät
       filament_name: Filament
       first_used: Zuerst genutzt
       last_used: Zuletzt genutzt
@@ -747,4 +748,5 @@ app:
     setting:
       auto_open_qr_camera: Kamera automatisch zur QR-Code- Erkennung öffnen
       auto_select_spool_on_match: Spulenauswahl bei QR-Code- Übereinstimmung automatisch übernehmen
+      prefer_device_camera: Gerätekamera wenn verfügbar zur QR-Code- Erkennung verwenden
       show_spool_selection_dialog_on_print_start: Spulenauswahl-Dialog automatisch bei Druckstart anzeigen

--- a/src/locales/de.yaml
+++ b/src/locales/de.yaml
@@ -746,4 +746,5 @@ app:
           eine andere Kameraquelle zu verwenden.
     setting:
       auto_open_qr_camera: Kamera automatisch zur QR-Code- Erkennung öffnen
+      auto_select_spool_on_match: Spulenauswahl bei QR-Code- Übereinstimmung automatisch übernehmen
       show_spool_selection_dialog_on_print_start: Spulenauswahl-Dialog automatisch bei Druckstart anzeigen

--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -772,6 +772,7 @@ app:
       device_camera: Device
       filament_name: Filament
       first_used: First Used
+      id: ID
       last_used: Last Used
       location: Location
       lot_nr: Lot Nr

--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -808,4 +808,5 @@ app:
           Please check your camera configuration or try another camera source.
     setting:
       auto_open_qr_camera: Automatically open camera for QR code detection
+      auto_select_spool_on_match: Automatically commit spool selection on QR code match
       show_spool_selection_dialog_on_print_start: Show spool selection dialog on print start

--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -804,6 +804,9 @@ app:
         code_not_recognized: This code doesn't look like a compatible QR code.
         invalid_spool_id: The spool ID contained in this QR code is invalid.
       error:
+        cors: >-
+          There was an error accessing the cameras feed.
+          Please make sure your webcam server allows CORS access.
         spool_not_existant: The spool you scanned doesn't exist in the database.
         no_image_data: >-
           There was an error accessing the cameras feed.

--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -769,6 +769,7 @@ app:
     label:
       change_spool: Change Spool
       comment: Comment
+      device_camera: Device
       filament_name: Filament
       first_used: First Used
       last_used: Last Used
@@ -809,4 +810,5 @@ app:
     setting:
       auto_open_qr_camera: Automatically open camera for QR code detection
       auto_select_spool_on_match: Automatically commit spool selection on QR code match
+      prefer_device_camera: Use device camera for QR code detection if available
       show_spool_selection_dialog_on_print_start: Show spool selection dialog on print start

--- a/src/store/cameras/types.ts
+++ b/src/store/cameras/types.ts
@@ -33,7 +33,7 @@ export interface CameraConfig extends CameraConfigWithoutId {
   id: string;
 }
 
-export type CameraService = 'mjpegstreamer' | 'mjpegstreamer-adaptive' | 'ipstream' | 'iframe' | 'hlsstream' | 'webrtc-camerastreamer'
+export type CameraService = 'mjpegstreamer' | 'mjpegstreamer-adaptive' | 'ipstream' | 'iframe' | 'hlsstream' | 'webrtc-camerastreamer' | 'device'
 
 export interface LegacyCamerasState {
   activeCamera: string;

--- a/src/store/config/state.ts
+++ b/src/store/config/state.ts
@@ -143,7 +143,8 @@ export const defaultState = (): ConfigState => {
       },
       spoolman: {
         autoSpoolSelectionDialog: true,
-        autoOpenQRDetectionCamera: null
+        autoOpenQRDetectionCamera: null,
+        autoSelectSpoolOnMatch: false
       }
     }
   }

--- a/src/store/config/state.ts
+++ b/src/store/config/state.ts
@@ -144,7 +144,8 @@ export const defaultState = (): ConfigState => {
       spoolman: {
         autoSpoolSelectionDialog: true,
         autoOpenQRDetectionCamera: null,
-        autoSelectSpoolOnMatch: false
+        autoSelectSpoolOnMatch: false,
+        preferDeviceCamera: false
       }
     }
   }

--- a/src/store/config/types.ts
+++ b/src/store/config/types.ts
@@ -34,6 +34,7 @@ export interface ToolheadConfig {
 export interface SpoolmanConfig {
   autoSpoolSelectionDialog: boolean;
   autoOpenQRDetectionCamera: string | null;
+  autoSelectSpoolOnMatch: boolean;
 }
 
 export interface HostConfig {

--- a/src/store/config/types.ts
+++ b/src/store/config/types.ts
@@ -35,6 +35,7 @@ export interface SpoolmanConfig {
   autoSpoolSelectionDialog: boolean;
   autoOpenQRDetectionCamera: string | null;
   autoSelectSpoolOnMatch: boolean;
+  preferDeviceCamera: boolean;
 }
 
 export interface HostConfig {


### PR DESCRIPTION
As described in https://github.com/fluidd-core/fluidd/pull/1119

Adds support for spoolman QR codes (https://github.com/Donkie/Spoolman/issues/10).
Adds an option to automatically commit a spool selection when a valid QR code is scanned (no need to manually confirm the selection)
Adds support for using the device's camera as a scan source (https://github.com/fluidd-core/fluidd/pull/1119#issuecomment-1676159359)
Closes https://github.com/fluidd-core/fluidd/issues/1151