### PR TITLE
feat(spoolman): handle v2 responses, improve connection error handling

### DIFF
--- a/src/api/socketActions.ts
+++ b/src/api/socketActions.ts
@@ -734,7 +734,8 @@ export const SocketActions = {
       'server.spoolman.proxy', {
         params: {
           request_method: 'GET',
-          path: '/v1/spool'
+          path: '/v1/spool',
+          use_v2_response: true
         },
         dispatch: 'spoolman/onAvailableSpools'
       }

--- a/src/components/layout/AppSettingsNav.vue
+++ b/src/components/layout/AppSettingsNav.vue
@@ -60,7 +60,7 @@ export default class AppSettingsNav extends Vue {
   }
 
   get supportsSpoolman () {
-    return this.$store.getters['spoolman/getSupported']
+    return this.$store.getters['server/componentSupport']('spoolman')
   }
 }
 </script>

--- a/src/components/settings/ToolheadSettings.vue
+++ b/src/components/settings/ToolheadSettings.vue
@@ -665,10 +665,6 @@ export default class ToolHeadSettings extends Mixins(ToolheadMixin) {
     return this.$store.getters['printer/getPrinterSettings']('force_move.enable_force_move') ?? false
   }
 
-  get printerSupportsSpoolman () {
-    return this.$store.getters['spoolman/getSupported']
-  }
-
   get showManualProbeDialogAutomatically () {
     return this.$store.state.config.uiSettings.general.showManualProbeDialogAutomatically
   }

