### PR TITLE
fix(i18n-DE): Fix typo in german translation

### DIFF
--- a/src/locales/de.yaml
+++ b/src/locales/de.yaml
@@ -704,7 +704,7 @@ app:
       spool_selection: Spulenauswahl
       scan_spool: Spule scannen
     label:
-      change_spool: Suple wechseln
+      change_spool: Spule wechseln
       comment: Kommentar
       device_camera: Gerät
       filament_name: Filament


### PR DESCRIPTION
just fixed a small typo in the german translation of the Spoolman widget