### PR TITLE
feat: improve drag & drop support

### DIFF
--- a/src/components/widgets/filesystem/FileSystem.vue
+++ b/src/components/widgets/filesystem/FileSystem.vue
@@ -5,10 +5,10 @@
     :max-height="maxHeight"
     :class="{ 'no-pointer-events': dragState.overlay }"
     flat
-    @dragenter.capture.prevent="handleDragEnter"
-    @dragover.prevent
+    @dragover="handleDragOver"
+    @dragenter.self.prevent
     @dragleave.self.prevent="handleDragLeave"
-    @drop.prevent.stop="handleDropFile"
+    @drop.self.prevent="handleDropFile"
   >
     <file-system-toolbar
       v-if="selected.length <= 0"
@@ -40,6 +40,7 @@
 
     <file-system-browser
       v-if="headers"
+      v-model="selected"
       :headers="visibleHeaders"
       :root="currentRoot"
       :dense="dense"
@@ -49,7 +50,6 @@
       :files="files"
       :drag-state.sync="dragState.browserState"
       :bulk-actions="bulkActions"
-      :selected.sync="selected"
       :large-thumbnails="currentRoot === 'timelapse'"
       @row-click="handleRowClick"
       @move="handleMove"
@@ -814,7 +814,7 @@ export default class FileSystem extends Mixins(StateMixin, FilesMixin, ServicesM
           jobs: files.map(file => file.name)
         }
 
-        dataTransfer.setData('jobs', JSON.stringify(data))
+        dataTransfer.setData('x-fluidd-jobs', JSON.stringify(data))
       }
     }
   }
@@ -945,9 +945,18 @@ export default class FileSystem extends Mixins(StateMixin, FilesMixin, ServicesM
    * Drag handling.
    * ===========================================================================
   */
-  handleDragEnter (e: DragEvent) {
-    if (!this.rootProperties.readonly && !this.dragState.browserState && e.dataTransfer && hasFilesInDataTransfer(e.dataTransfer)) {
+  handleDragOver (e: DragEvent) {
+    if (
+      !this.rootProperties.readonly &&
+      !this.dragState.browserState &&
+      e.dataTransfer &&
+      hasFilesInDataTransfer(e.dataTransfer)
+    ) {
+      e.preventDefault()
+
       this.dragState.overlay = true
+
+      e.dataTransfer.dropEffect = 'copy'
     }
   }
 

--- a/src/components/widgets/job-queue/JobQueue.vue
+++ b/src/components/widgets/job-queue/JobQueue.vue
@@ -1,10 +1,10 @@
 <template>
   <v-card
     :class="{ 'no-pointer-events': overlay }"
-    @dragenter.capture.prevent="handleDragEnter"
-    @dragover.prevent
+    @dragover="handleDragOver"
+    @dragenter.self.prevent
     @dragleave.self.prevent="handleDragLeave"
-    @drop.prevent.stop="handleDropJob"
+    @drop.self.prevent="handleDrop"
   >
     <job-queue-toolbar
       v-if="selected.length === 0"
@@ -143,8 +143,12 @@ export default class JobQueue extends Vue {
     SocketActions.serverJobQueueDeleteJobs(jobIds)
   }
 
-  handleDragEnter (e: DragEvent) {
-    if (e.dataTransfer?.types.includes('jobs')) {
+  handleDragOver (e: DragEvent) {
+    if (e.dataTransfer?.types.includes('x-fluidd-jobs')) {
+      e.preventDefault()
+
+      e.dataTransfer.dropEffect = 'link'
+
       this.overlay = true
     }
   }
@@ -153,11 +157,11 @@ export default class JobQueue extends Vue {
     this.overlay = false
   }
 
-  handleDropJob (e: DragEvent) {
+  handleDrop (e: DragEvent) {
     this.overlay = false
 
-    if (e.dataTransfer?.types.includes('jobs')) {
-      const data = e.dataTransfer.getData('jobs')
+    if (e.dataTransfer?.types.includes('x-fluidd-jobs')) {
+      const data = e.dataTransfer.getData('x-fluidd-jobs')
       const files: { path: string, jobs: string[] } = JSON.parse(data)
       const filePath = files.path ? `${files.path}/` : ''
       const filenames = files.jobs

--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -133,6 +133,8 @@ app:
       confirm: >-
         The file "%{filename}" is %{size}, this might be resource intensive for
         your system. Are you sure?
+    overlay:
+      drag_file_load: <strong>Drag</strong> a gcode file here to load
   general:
     btn:
       abort: Abort


### PR DESCRIPTION
Improves drag & drop support by:

- adds `text/html`, `text/plain` and `text/uri-list` data types
- allows loading of gcode files in the Gcode Previewer via drag & drop
- refactored (simplified) the multi-selection code

Resolves #1202

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>