### PR TITLE
i18n: adds translation keys for System Utilization labels

### DIFF
--- a/src/components/widgets/system/KlipperLoadChart.vue
+++ b/src/components/widgets/system/KlipperLoadChart.vue
@@ -42,7 +42,7 @@ export default class KlipperLoadChart extends Vue {
 
   get series () {
     return this.$store.getters['charts/getBaseSeries']({
-      name: 'load',
+      name: this.$t('app.system_info.label.load'),
       encode: { x: 'date', y: 'cputime_change' }
     })
   }

--- a/src/components/widgets/system/McuLoadChart.vue
+++ b/src/components/widgets/system/McuLoadChart.vue
@@ -71,12 +71,12 @@ export default class McuLoadChart extends Vue {
 
   get series () {
     const load = this.$store.getters['charts/getBaseSeries']({
-      name: 'load',
+      name: this.$t('app.system_info.label.load'),
       encode: { x: 'date', y: 'load' }
     })
 
     const awake = this.$store.getters['charts/getBaseSeries']({
-      name: 'awake time',
+      name: this.$t('app.system_info.label.awake_time'),
       encode: { x: 'date', y: 'awake' }
     })
 

--- a/src/components/widgets/system/MoonrakerLoadChart.vue
+++ b/src/components/widgets/system/MoonrakerLoadChart.vue
@@ -42,7 +42,7 @@ export default class MoonrakerLoadChart extends Vue {
 
   get series () {
     return this.$store.getters['charts/getBaseSeries']({
-      name: 'load',
+      name: this.$t('app.system_info.label.load'),
       encode: { x: 'date', y: 'load' }
     })
   }

--- a/src/components/widgets/system/SystemLoadChart.vue
+++ b/src/components/widgets/system/SystemLoadChart.vue
@@ -49,7 +49,7 @@ export default class SystemLoadChart extends Vue {
 
   get series () {
     return this.$store.getters['charts/getBaseSeries']({
-      name: 'load',
+      name: this.$t('app.system_info.label.load'),
       encode: { x: 'date', y: 'load' }
     })
   }

--- a/src/components/widgets/system/SystemMemoryChart.vue
+++ b/src/components/widgets/system/SystemMemoryChart.vue
@@ -42,7 +42,7 @@ export default class SystemMemoryChart extends Vue {
 
   get series () {
     return this.$store.getters['charts/getBaseSeries']({
-      name: 'memory used',
+      name: this.$t('app.system_info.label.memory_used'),
       encode: { x: 'date', y: 'memused' }
     })
   }

--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -653,6 +653,7 @@ app:
       no_connection: No moonraker connection. Please check moonraker status and / or refresh.
   system_info:
     label:
+      awake_time: awake time
       capacity: Capacity
       cpu_desc: CPU Description
       distribution_codename: Codename
@@ -662,8 +663,10 @@ app:
       hardware_desc: Hardware Description
       hostname: Hostname
       klipper_load: Klipper Load
+      load: load
       manufactured: Manufactured
       manufacturer: Manufacturer
+      memory_used: memory used
       mcu_awake: '{mcu} Awake Time'
       mcu_bandwidth: '{mcu} Bandwidth'
       mcu_information: '{mcu} Information'


### PR DESCRIPTION
As you can see on image below, **load**, **awake time** and **memory used** are not translated. They are fixed string in the code. Changed fixed string with translatable code.

![slika](https://github.com/fluidd-core/fluidd/assets/61543115/1b4f49cc-fcc5-427a-b8c0-dfdc9a463218)
