### PR TITLE
feat: highlight active tool

### DIFF
--- a/src/components/widgets/toolhead/ToolChangeCommands.vue
+++ b/src/components/widgets/toolhead/ToolChangeCommands.vue
@@ -1,7 +1,12 @@
 <template>
   <v-row v-if="toolChangeCommands.length > 0">
     <v-col>
-      <app-btn-group class="d-flex">
+      <app-btn-group
+        class="app-toolchanger-control d-flex"
+        :class="{
+          [$vuetify.theme.dark ? 'theme--dark': 'theme--light']: true,
+        }"
+      >
         <v-tooltip
           v-for="(macro, index) of toolChangeCommands"
           :key="index"
@@ -11,12 +16,22 @@
             <app-btn
               v-bind="attrs"
               min-width="10"
-              :color="macro.color"
+              :color="macro.active ? 'primary' : undefined"
               :disabled="!klippyReady || printerPrinting"
               class="px-0 flex-grow-1"
               v-on="on"
               @click="sendGcode(macro.name)"
             >
+              <span
+                v-if="macro.color"
+                class="extruder-color mr-1"
+                :class="{
+                  active: macro.active
+                }"
+                :style="{
+                  background: macro.color
+                }"
+              />
               {{ macro.name }}
             </app-btn>
           </template>
@@ -68,3 +83,25 @@ export default class ToolChangeCommands extends Mixins(StateMixin) {
   }
 }
 </script>
+
+<style lang="scss" scoped>
+  @import 'vuetify/src/styles/styles.sass';
+
+  @include theme(app-toolchanger-control) using ($material) {
+    .extruder-color {
+      border-color: map-deep-get($material, 'text', 'primary');
+    }
+  }
+
+  .app-toolchanger-control .extruder-color {
+    width: 15px;
+    height: 15px;
+    border-width: 1px;
+    border-style: solid;
+    border-radius: 50%;
+
+    &.active {
+      border-color: map-deep-get($material-dark, 'text', 'primary');
+    }
+  }
+</style>


### PR DESCRIPTION
Adds support for the `Tx` macros `variable_active` so that the active tool is highlighted.

![image](https://github.com/fluidd-core/fluidd/assets/85504/37ecd501-a1ff-4441-b572-a09556b574ed)

Resolves #1261