### PR TITLE
feat: use full bed dimensions on bed mesh preview

### DIFF
--- a/src/components/widgets/bedmesh/BedMeshChart.vue
+++ b/src/components/widgets/bedmesh/BedMeshChart.vue
@@ -22,6 +22,7 @@ import { Component, Prop, Watch, Ref, Mixins } from 'vue-property-decorator'
 import type { ECharts, EChartsOption, GraphicComponentOption } from 'echarts'
 import { merge, cloneDeepWith } from 'lodash-es'
 import BrowserMixin from '@/mixins/browser'
+import type { BedSize } from '@/store/printer/types'
 
 @Component({})
 export default class BedMeshChart extends Mixins(BrowserMixin) {
@@ -42,6 +43,10 @@ export default class BedMeshChart extends Mixins(BrowserMixin) {
 
   get flatSurface () {
     return this.$store.state.mesh.flatSurface
+  }
+
+  get bedSize (): BedSize | undefined {
+    return this.$store.getters['printer/getBedSize'] as BedSize | undefined
   }
 
   @Watch('flatSurface')
@@ -175,10 +180,14 @@ export default class BedMeshChart extends Mixins(BrowserMixin) {
       },
       xAxis3D: {
         type: 'value',
+        min: this.bedSize?.minX,
+        max: this.bedSize?.maxX,
         ...axisCommon
       },
       yAxis3D: {
         type: 'value',
+        min: this.bedSize?.minY,
+        max: this.bedSize?.maxY,
         ...axisCommon
       },
       zAxis3D: {


### PR DESCRIPTION
We currently use the Bed Mesh rectangle as the limits for the preview.

This changes that behavior to ensure we show the Bed Mesh preview using the full configured bed dimensions.

## Before

![image](https://github.com/fluidd-core/fluidd/assets/85504/966c3130-2a81-40ed-ad63-4f1f2a82defd)

## After

![image](https://github.com/fluidd-core/fluidd/assets/85504/e3b9a4de-509e-463c-b310-0554fcf5e27a)


On both examples above, the bed size is 235x235 yet on the top we are not using the full bed dimensions but the mesh dimensions.

Resolves: #1243