### PR TITLE
fix: disable console timestamps text wrap

### DIFF
--- a/src/components/widgets/console/ConsoleItem.vue
+++ b/src/components/widgets/console/ConsoleItem.vue
@@ -2,7 +2,7 @@
   <v-layout class="console-item">
     <span
       v-if="value.time"
-      class="secondary--text mr-3 d-none d-sm-block"
+      class="secondary--text mr-3 d-none d-sm-block text-no-wrap"
     >
       {{ itemTime }}&nbsp;
     </span>


### PR DESCRIPTION
Fixes #1249

## Before

![image](https://github.com/fluidd-core/fluidd/assets/85504/95874572-1126-437f-a42d-c90b993f2d6f)

## After

![image](https://github.com/fluidd-core/fluidd/assets/85504/95466ae5-792f-4f1b-bc83-ae6e255c5254)
