### PR TITLE
fix: delta printers can only home all

### DIFF
--- a/src/components/widgets/toolhead/ToolheadMoves.vue
+++ b/src/components/widgets/toolhead/ToolheadMoves.vue
@@ -28,7 +28,6 @@
         />
       </v-col>
       <v-col
-        v-if="canHomeXY"
         class="ml-2"
       >
         <app-btn-toolhead-move
@@ -48,7 +47,12 @@
       justify="start"
       class="mb-2"
     >
-      <v-col cols="auto">
+      <v-col
+        cols="auto"
+        :class="{
+          'mr-12': !canHomeXY,
+        }"
+      >
         <app-btn-toolhead-move
           :color="axisButtonColor(xHomed)"
           :disabled="axisButtonDisabled(xHomed, xHasMultipleSteppers)"
@@ -57,6 +61,7 @@
         />
       </v-col>
       <v-col
+        v-if="canHomeXY"
         cols="auto"
         class="ml-2"
       >


### PR DESCRIPTION
Delta printers can only home all axis at the same time, but currently we show "Home XY" button when we should be showing "Home All" button.

## Before

![image](https://github.com/fluidd-core/fluidd/assets/85504/a622227c-24d4-4c12-9abe-387211f4b74a)

## After

![image](https://github.com/fluidd-core/fluidd/assets/85504/86e1286b-b44a-4fd7-973f-9f0b864d9ac3)

Fixes #1174