### PR TITLE
fix: corrects order of e-charts dimensions

### DIFF
--- a/src/components/widgets/bedmesh/BedMeshCard.vue
+++ b/src/components/widgets/bedmesh/BedMeshCard.vue
@@ -33,7 +33,7 @@
     </template>
 
     <v-card-text>
-      <e-charts-bed-mesh
+      <bed-mesh-chart
         v-if="mesh && mesh[matrix] && mesh[matrix].coordinates && mesh[matrix].coordinates.length > 0"
         ref="chart"
         :options="options"
@@ -49,7 +49,7 @@
 
 <script lang="ts">
 import { Component, Mixins, Prop } from 'vue-property-decorator'
-import EChartsBedMesh from './BedMeshChart.vue'
+import BedMeshChart from './BedMeshChart.vue'
 import StateMixin from '@/mixins/state'
 import ToolheadMixin from '@/mixins/toolhead'
 import BrowserMixin from '@/mixins/browser'
@@ -57,7 +57,7 @@ import type { AppMeshes } from '@/store/mesh/types'
 
 @Component({
   components: {
-    EChartsBedMesh
+    BedMeshChart
   }
 })
 export default class BedMeshCard extends Mixins(StateMixin, ToolheadMixin, BrowserMixin) {

--- a/src/components/widgets/bedmesh/BedMeshChart.vue
+++ b/src/components/widgets/bedmesh/BedMeshChart.vue
@@ -24,7 +24,7 @@ import { merge, cloneDeepWith } from 'lodash-es'
 import BrowserMixin from '@/mixins/browser'
 
 @Component({})
-export default class EChartsBedMesh extends Mixins(BrowserMixin) {
+export default class BedMeshChart extends Mixins(BrowserMixin) {
   @Prop({ type: Array, required: true })
   readonly data!: []
 

--- a/src/util/transform-mesh.ts
+++ b/src/util/transform-mesh.ts
@@ -53,7 +53,7 @@ export const transformMesh = (bedMesh: KlipperBedMesh, meshMatrix: keyof Klipper
 
   return {
     coordinates,
-    dimensions: [x_idx, y_idx],
+    dimensions: [y_idx, x_idx],
     min,
     mid,
     max,


### PR DESCRIPTION
Corrects the order or e-charts dimensions.

Tested with sample config:

```ini
[bed_mesh]
speed = 400
mesh_min = 5,5
mesh_max = 225,182
probe_count = 5, 4

[bed_mesh default]
version = 1
points = 
  -0.016250, -0.010833, 0.001667, 0.004167, 0.047500
  0.035000, 0.023750, 0.018750, -0.015000, 0.046667
  0.020417, 0.002083, 0.027500, 0.007500, 0.039167
  -0.000833, -0.030000, -0.028333, -0.019583, 0.008333
tension = 0.2
min_x = 5.0
algo = lagrange
y_count = 4
mesh_y_pps = 2
min_y = 5.0
x_count = 5
max_y = 182.0
mesh_x_pps = 2
max_x = 225.0
```

Results:

![image](https://github.com/fluidd-core/fluidd/assets/85504/e3ef6dd5-8f4e-4b5a-9772-090d64341fce)

Introduced by fb9a46ce0de9ef465a3a8127673e092fdae10c2c

Fixes #1234 