### PR TITLE
fix: ensures .git folders are excluded

### DIFF
--- a/src/globals.ts
+++ b/src/globals.ts
@@ -221,6 +221,7 @@ export const Globals = Object.freeze({
     { filename: 'telegram.conf', service: 'moonraker-telegram-bot', link: 'https://github.com/nlef/moonraker-telegram-bot/wiki/Sample-config' },
     { suffix: '.cfg', service: 'klipper', link: 'https://www.klipper3d.org/Config_Reference.html' }
   ],
+  FILTERED_FOLDER_NAMES: ['.git'],
   FILTERED_FILES_PREFIX: ['.thumbs', 'thumbs'],
   FILTERED_FILES_EXTENSION: ['.ignoreme'],
   DOCS_ROOT: 'https://docs.fluidd.xyz',

--- a/src/store/files/types.ts
+++ b/src/store/files/types.ts
@@ -81,6 +81,7 @@ export interface FilePaths {
   filename: string;
   path: string;
   rootPath: string;
+  filtered: boolean;
 }
 
 export interface FileUpdate {

--- a/src/util/get-file-paths.ts
+++ b/src/util/get-file-paths.ts
@@ -1,6 +1,5 @@
-import {
-  FilePaths
-} from '@/store/files/types'
+import { Globals } from '@/globals'
+import { FilePaths } from '@/store/files/types'
 
 /**
  * Takes a filename and root and provides;
@@ -9,13 +8,15 @@ import {
  * - the path, including root.
  */
 export default (filePath: string, root: string): FilePaths => {
-  let path = filePath.substr(0, filePath.lastIndexOf('/'))
-  path = (path && path.startsWith(root))
-    ? path.substring(root.length + 1)
-    : path
+  const pathParts = filePath.split('/')
+  const filtered = Globals.FILTERED_FOLDER_NAMES.some(x => pathParts.includes(x))
+  const filename = pathParts.pop() ?? ''
+  const path = pathParts.join('/')
+
   return {
-    filename: filePath.split('/').pop() || '',
+    filename,
     path,
-    rootPath: (path.length === 0) ? root : root + '/' + path
+    rootPath: path ? `${root}/${path}` : root,
+    filtered
   }
 }


### PR DESCRIPTION
Moonraker currently sends websocket notifications for file system changes on ".git" folders, causing Fluidd to refresh the File System cache.

This PR will check if a ".git" folder is part of the path in the notification, and if so, ignore it.

Fixes #1193 