### PR TITLE
fix: mixed ISO / non-ISO date & time formats

### DIFF
--- a/src/components/settings/GeneralSettings.vue
+++ b/src/components/settings/GeneralSettings.vue
@@ -260,7 +260,7 @@ export default class GeneralSettings extends Mixins(StateMixin) {
     return Object.entries(DateFormats)
       .map(([key, entry]) => ({
         value: key,
-        text: `${date.toLocaleDateString(entry.locale ?? this.$i18n.locale, entry.options)}${entry.suffix ?? ''}`
+        text: `${date.toLocaleDateString(entry.locales ?? this.$filters.getNavigatorLocales(), entry.options)}${entry.suffix ?? ''}`
       }))
   }
 
@@ -282,7 +282,7 @@ export default class GeneralSettings extends Mixins(StateMixin) {
     return Object.entries(TimeFormats)
       .map(([key, entry]) => ({
         value: key,
-        text: `${date.toLocaleTimeString(entry.locale ?? this.$i18n.locale, entry.options)}${entry.suffix ?? ''}`
+        text: `${date.toLocaleTimeString(entry.locales ?? this.$filters.getNavigatorLocales(), entry.options)}${entry.suffix ?? ''}`
       }))
   }
 
@@ -432,10 +432,6 @@ export default class GeneralSettings extends Mixins(StateMixin) {
       value,
       server: true
     })
-  }
-
-  get current_time () {
-    return Math.floor(Date.now() / 1000)
   }
 }
 </script>

--- a/src/globals.ts
+++ b/src/globals.ts
@@ -494,15 +494,15 @@ export const SupportedVideoFormats = Object.freeze([
   '.mpg'
 ])
 
-type DateTimeFormat = {
-  locale?: string,
+export type DateTimeFormat = {
+  locales?: Intl.LocalesArgument,
   options: Intl.DateTimeFormatOptions,
   suffix?: string
 }
 
 export const DateFormats = Object.freeze<Record<string, DateTimeFormat>>({
   iso: {
-    locale: 'lt',
+    locales: 'lt',
     options: { day: '2-digit', month: '2-digit', year: 'numeric' },
     suffix: ' (ISO 8601)'
   },
@@ -516,7 +516,7 @@ export const DateFormats = Object.freeze<Record<string, DateTimeFormat>>({
 
 export const TimeFormats = Object.freeze<Record<string, DateTimeFormat>>({
   iso: {
-    locale: 'lt',
+    locales: 'lt',
     options: { hour: '2-digit', minute: '2-digit', hour12: false },
     suffix: ' (ISO 8601)'
   },

--- a/src/plugins/filters.ts
+++ b/src/plugins/filters.ts
@@ -3,7 +3,7 @@ import VueRouter from 'vue-router'
 import { camelCase, startCase, capitalize, isFinite } from 'lodash-es'
 import type { ApiConfig, TextSortOrder } from '@/store/config/types'
 import { TinyColor } from '@ctrl/tinycolor'
-import { DateFormats, Globals, TimeFormats, Waits } from '@/globals'
+import { DateFormats, Globals, TimeFormats, Waits, type DateTimeFormat } from '@/globals'
 import i18n from '@/plugins/i18n'
 import type { TranslateResult } from 'vue-i18n'
 import store from '@/store'
@@ -67,16 +67,20 @@ export const Filters = {
     return (isNeg) ? '-' + r : r
   },
 
-  getDateFormat: (override?: string) => {
+  getNavigatorLocales: () => {
+    return navigator.languages ?? [navigator.language]
+  },
+
+  getDateFormat: (override?: string): DateTimeFormat => {
     return {
-      locale: i18n.locale,
+      locales: Filters.getNavigatorLocales(),
       ...DateFormats[override ?? store.state.config.uiSettings.general.dateFormat]
     }
   },
 
-  getTimeFormat: (override?: string) => {
+  getTimeFormat: (override?: string): DateTimeFormat => {
     return {
-      locale: i18n.locale,
+      locales: Filters.getNavigatorLocales(),
       ...TimeFormats[override ?? store.state.config.uiSettings.general.timeFormat]
     }
   },
@@ -85,7 +89,7 @@ export const Filters = {
     const date = new Date(value)
     const dateFormat = Filters.getDateFormat()
 
-    return date.toLocaleDateString(dateFormat.locale, {
+    return date.toLocaleDateString(dateFormat.locales, {
       ...dateFormat.options,
       ...options
     })
@@ -95,7 +99,7 @@ export const Filters = {
     const date = new Date(value)
     const timeFormat = Filters.getTimeFormat()
 
-    return date.toLocaleTimeString(timeFormat.locale, {
+    return date.toLocaleTimeString(timeFormat.locales, {
       ...timeFormat.options,
       ...options
     })
@@ -109,11 +113,16 @@ export const Filters = {
   },
 
   formatDateTime: (value: number | string | Date, options?: Intl.DateTimeFormatOptions) => {
-    const date = new Date(value)
     const timeFormat = Filters.getTimeFormat()
     const dateFormat = Filters.getDateFormat()
 
-    return date.toLocaleDateString(dateFormat.locale, {
+    if (timeFormat.locales !== dateFormat.locales) {
+      return Filters.formatDate(value, options) + ' ' + Filters.formatTime(value, options)
+    }
+
+    const date = new Date(value)
+
+    return date.toLocaleDateString(dateFormat.locales, {
       ...dateFormat.options,
       ...timeFormat.options,
       ...options
@@ -148,7 +157,7 @@ export const Filters = {
   },
 
   formatRelativeTime (value: number, unit: Intl.RelativeTimeFormatUnit, options?: Intl.RelativeTimeFormatOptions) {
-    const rtf = new Intl.RelativeTimeFormat(i18n.locale, {
+    const rtf = new Intl.RelativeTimeFormat(Filters.getNavigatorLocales() as string[], {
       numeric: 'auto',
       ...options
     })


### PR DESCRIPTION
We currently use Lithuanian for ISO 8601 date & time formatting as that is the closest match to it.

Given that, a bug was introduced when we mix ISO with non-ISO date & time formats, where a full datetime would always be formatted in Lithuanian.

To mitigate this issue, when the user has selected to mix ISO with non-ISO formats, we will format each part separately and join the results (separated by a simple space).

Fixes #1220 