### PR TITLE
fix: use full Klipper key for thermal data storage

### DIFF
--- a/src/components/widgets/thermals/TemperatureCard.vue
+++ b/src/components/widgets/thermals/TemperatureCard.vue
@@ -162,17 +162,17 @@ export default class TemperatureCard extends Mixins(StateMixin, BrowserMixin) {
     // If this has a target, toggle that too.
     if (this.chartVisible) {
       if ('target' in item) {
-        this.thermalChartElement.legendToggleSelect(item.name + 'Target')
+        this.thermalChartElement.legendToggleSelect(item.key + 'Target')
       }
-      this.thermalChartElement.legendToggleSelect(item.name)
+      this.thermalChartElement.legendToggleSelect(item.key)
     }
   }
 
   legendTogglePowerSelect (item: Heater | Fan) {
     if (this.chartVisible) {
       const name = ('speed' in item)
-        ? item.name + 'Speed'
-        : item.name + 'Power'
+        ? item.key + 'Speed'
+        : item.key + 'Power'
       this.thermalChartElement.legendToggleSelect(name)
     }
   }

--- a/src/components/widgets/thermals/TemperatureTargets.vue
+++ b/src/components/widgets/thermals/TemperatureTargets.vue
@@ -28,7 +28,7 @@
       <tbody v-if="klippyReady">
         <tr
           v-for="item in heaters"
-          :key="item.name"
+          :key="item.key"
         >
           <td>
             <v-icon
@@ -40,7 +40,7 @@
           </td>
           <td class="temp-name">
             <span
-              :class="{ 'active': !(item.name in chartSelectedLegends) || chartSelectedLegends[item.name] }"
+              :class="{ 'active': !(item.key in chartSelectedLegends) || chartSelectedLegends[item.key] }"
               class="legend-item"
               @click="$emit('legendClick', item)"
             >
@@ -49,7 +49,7 @@
           </td>
           <td class="temp-power">
             <span
-              :class="{ 'active': chartSelectedLegends[item.name + 'Power'] }"
+              :class="{ 'active': chartSelectedLegends[item.key + 'Power'] }"
               class="legend-item"
               @click="$emit('legendPowerClick', item)"
             >
@@ -64,7 +64,7 @@
             class="rate-of-change"
           >
             <span
-              :class="{ 'active': chartSelectedLegends[item.name + 'Power'] }"
+              :class="{ 'active': chartSelectedLegends[item.key + 'Power'] }"
               class="legend-item"
             >
               <span>{{ getRateOfChange(item) }}<small>&deg;C/s</small></span>
@@ -97,7 +97,7 @@
         </tr>
         <tr
           v-for="item in fans"
-          :key="item.name"
+          :key="item.key"
         >
           <td>
             <v-icon
@@ -110,7 +110,7 @@
           </td>
           <td class="temp-name">
             <span
-              :class="{ 'active': !(item.name in chartSelectedLegends) || chartSelectedLegends[item.name] }"
+              :class="{ 'active': !(item.key in chartSelectedLegends) || chartSelectedLegends[item.key] }"
               class="legend-item"
               @click="$emit('legendClick', item)"
             >
@@ -120,7 +120,7 @@
           <td class="temp-power">
             <span
               v-if="item.speed"
-              :class="{ 'active': chartSelectedLegends[item.name + 'Speed'] }"
+              :class="{ 'active': chartSelectedLegends[item.key + 'Speed'] }"
               class="legend-item"
               @click="$emit('legendPowerClick', item)"
             >
@@ -138,7 +138,7 @@
             class="rate-of-change"
           >
             <span
-              :class="{ 'active': chartSelectedLegends[item.name + 'Power'] }"
+              :class="{ 'active': chartSelectedLegends[item.key + 'Power'] }"
               class="legend-item"
             >
               <span>{{ getRateOfChange(item) }}<small>&deg;C/s</small></span>
@@ -179,7 +179,7 @@
         </tr>
         <tr
           v-for="item in sensors"
