### PR TITLE
fix: corrects original source attributions

### DIFF
--- a/src/components/widgets/camera/services/WebrtcGo2RtcCamera.vue
+++ b/src/components/widgets/camera/services/WebrtcGo2RtcCamera.vue
@@ -36,8 +36,7 @@ export default class WebrtcGo2RtcCamera extends Mixins(CameraMixin) {
   abortController: AbortController | null = null
 
   // webrtc player methods
-  // adapted from https://github.com/AlexxIT/go2rtc/blob/master/www/webrtc.html
-  // also adapted from https://github.com/mainsail-crew/mainsail/pull/1651
+  // adapted from https://github.com/AlexxIT/go2rtc/blob/master/www/video-rtc.js
 
   startPlayback () {
     this.abortController?.abort()

--- a/src/components/widgets/toolhead/ToolheadControlCircle.vue
+++ b/src/components/widgets/toolhead/ToolheadControlCircle.vue
@@ -3,7 +3,8 @@
     <v-row>
       <v-col class="pa-0 mt-1">
         <!--
-          SVG assets from Mainsail Toolhead Circle Control, rest of control heavly adapted from https://github.com/mainsail-crew/mainsail/blob/develop/src/components/panels/ToolheadControls/CircleControl.vue
+          SVG assets from Mainsail Toolhead Circle Control, rest of control
+          adapted for Fluidd from https://github.com/mainsail-crew/mainsail/blob/develop/src/components/panels/ToolheadControls/CircleControl.vue
         -->
         <svg
           width="100%"

--- a/src/components/widgets/toolhead/ToolheadControlCircle.vue
+++ b/src/components/widgets/toolhead/ToolheadControlCircle.vue
@@ -1,6 +1,7 @@
+  <!-- Circle control adapted from Mainsail's cirlce control, new SVG icons added for toolhead centering
+       heavly adapted from https://github.com/mainsail-crew/mainsail/blob/develop/src/components/panels/ToolheadControls/CrossControl.vue
+       modified to work with fluidd's concepts -->
 <template>
-  <!-- Circle control adapted from Mainsail's cirlce control, new SVG icons added for toolhead centering -->
-  <!-- https://github.com/mainsail-crew/mainsail/blob/develop/src/components/panels/ToolheadControls/CircleControl.vue -->
   <div>
     <v-row>
       <v-col class="pa-0 mt-1">
@@ -675,9 +676,6 @@ import { Component, Mixins } from 'vue-property-decorator'
 import StateMixin from '@/mixins/state'
 import ToolheadMixin from '@/mixins/toolhead'
 import type { BedSize } from '@/store/printer/types'
-
-// heavly adapted from https://github.com/mainsail-crew/mainsail/blob/develop/src/components/panels/ToolheadControls/CrossControl.vue
-// modified to work with fluidd concepts.
 
 @Component({})
 export default class ToolheadControlCircle extends Mixins(StateMixin, ToolheadMixin) {

--- a/src/components/widgets/toolhead/ToolheadControlCircle.vue
+++ b/src/components/widgets/toolhead/ToolheadControlCircle.vue
@@ -1,10 +1,10 @@
-  <!-- Circle control adapted from Mainsail's cirlce control, new SVG icons added for toolhead centering
-       heavly adapted from https://github.com/mainsail-crew/mainsail/blob/develop/src/components/panels/ToolheadControls/CrossControl.vue
-       modified to work with fluidd's concepts -->
 <template>
   <div>
     <v-row>
       <v-col class="pa-0 mt-1">
+        <!--
+          SVG assets from Mainsail Toolhead Circle Control, rest of control heavly adapted from https://github.com/mainsail-crew/mainsail/blob/develop/src/components/panels/ToolheadControls/CircleControl.vue
+        -->
         <svg
           width="100%"
           height="100%"

--- a/src/components/widgets/toolhead/ToolheadControlCircle.vue
+++ b/src/components/widgets/toolhead/ToolheadControlCircle.vue
@@ -1,4 +1,6 @@
 <template>
+  <!-- Circle control adapted from Mainsail's cirlce control, new SVG icons added for toolhead centering -->
+  <!-- https://github.com/mainsail-crew/mainsail/blob/develop/src/components/panels/ToolheadControls/CircleControl.vue -->
   <div>
     <v-row>
       <v-col class="pa-0 mt-1">


### PR DESCRIPTION
fix: add attribution and inspiration for the source circle control was adapted from. This was already in the original PR, making it more obvious by moving out the top. 

Signed-off-by: vajonam <152501+vajonam@users.noreply.github.com>