### PR TITLE
feat(GcodePreview): add option to hide part bounding box when printing a single part

### DIFF
--- a/src/components/settings/GcodePreviewSettings.vue
+++ b/src/components/settings/GcodePreviewSettings.vue
@@ -174,6 +174,17 @@
 
       <v-divider />
 
+      <app-setting :title="$t('app.setting.label.hide_single_part_bounding_box')">
+        <v-switch
+          v-model="hideSinglePartBoundingBox"
+          hide-details
+          class="mb-5"
+          @click.native.stop
+        />
+      </app-setting>
+
+      <v-divider />
+
       <app-setting :title="$t('app.setting.label.reset')">
         <app-btn
           outlined
@@ -339,6 +350,18 @@ export default class GcodePreviewSettings extends Vue {
   set autoFollowOnFileLoad (value: boolean) {
     this.$store.dispatch('config/saveByPath', {
       path: 'uiSettings.gcodePreview.autoFollowOnFileLoad',
+      value,
+      server: true
+    })
+  }
+
+  get hideSinglePartBoundingBox () {
+    return this.$store.state.config.uiSettings.gcodePreview.hideSinglePartBoundingBox
+  }
+
+  set hideSinglePartBoundingBox (value: boolean) {
+    this.$store.dispatch('config/saveByPath', {
+      path: 'uiSettings.gcodePreview.hideSinglePartBoundingBox',
       value,
       server: true
     })

--- a/src/locales/de.yaml
+++ b/src/locales/de.yaml
@@ -556,6 +556,7 @@ app:
       fps_idle_target: FPS Ziel im Ruhezustand
       gcode_coords: GCode-Koordinaten verwenden
       height: Höhe
+      hide_single_part_bounding_box: Bauteilrahmen bei Druck eines einzelnen Teils verstecken
       invert_x_control: X-Steuerung invertieren
       invert_y_control: Y-Steuerung invertieren
       invert_z_control: Z-Steuerung invertieren

--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -558,6 +558,7 @@ app:
       fps_target: FPS Target
       fps_idle_target: FPS Target when not in focus
       height: Height
+      hide_single_part_bounding_box: Hide part bounding box when printing a single part
       gcode_coords: Use GCode Coordinates
       icon: Icon
       invert_x_control: Invert X control

--- a/src/store/config/state.ts
+++ b/src/store/config/state.ts
@@ -129,6 +129,7 @@ export const defaultState = (): ConfigState => {
         autoLoadOnPrintStart: false,
         autoLoadMobileOnPrintStart: false,
         autoFollowOnFileLoad: true,
+        hideSinglePartBoundingBox: false,
         autoZoom: false,
         flip: {
           horizontal: false,

--- a/src/store/config/types.ts
+++ b/src/store/config/types.ts
@@ -205,6 +205,7 @@ export interface GcodePreviewConfig {
   autoLoadOnPrintStart: boolean;
   autoLoadMobileOnPrintStart: boolean;
   autoFollowOnFileLoad: boolean;
+  hideSinglePartBoundingBox: boolean;
   autoZoom: boolean;
   flip: {
     horizontal: boolean;

--- a/src/store/gcodePreview/actions.ts
+++ b/src/store/gcodePreview/actions.ts
@@ -26,7 +26,7 @@ export const actions: ActionTree<GcodePreviewState, RootState> = {
     }
   },
 
-  async loadGcode ({ commit, getters, state }, payload: { file: AppFile; gcode: string }) {
+  async loadGcode ({ commit, getters, state, rootState }, payload: { file: AppFile; gcode: string }) {
     const worker = new ParseGcodeWorker()
 
     commit('setParserWorker', worker)
@@ -46,6 +46,10 @@ export const actions: ActionTree<GcodePreviewState, RootState> = {
             commit('setLayers', data.layers)
             commit('setParts', data.parts)
             commit('setParserProgress', payload.file.size ?? payload.gcode.length)
+
+            if (rootState.config.uiSettings.gcodePreview.hideSinglePartBoundingBox && data.parts.length <= 1) {
+              commit('setViewerState', { showParts: false })
+            }
           } catch (error) {
             consola.error('Parser worker error', error)
           }


### PR DESCRIPTION
Adds a config option to disable displaying part bounding boxes in the Gcode viewer if there's only a single part

Closes https://github.com/fluidd-core/fluidd/issues/1308