### PR TITLE
feat: ignore pending config changes in custom sections

### DIFF
--- a/src/components/layout/AppBar.vue
+++ b/src/components/layout/AppBar.vue
@@ -243,13 +243,14 @@ export default class AppBar extends Mixins(StateMixin, ServicesMixin, FilesMixin
       return false
     }
 
-    if (!this.ignoreDefaultBedMeshPendingConfigurationChanges) {
-      return true
-    }
+    const sectionsToIgnore = this.sectionsToIgnorePendingConfigurationChanges
 
-    const saveConfigPendingItemsKeys = Object.keys(this.saveConfigPendingItems)
-
-    return saveConfigPendingItemsKeys.length > 1 || saveConfigPendingItemsKeys[0] !== 'bed_mesh default'
+    return (
+      sectionsToIgnore.length === 0 ||
+      Object.keys(this.saveConfigPendingItems)
+        .filter(key => !sectionsToIgnore.includes(key))
+        .length > 0
+    )
   }
 
   get devicePowerComponentEnabled () {
@@ -268,8 +269,8 @@ export default class AppBar extends Mixins(StateMixin, ServicesMixin, FilesMixin
     return this.$store.state.config.uiSettings.general.showSaveConfigAndRestart as boolean
   }
 
-  get ignoreDefaultBedMeshPendingConfigurationChanges (): boolean {
-    return this.$store.state.config.uiSettings.general.ignoreDefaultBedMeshPendingConfigurationChanges as boolean
+  get sectionsToIgnorePendingConfigurationChanges (): string[] {
+    return this.$store.state.config.uiSettings.general.sectionsToIgnorePendingConfigurationChanges as string[]
   }
 
   get showUploadAndPrint (): boolean {

--- a/src/components/settings/FileEditorSettings.vue
+++ b/src/components/settings/FileEditorSettings.vue
@@ -105,12 +105,11 @@ export default class FileEditorSettings extends Mixins(StateMixin) {
   }
 
   set autoEditExtensions (value: string[]) {
-    value = value.map((ext: string) => ext.startsWith('.') ? ext : `.${ext}`)
-    value = value.filter((ext: string, index: number) => value.indexOf(ext) === index) // deduplicate entries
-
     this.$store.dispatch('config/saveByPath', {
       path: 'uiSettings.editor.autoEditExtensions',
-      value: value.sort(),
+      value: [
+        ...new Set(value.map(ext => ext.startsWith('.') ? ext : `.${ext}`))
+      ].sort((a, b) => a.localeCompare(b)),
       server: true
     })
   }

--- a/src/components/settings/GeneralSettings.vue
+++ b/src/components/settings/GeneralSettings.vue
@@ -156,17 +156,25 @@
             @click.native.stop
           />
         </app-setting>
+      </template>
 
+      <template v-if="showSaveConfigAndRestart && confirmOnSaveConfigAndRestart">
         <v-divider />
 
         <app-setting
-          :title="$t('app.setting.label.ignore_default_bed_mesh_pending_configuration_changes')"
+          :title="$t('app.setting.label.sections_to_ignore_pending_configuration_changes')"
         >
-          <v-switch
-            v-model="ignoreDefaultBedMeshPendingConfigurationChanges"
-            hide-details
-            class="mb-5"
-            @click.native.stop
+          <v-combobox
+            v-model="sectionsToIgnorePendingConfigurationChanges"
+            :items="['bed_mesh default', 'bed_tilt']"
+            filled
+            dense
+            hide-selected
+            hide-details="auto"
+            multiple
+            small-chips
+            append-icon=""
+            deletable-chips
           />
         </app-setting>
       </template>
@@ -402,14 +410,14 @@ export default class GeneralSettings extends Mixins(StateMixin) {
     })
   }
 
-  get ignoreDefaultBedMeshPendingConfigurationChanges (): boolean {
-    return this.$store.state.config.uiSettings.general.ignoreDefaultBedMeshPendingConfigurationChanges as boolean
+  get sectionsToIgnorePendingConfigurationChanges (): string[] {
+    return this.$store.state.config.uiSettings.general.sectionsToIgnorePendingConfigurationChanges as string[]
   }
 
-  set ignoreDefaultBedMeshPendingConfigurationChanges (value: boolean) {
+  set sectionsToIgnorePendingConfigurationChanges (value: string[]) {
     this.$store.dispatch('config/saveByPath', {
-      path: 'uiSettings.general.ignoreDefaultBedMeshPendingConfigurationChanges',
-      value,
+      path: 'uiSettings.general.sectionsToIgnorePendingConfigurationChanges',
+      value: [...new Set(value)].sort((a, b) => a.localeCompare(b)),
       server: true
     })
   }

--- a/src/locales/af.yaml
+++ b/src/locales/af.yaml
@@ -530,7 +530,6 @@ app:
       height: Hoogte
       gcode_coords: Gebruik GCode-koordinate
       icon: Ikoon
-      ignore_default_bed_mesh_pending_configuration_changes: Ignoreer verstek bedmaas hangende konfigurasie veranderinge
       invert_x_control: Keer X-beheer om
       invert_y_control: Keer Y-beheer om
       invert_z_control: Keer Z-beheer om

--- a/src/locales/de.yaml
+++ b/src/locales/de.yaml
@@ -600,8 +600,6 @@ app:
       collector: Kollektor
       dotted: Gepunktet
       axes: Achsen
-      ignore_default_bed_mesh_pending_configuration_changes: Ausstehende Änderungen
-        der Bettnivellierung ignorieren
       camera_url_snapshot: Kamera-Snapshot-URL
       camera_url_stream: Kamera-Stream-URL
       default_min_layer_height: Standard minimum Schichthöhe

--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -544,7 +544,6 @@ app:
       height: Height
       gcode_coords: Use GCode Coordinates
       icon: Icon
-      ignore_default_bed_mesh_pending_configuration_changes: Ignore default bed mesh Pending Configuration Changes
       invert_x_control: Invert X control
       invert_y_control: Invert Y control
       invert_z_control: Invert Z control
@@ -568,6 +567,7 @@ app:
       retraction_icon_size: Retraction Icon Size
       right_y: Right Y-Axis
       save_and_restore_view_state: Save and restore view state
+      sections_to_ignore_pending_configuration_changes: Sections to ignore Pending Configuration Changes
       show_animations: Show animations
       show_barometric_pressure: Show barometric pressure
       show_chart: Show chart

--- a/src/locales/hu.yaml
+++ b/src/locales/hu.yaml
@@ -538,7 +538,6 @@ app:
       height: Magasság
       gcode_coords: G-Kód koordináták használata
       icon: Ikon
-      ignore_default_bed_mesh_pending_configuration_changes: Az alapértelmezett ágyháló figyelmen kívül hagyása - Függő konfigurációs módosítások
       invert_x_control: Fordított (X) vezérlés
       invert_y_control: Fordított (Y) vezérlés
       invert_z_control: Fordított (Z) vezérlés

--- a/src/locales/pl.yaml
+++ b/src/locales/pl.yaml
@@ -493,8 +493,6 @@ app:
       show_barometric_pressure: Pokaż ciśnienie barometryczne
       show_gas_resistance: Pokaż opór gazu
       show_upload_and_print: Pokaż przycisk „Wgraj i drukuj” w górnym pasku nawigacyjnym
-      ignore_default_bed_mesh_pending_configuration_changes: Ignoruj domyślną siatkę
-        stołu w oczekiwaniu na zmiany konfiguracji
       optional: Opcjonalne
       save_and_restore_view_state: Zapisz i przywróć stan widoku
       thermal_preset_gcode: G-Code

--- a/src/locales/ru.yaml
+++ b/src/locales/ru.yaml
@@ -497,7 +497,6 @@ app:
       height: Высота
       gcode_coords: Испрользовать координаты GCode
       icon: Иконка
-      ignore_default_bed_mesh_pending_configuration_changes: Игнорировать запланированные изменения сетки стола
       invert_x_control: Инвертировать управление по оси X
       invert_y_control: Инвертировать управление по оси Y
       invert_z_control: Инвертировать управление по оси Z

--- a/src/locales/zh-CN.yaml
+++ b/src/locales/zh-CN.yaml
@@ -502,7 +502,6 @@ app:
       height: 高度
       gcode_coords: 使用 GCode 坐标
       icon: 图标
-      ignore_default_bed_mesh_pending_configuration_changes: 忽略默认的床网，等待配置更改
       invert_x_control: 反转X轴控制
       invert_y_control: 反转Y轴控制
       invert_z_control: 反转Z轴控制

--- a/src/store/config/state.ts
+++ b/src/store/config/state.ts
@@ -40,7 +40,7 @@ export const defaultState = (): ConfigState => {
         confirmOnEstop: false,
         confirmOnPowerDeviceChange: false,
         confirmOnSaveConfigAndRestart: true,
-        ignoreDefaultBedMeshPendingConfigurationChanges: false,
+        sectionsToIgnorePendingConfigurationChanges: [],
         dateFormat: 'iso',
         timeFormat: 'iso',
         textSortOrder: 'default',

--- a/src/store/config/types.ts
+++ b/src/store/config/types.ts
@@ -73,7 +73,7 @@ export interface GeneralConfig {
   confirmOnEstop: boolean;
   confirmOnPowerDeviceChange: boolean;
   confirmOnSaveConfigAndRestart: boolean;
-  ignoreDefaultBedMeshPendingConfigurationChanges: boolean;
+  sectionsToIgnorePendingConfigurationChanges: string[];
   dateFormat: string;
   timeFormat: string;
   textSortOrder: TextSortOrder;

--- a/src/util/is-key-of.ts
+++ b/src/util/is-key-of.ts
@@ -1,4 +1,4 @@
-const isKeyOf = <T extends object>(key: string | number | symbol, parent: T): key is keyof T => {
+const isKeyOf = <T extends object>(key: PropertyKey, parent: T): key is keyof T => {
   return key in parent
 }
 


### PR DESCRIPTION
Replaces the existing "Ignore default bed mesh Pending Configuration Changes" boolean setting with a new configurable "Sections to ignore Pending Configuration Changes" combo setting.

It defaults to an empty list, but when clicked it will provide two items that can be easily added by clicking on them.

![image](https://github.com/fluidd-core/fluidd/assets/85504/562c37ff-07b6-4aa6-a1ea-4120407eb116)

Besides those items, users will be able to add whatever they want to the list.

Any pending configuration changes on these sections will just be ignored and will NOT cause the "Save Config & Restart" button to show (unless some other section that is not also on this list also has pending changes).

Resolves #1210 