-          :key="item.name"
+          :key="item.key"
         >
           <td>
             <v-icon
@@ -191,7 +191,7 @@
           </td>
           <td class="temp-name">
             <span
-              :class="{ 'active': !(item.name in chartSelectedLegends) || chartSelectedLegends[item.name] }"
+              :class="{ 'active': !(item.key in chartSelectedLegends) || chartSelectedLegends[item.key] }"
               class="legend-item"
               @click="$emit('legendClick', item)"
             >
@@ -314,14 +314,14 @@ export default class TemperatureTargets extends Mixins(StateMixin) {
   getRateOfChange (item: Heater | Sensor) {
     const recentChartData = this.chartData
       .slice(-5)
-    const filteredChartData = takeRightWhile(recentChartData, x => x[item.name] != null)
+    const filteredChartData = takeRightWhile(recentChartData, x => x[item.key] != null)
 
     let rateOfChange = 0
     if (filteredChartData.length >= 2) {
       const curr = filteredChartData[filteredChartData.length - 1]
       const prev = filteredChartData[0]
 
-      rateOfChange = (+curr[item.name] - +prev[item.name]) / (+curr.date - +prev.date) * 1000
+      rateOfChange = (+curr[item.key] - +prev[item.key]) / (+curr.date - +prev.date) * 1000
 
       if (Math.abs(rateOfChange) < 0.05) {
         rateOfChange = 0 // prevent constant change of sign

--- a/src/components/widgets/thermals/ThermalChart.vue
+++ b/src/components/widgets/thermals/ThermalChart.vue
@@ -88,12 +88,10 @@ export default class ThermalChart extends Mixins(BrowserMixin) {
     const keys = this.$store.getters['printer/getChartableSensors'] as string[]
 
     keys.forEach((key) => {
-      const label = key.split(' ', 2).pop() || ''
-
-      this.series.push(this.createSeries(label, key))
-      if (dataKeys.includes(label + 'Target')) this.series.push(this.createSeries(label + 'Target', key))
-      if (dataKeys.includes(label + 'Power')) this.series.push(this.createSeries(label + 'Power', key))
-      if (dataKeys.includes(label + 'Speed')) this.series.push(this.createSeries(label + 'Speed', key))
+      this.series.push(this.createSeries(key))
+      if (dataKeys.includes(`${key}Target`)) this.series.push(this.createSeries(`${key}Target`))
+      if (dataKeys.includes(`${key}Power`)) this.series.push(this.createSeries(`${key}Power`))
+      if (dataKeys.includes(`${key}Speed`)) this.series.push(this.createSeries(`${key}Speed`))
     })
   }
 
@@ -171,11 +169,12 @@ export default class ThermalChart extends Mixins(BrowserMixin) {
                 param.seriesName &&
                 param.value[param.seriesName] != null
               ) {
+                const name = param.seriesName.split(' ', 2).pop()
                 text += `
                   <div>
                     ${param.marker}
                     <span style="font-size:${fontSize}px;color:${fontColor};font-weight:400;margin-left:2px">
-                      ${this.$filters.startCase(param.seriesName)}:
+                      ${this.$filters.startCase(name)}:
                     </span>
                     <span style="float:right;margin-left:20px;font-size:${fontSize}px;color:${fontColor};font-weight:900">
                       ${param.value[param.seriesName].toFixed(2)}<small>°C</small>`
@@ -289,13 +288,13 @@ export default class ThermalChart extends Mixins(BrowserMixin) {
     return options
   }
 
-  createSeries (label: string, key: string) {
+  createSeries (key: string) {
     // Grab the color
     const color = this.$colorset.next(getKlipperType(key), key)
 
     // Base properties
     const series: any = {
-      name: label,
+      name: key,
       // id,
       type: 'line',
       yAxisIndex: 0,
@@ -314,11 +313,11 @@ export default class ThermalChart extends Mixins(BrowserMixin) {
         opacity: 1
       },
       areaStyle: { opacity: 0.05 },
-      encode: { x: 'date', y: label }
+      encode: { x: 'date', y: key }
     }
 
     // If this is a target, adjust its display.
-    if (label.toLowerCase().endsWith('target')) {
+    if (key.toLowerCase().endsWith('target')) {
       series.yAxisIndex = 0
       series.emphasis.lineStyle.width = 1
       series.lineStyle.width = 1
@@ -329,8 +328,8 @@ export default class ThermalChart extends Mixins(BrowserMixin) {
 
     // If this is a power or speed, adjust its display.
     if (
-      label.toLowerCase().endsWith('power') ||
-      label.toLowerCase().endsWith('speed')
+      key.toLowerCase().endsWith('power') ||
+      key.toLowerCase().endsWith('speed')
     ) {
       series.yAxisIndex = 1
       series.emphasis.lineStyle.width = 1
@@ -342,12 +341,12 @@ export default class ThermalChart extends Mixins(BrowserMixin) {
 
     // Set the initial legend state (power and speed default off)
     const storedLegends = this.$store.getters['charts/getSelectedLegends']
-    if (storedLegends[label] !== undefined) {
-      this.initialSelected[label] = storedLegends[label]
+    if (storedLegends[key] !== undefined) {
+      this.initialSelected[key] = storedLegends[key]
     } else {
-      this.initialSelected[label] = !(
-        label.toLowerCase().endsWith('power') ||
-        label.toLowerCase().endsWith('speed')
+      this.initialSelected[key] = !(
+        key.toLowerCase().endsWith('power') ||
+        key.toLowerCase().endsWith('speed')
       )
     }
 

--- a/src/store/chart_helpers.ts
+++ b/src/store/chart_helpers.ts
@@ -132,15 +132,14 @@ export const handleAddChartEntry = (retention: number, state: RootState, commit:
     const keys: string[] = getters.getChartableSensors
 
     keys.forEach((key) => {
-      const label = key.split(' ', 2).pop() || ''
       const temp = state.printer.printer[key].temperature
       const target = state.printer.printer[key].target
       const power = state.printer.printer[key].power
       const speed = state.printer.printer[key].speed
-      r[label] = temp
-      if (target != null) r[`${label}Target`] = target
-      if (power != null) r[`${label}Power`] = power
-      if (speed != null) r[`${label}Speed`] = speed
+      r[key] = temp
+      if (target != null) r[`${key}Target`] = target
+      if (power != null) r[`${key}Power`] = power
+      if (speed != null) r[`${key}Speed`] = speed
     })
 
     return r

--- a/src/store/charts/actions.ts
+++ b/src/store/charts/actions.ts
@@ -71,13 +71,11 @@ export const actions: ActionTree<ChartState, RootState> = {
         date
       }
       keys.forEach(key => {
-        const label = key.split(' ', 2).pop() || ''
-
         if (rootState.printer.printer[key]) {
-          r[label] = payload[key].temperatures[i]
-          if ('targets' in payload[key]) r[`${label}Target`] = payload[key].targets[i]
-          if ('powers' in payload[key]) r[`${label}Power`] = payload[key].powers[i]
-          if ('speeds' in payload[key]) r[`${label}Speed`] = payload[key].speeds[i]
+          r[key] = payload[key].temperatures[i]
+          if ('targets' in payload[key]) r[`${key}Target`] = payload[key].targets[i]
+          if ('powers' in payload[key]) r[`${key}Power`] = payload[key].powers[i]
+          if ('speeds' in payload[key]) r[`${key}Speed`] = payload[key].speeds[i]
         }
       })
       d.push(r)


### PR DESCRIPTION
We currently take the Klipper section name and use only the component name (as in the second part of said section name) as key to the thermal storage, but that is becoming a problem when we have a `[extruder]` and `[tmc2240 extruder]` as these will both have "extruder" as key.

This PR fixes this issue by using the full section name as key.

Note: the thermal chart will still show two Extruder entries! We probably can and should improve this, but I will leave that for a different PR.

Fixes #1166 