### PR TITLE
fix: ignore crossorigin in cameras by default

### DIFF
--- a/src/components/widgets/camera/CameraItem.vue
+++ b/src/components/widgets/camera/CameraItem.vue
@@ -9,6 +9,7 @@
         :is="cameraComponent"
         ref="component-instance"
         :camera="camera"
+        :crossorigin="crossorigin"
         class="camera-image"
         @raw-camera-url="rawCameraUrl = $event"
         @frames-per-second="framesPerSecond = $event"
@@ -67,6 +68,9 @@ export default class CameraItem extends Vue {
 
   @Prop({ type: Boolean, required: false, default: false })
   readonly fullscreen!: boolean
+
+  @Prop({ type: String })
+  readonly crossorigin?: 'anonymous' | 'use-credentials' | ''
 
   @Ref('component-instance')
   readonly componentInstance!: CameraMixin

--- a/src/components/widgets/camera/services/HlsstreamCamera.vue
+++ b/src/components/widgets/camera/services/HlsstreamCamera.vue
@@ -3,7 +3,7 @@
     ref="streamingElement"
     autoplay
     muted
-    crossorigin="anonymous"
+    :crossorigin="crossorigin"
     :style="cameraStyle"
   />
 </template>

--- a/src/components/widgets/camera/services/IpstreamCamera.vue
+++ b/src/components/widgets/camera/services/IpstreamCamera.vue
@@ -4,7 +4,7 @@
     :src="cameraVideoSource"
     autoplay
     muted
-    crossorigin="anonymous"
+    :crossorigin="crossorigin"
     :style="cameraStyle"
   />
 </template>

--- a/src/components/widgets/camera/services/MjpegstreamerAdaptiveCamera.vue
+++ b/src/components/widgets/camera/services/MjpegstreamerAdaptiveCamera.vue
@@ -3,7 +3,7 @@
     ref="streamingElement"
     :src="cameraImageSource"
     :style="cameraStyle"
-    crossorigin="anonymous"
+    :crossorigin="crossorigin"
     @load="handleImageLoad"
   >
 </template>

--- a/src/components/widgets/camera/services/MjpegstreamerCamera.vue
+++ b/src/components/widgets/camera/services/MjpegstreamerCamera.vue
@@ -3,7 +3,7 @@
     ref="streamingElement"
     :src="cameraImageSource"
     :style="cameraStyle"
-    crossorigin="anonymous"
+    :crossorigin="crossorigin"
   >
 </template>
 

--- a/src/components/widgets/camera/services/WebrtcCamerastreamerCamera.vue
+++ b/src/components/widgets/camera/services/WebrtcCamerastreamerCamera.vue
@@ -4,7 +4,7 @@
     autoplay
     muted
     :style="cameraStyle"
-    crossorigin="anonymous"
+    :crossorigin="crossorigin"
   />
 </template>
 

--- a/src/mixins/camera.ts
+++ b/src/mixins/camera.ts
@@ -7,6 +7,9 @@ export default class CameraMixin extends Vue {
   @Prop({ type: Object, required: true })
   readonly camera!: CameraConfig
 
+  @Prop({ type: String })
+  readonly crossorigin?: 'anonymous' | 'use-credentials' | ''
+
   @Ref('streamingElement')
   readonly streamingElement!: HTMLImageElement | HTMLIFrameElement | HTMLVideoElement
 


### PR DESCRIPTION
In v1.25.0 we added a new `crossorigin="anonymous"` attribute to the `<video>` and `<img>` elements used by the cameras, but this introduced a bug where cameras that are accessed across domains without `Access-Control-Allow-Origin "*"` header set by the server would fail to load with a CORS error.

This PR adds a new `crossorigin` property that allows setting the attribute when needed, but defaults to `undefined` so it won't get output in that case.

Fixes #1150