### PR TITLE
fix(style): pad navigation drawer bottom on mobile view 

### DIFF
--- a/src/components/layout/AppNavDrawer.vue
+++ b/src/components/layout/AppNavDrawer.vue
@@ -15,6 +15,7 @@
         :color="theme.currentTheme.drawer"
         mini-variant
         :value="open"
+        class="pb-16 pb-sm-0"
       >
         <div
           v-show="isMobileViewport"


### PR DESCRIPTION
Adds some padding to the bottom of the navigation bar on mobile view to ensure that the floating Emergency Button doesn't stop users from accessing the navigation options.

![image](https://github.com/fluidd-core/fluidd/assets/85504/5d74e045-7c6d-4d46-a76d-b949c55cf636)

![image](https://github.com/fluidd-core/fluidd/assets/85504/0cf7252e-8a8e-4748-82f4-114968203117)

Fixes #1231 