### PR TITLE
feat: adds Multiply context menu item to Job Queue

### DIFF
--- a/src/components/widgets/job-queue/JobQueue.vue
+++ b/src/components/widgets/job-queue/JobQueue.vue
@@ -16,6 +16,7 @@
     <job-queue-bulk-actions
       v-else
       @remove="handleRemove(selected)"
+      @multiply="handleMultiplyDialog(selected)"
     />
 
     <job-queue-browser
@@ -40,6 +41,14 @@
       :position-x="contextMenuState.x"
       :position-y="contextMenuState.y"
       @remove="handleRemove"
+      @multiply="handleMultiplyDialog"
+    />
+
+    <job-queue-multiply-job-dialog
+      v-if="multiplyJobDialogState.open"
+      v-model="multiplyJobDialogState.open"
+      :job="multiplyJobDialogState.job"
+      @save="handleMultiply"
     />
   </v-card>
 </template>
@@ -52,6 +61,7 @@ import JobQueueToolbar from './JobQueueToolbar.vue'
 import JobQueueBulkActions from './JobQueueBulkActions.vue'
 import JobQueueBrowser from './JobQueueBrowser.vue'
 import JobQueueContextMenu from './JobQueueContextMenu.vue'
+import JobQueueMultiplyJobDialog from './JobQueueMultiplyJobDialog.vue'
 import type { AppTableHeader } from '@/types'
 
 @Component({
@@ -59,6 +69,7 @@ import type { AppTableHeader } from '@/types'
     JobQueueToolbar,
     JobQueueBulkActions,
     JobQueueBrowser,
+    JobQueueMultiplyJobDialog,
     JobQueueContextMenu
   }
 })
@@ -67,6 +78,11 @@ export default class JobQueue extends Vue {
     open: false,
     x: 0,
     y: 0,
+    job: null
+  }
+
+  multiplyJobDialogState: any = {
+    open: false,
     job: null
   }
 
@@ -142,6 +158,25 @@ export default class JobQueue extends Vue {
       : [jobs.job_id]
 
     SocketActions.serverJobQueueDeleteJobs(jobIds)
+  }
+
+  handleMultiplyDialog (jobs: QueuedJob | QueuedJob[]) {
+    this.multiplyJobDialogState = {
+      open: true,
+      job: jobs
+    }
+  }
+
+  handleMultiply (jobs: QueuedJob | QueuedJob[], copies: number) {
+    const filenames = Array.isArray(jobs)
+      ? jobs.map(job => job.filename)
+      : [jobs.filename]
+
+    const multipliedFilenames = Array.from({ length: copies })
+      .map(() => filenames)
+      .flat()
+
+    SocketActions.serverJobQueuePostJob(multipliedFilenames)
   }
 
   handleDragOver (event: DragEvent) {

--- a/src/components/widgets/job-queue/JobQueueBulkActions.vue
+++ b/src/components/widgets/job-queue/JobQueueBulkActions.vue
@@ -9,6 +9,22 @@
           fab
           small
           text
+          @click="$emit('multiply')"
+          v-on="on"
+        >
+          <v-icon>$duplicate</v-icon>
+        </v-btn>
+      </template>
+      <span>{{ $t('app.general.btn.multiply') }}</span>
+    </v-tooltip>
+
+    <v-tooltip bottom>
+      <template #activator="{ on, attrs }">
+        <v-btn
+          v-bind="attrs"
+          fab
+          small
+          text
           @click="$emit('remove')"
           v-on="on"
         >

--- a/src/components/widgets/job-queue/JobQueueContextMenu.vue
+++ b/src/components/widgets/job-queue/JobQueueContextMenu.vue
@@ -9,6 +9,17 @@
     right
   >
     <v-list dense>
+      <v-list-item @click="$emit('multiply', job)">
+        <v-list-item-icon>
+          <v-icon>
+            $duplicate
+          </v-icon>
+        </v-list-item-icon>
+        <v-list-item-content>
+          <v-list-item-title>{{ $t('app.general.btn.multiply') }}</v-list-item-title>
+        </v-list-item-content>
+      </v-list-item>
+
       <v-list-item @click="$emit('remove', job)">
         <v-list-item-icon>
           <v-icon>

--- a/src/components/widgets/job-queue/JobQueueMultiplyJobDialog.vue
+++ b/src/components/widgets/job-queue/JobQueueMultiplyJobDialog.vue
@@ -1,0 +1,51 @@
+<template>
+  <app-dialog
+    v-model="open"
+    :title="$tc('app.job_queue.title.multiply_job', jobCount)"
+    max-width="320"
+    @save="handleSave"
+  >
+    <v-card-text>
+      <v-text-field
+        v-model.number="copies"
+        autofocus
+        outlined
+        :label="$t('app.job_queue.label.number_of_copies')"
+        :rules="[
+          $rules.required,
+          $rules.numberValid,
+          $rules.numberGreaterThanOrEqual(1)
+        ]"
+        required
+      />
+    </v-card-text>
+  </app-dialog>
+</template>
+
+<script lang="ts">
+import { Component, Vue, VModel, Prop } from 'vue-property-decorator'
+import type { QueuedJob } from '@/store/jobQueue/types'
+import { isArray } from 'lodash-es'
+
+@Component({})
+export default class JobQueueMultiplyJobDialog extends Vue {
+  copies = 1
+
+  @VModel({ type: Boolean, required: true })
+    open!: boolean
+
+  @Prop({ type: [Object, Array], required: true })
+  readonly job!: QueuedJob | QueuedJob[]
+
+  get jobCount () {
+    return isArray(this.job)
+      ? this.job.length
+      : 1
+  }
+
+  handleSave () {
+    this.$emit('save', this.job, this.copies)
+    this.open = false
+  }
+}
+</script>

--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -168,6 +168,7 @@ app:
       login: Login
       logout: Logout
       more_information: More information
+      multiply: Multiply
       pause: Pause
       preheat: Preheat
       presets: Presets
@@ -452,6 +453,10 @@ app:
   job_queue:
     msg:
       confirm: Are you sure? This will clear the entire printer queue
+    label:
+      number_of_copies: Number of copies
+    title:
+      multiply_job: Multiply Job | Multiply Jobs
   printer:
     state:
       busy: Busy


### PR DESCRIPTION
Adds a new Multiply context menu item (and bulk item selection toolbar action) that allows to enqueue multiple copies of the same queued job.

## Context menu item

![image](https://github.com/fluidd-core/fluidd/assets/85504/cf01a81a-2d8c-4b8b-9083-2ccc9cfae191)

## Bulk selection toolbar action

![image](https://github.com/fluidd-core/fluidd/assets/85504/fc83cde3-98f0-46fb-98ba-aa5698674ffb)

## Multiply Job dialog

![image](https://github.com/fluidd-core/fluidd/assets/85504/2ca059d1-988d-46cc-8a6d-880e3fc9700d)

Resolves #1212 