--- a/src/components/widgets/filesystem/FileSystem.vue
+++ b/src/components/widgets/filesystem/FileSystem.vue
@@ -725,7 +725,7 @@ export default class FileSystem extends Mixins(StateMixin, FilesMixin, ServicesM
 
     const filename = file.path ? `${file.path}/${file.filename}` : file.filename
 
-    const spoolmanSupported = this.$store.getters['spoolman/getSupported']
+    const spoolmanSupported = this.$store.getters['spoolman/getAvailable']
     const autoSpoolSelectionDialog = this.$store.state.config.uiSettings.spoolman.autoSpoolSelectionDialog
     if (spoolmanSupported && autoSpoolSelectionDialog) {
       this.$store.commit('spoolman/setDialogState', {

--- a/src/components/widgets/spoolman/SpoolmanCard.vue
+++ b/src/components/widgets/spoolman/SpoolmanCard.vue
@@ -9,6 +9,7 @@
       <app-btn
         small
         class="ms-1 my-1"
+        :disabled="!isConnected"
         @click="handleSelectSpool"
       >
         {{ $t('app.spoolman.label.change_spool') }}
@@ -85,10 +86,17 @@
         </template>
 
         <v-col
-          v-else
+          v-else-if="isConnected"
           align-self="center"
         >
           {{ $t('app.spoolman.msg.tracking_inactive') }}
+        </v-col>
+
+        <v-col
+          v-else
+          align-self="center"
+        >
+          {{ $t('app.spoolman.msg.not_connected') }}
         </v-col>
 
         <v-col
@@ -105,10 +113,17 @@
             $filament
           </v-icon>
           <v-icon
-            v-else
+            v-else-if="isConnected"
             size="55px"
           >
             $progressQuestion
+          </v-icon>
+          <v-icon
+            v-else
+            color="warning"
+            size="55px"
+          >
+            $warning
           </v-icon>
         </v-col>
       </v-row>
@@ -133,7 +148,12 @@ export default class SpoolmanCard extends Mixins(StateMixin) {
   }
 
   get activeSpool (): Spool | null {
+    if (!this.isConnected) return null
     return this.$store.getters['spoolman/getActiveSpool']
+  }
+
+  get isConnected (): boolean {
+    return this.$store.getters['spoolman/getConnected']
   }
 }
 </script>

--- a/src/components/widgets/status/PrinterStatusCard.vue
+++ b/src/components/widgets/status/PrinterStatusCard.vue
@@ -114,7 +114,7 @@ export default class PrinterStatusCard extends Mixins(StateMixin) {
   }
 
   handlePrint (filename: string) {
-    const spoolmanSupported = this.$store.getters['spoolman/getSupported']
+    const spoolmanSupported = this.$store.getters['spoolman/getAvailable']
     const autoSpoolSelectionDialog = this.$store.state.config.uiSettings.spoolman.autoSpoolSelectionDialog
     if (spoolmanSupported && autoSpoolSelectionDialog) {
       this.$store.commit('spoolman/setDialogState', {

--- a/src/locales/de.yaml
+++ b/src/locales/de.yaml
@@ -865,7 +865,7 @@ app:
       tracking_inactive: >-
         Filament-Tracking ist inaktiv.
         Bitte wählen Sie eine Spule aus um fortzufahren.
-      not_connected: Spoolman-Sserver nicht verfügbar.
+      not_connected: Spoolman-Server nicht verfügbar.
       info:
         howto: >-
           Halten Sie den QR-Code der Spule in die Kamera.

--- a/src/locales/de.yaml
+++ b/src/locales/de.yaml
@@ -865,6 +865,7 @@ app:
       tracking_inactive: >-
         Filament-Tracking ist inaktiv.
         Bitte wählen Sie eine Spule aus um fortzufahren.
+      not_connected: Spoolman-Sserver nicht verfügbar.
       info:
         howto: >-
           Halten Sie den QR-Code der Spule in die Kamera.

--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -839,6 +839,7 @@ app:
       tracking_inactive: >-
         Filament tracking is inactive.
         To get started, please select a spool.
+      not_connected: Spoolman server not available.
       info:
         howto: >-
           Show your spool's QR code to the camera.

--- a/src/store/socket/actions.ts
+++ b/src/store/socket/actions.ts
@@ -248,5 +248,9 @@ export const actions: ActionTree<SocketState, RootState> = {
 
   async notifyActiveSpoolSet ({ dispatch }, payload) {
     dispatch('spoolman/onActiveSpool', payload, { root: true })
+  },
+
+  async notifySpoolmanStatusChanged ({ dispatch }, payload) {
+    dispatch('spoolman/onStatusChanged', payload.spoolman_connected, { root: true })
   }
 }

--- a/src/store/spoolman/getters.ts
+++ b/src/store/spoolman/getters.ts
@@ -15,7 +15,11 @@ export const getters: GetterTree<SpoolmanState, RootState> = {
     return state.availableSpools
   },
 
-  getSupported: (state) => {
-    return state.supported
+  getConnected: (state) => {
+    return state.connected
+  },
+
+  getAvailable: (state) => {
+    return state.connected && state.availableSpools.length
   }
 }

--- a/src/store/spoolman/mutations.ts
+++ b/src/store/spoolman/mutations.ts
@@ -20,7 +20,6 @@ export const mutations: MutationTree<SpoolmanState> = {
 
   setAvailableSpools (state, payload: Spool[]) {
     // implies working communication with spoolman server
-    state.supported = !!payload.length // spools available
     state.availableSpools = payload.map(spool => ({
       ...spool,
       registered: new Date(spool.registered),
@@ -31,5 +30,9 @@ export const mutations: MutationTree<SpoolmanState> = {
 
   setDialogState (state, payload: SpoolSelectionDialogState) {
     state.dialog = payload
+  },
+
+  setConnected (state, payload) {
+    state.connected = payload
   }
 }

--- a/src/store/spoolman/state.ts
+++ b/src/store/spoolman/state.ts
@@ -4,7 +4,7 @@ export const defaultState = (): SpoolmanState => {
   return {
     availableSpools: [],
     activeSpool: undefined,
-    supported: false,
+    connected: false,
     dialog: {
       show: false,
       filename: ''

--- a/src/store/spoolman/types.ts
+++ b/src/store/spoolman/types.ts
@@ -44,7 +44,7 @@ export interface Spool {
 export interface SpoolmanState {
   availableSpools: Spool[];
   activeSpool?: number;
-  supported: boolean;
+  connected: boolean;
   dialog: SpoolSelectionDialogState;
   socket?: WebSocket;
 }

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -143,7 +143,7 @@ export default class Dashboard extends Mixins(StateMixin) {
   }
 
   get supportsSpoolman () {
-    return this.$store.getters['spoolman/getSupported']
+    return this.$store.getters['server/componentSupport']('spoolman')
   }
 
   get hasMacros () {

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -79,7 +79,7 @@ export default class Settings extends Mixins(StateMixin) {
   }
 
   get supportsSpoolman () {
-    return this.$store.getters['spoolman/getSupported']
+    return this.$store.getters['server/componentSupport']('spoolman')
   }
 }
 </script>


### PR DESCRIPTION
Adds support for the v2 responses and events proposed in https://github.com/Arksine/moonraker/pull/792

Emits errors via toast notifications (on initial load) and shows a disconnected/out-of-sync state more clearly:
![image](https://github.com/fluidd-core/fluidd/assets/25269274/df03f552-38c9-4043-86bb-fe9419367385)
