### PR TITLE
fix: don't assume user is trusted when force_logins is turned off

### DIFF
--- a/src/mixins/files.ts
+++ b/src/mixins/files.ts
@@ -12,9 +12,7 @@ export default class FilesMixin extends Vue {
   }
 
   get isTrustedUser (): boolean {
-    const forceLogins = this.$store.getters['server/getConfig'].authorization.force_logins
-
-    return forceLogins === false || this.$store.getters['auth/getCurrentUser']?.username === '_TRUSTED_USER_'
+    return this.$store.getters['auth/getCurrentUser']?.username === '_TRUSTED_USER_'
   }
 
   getThumbUrl (meta: KlipperFileMeta, root: string, path: string, large: boolean, date?: number) {


### PR DESCRIPTION
Fixes https://github.com/fluidd-core/fluidd/issues/1317.

I've tested theme loading and couldn't reproduce the issue described in https://github.com/fluidd-core/fluidd/pull/1065, so I don't think there's any side effects. Not sure why the `!forceLogins` check was required in the first place in https://github.com/fluidd-core/fluidd/commit/e5d177c854dc806c87c10c6568b04dfe74163b8a, @pedrolamas any chance you remember?