### PR TITLE
refactor(cameras): use cached url object for adaptive MJPEG sources

### DIFF
--- a/src/components/widgets/camera/services/MjpegstreamerAdaptiveCamera.vue
+++ b/src/components/widgets/camera/services/MjpegstreamerAdaptiveCamera.vue
@@ -24,6 +24,7 @@ export default class MjpegstreamerAdaptiveCamera extends Mixins(CameraMixin) {
   requestTime = 0
   timeSmoothing = 0.6
   requestTimeSmoothing = 0.1
+  url: URL | undefined
 
   handleImageLoad () {
     const fpsTarget = (!document.hasFocus() && this.camera.targetFpsIdle) || this.camera.targetFps || 10
@@ -54,13 +55,13 @@ export default class MjpegstreamerAdaptiveCamera extends Mixins(CameraMixin) {
       this.$emit('frames-per-second', framesPerSecond)
 
       this.$nextTick(() => {
-        const url = new URL(this.cameraImageSource)
+        if (!this.url) return
 
-        url.searchParams.set('cacheBust', Date.now().toString())
+        this.url.searchParams.set('cacheBust', Date.now().toString())
 
         this.requestStartTime = performance.now()
 
-        this.cameraImageSource = url.toString()
+        this.cameraImageSource = this.url.toString()
       })
     } else {
       this.stopPlayback()
@@ -74,6 +75,7 @@ export default class MjpegstreamerAdaptiveCamera extends Mixins(CameraMixin) {
 
     url.searchParams.set('cacheBust', Date.now().toString())
 
+    this.url = url
     this.cameraImageSource = url.toString()
 
     const rawUrl = this.buildAbsoluteUrl(this.camera.urlStream || '')
@@ -86,6 +88,7 @@ export default class MjpegstreamerAdaptiveCamera extends Mixins(CameraMixin) {
   stopPlayback () {
     this.cameraImageSource = ''
     this.cameraImage.src = ''
+    this.url = undefined
   }
 }
 </script>

--- a/src/components/widgets/camera/services/MjpegstreamerAdaptiveCamera.vue
+++ b/src/components/widgets/camera/services/MjpegstreamerAdaptiveCamera.vue
@@ -24,7 +24,7 @@ export default class MjpegstreamerAdaptiveCamera extends Mixins(CameraMixin) {
   requestTime = 0
   timeSmoothing = 0.6
   requestTimeSmoothing = 0.1
-  url: URL | undefined
+  url?: URL
 
   handleImageLoad () {
     const fpsTarget = (!document.hasFocus() && this.camera.targetFpsIdle) || this.camera.targetFps || 10

--- a/src/components/widgets/camera/services/MjpegstreamerAdaptiveCamera.vue
+++ b/src/components/widgets/camera/services/MjpegstreamerAdaptiveCamera.vue
@@ -24,7 +24,6 @@ export default class MjpegstreamerAdaptiveCamera extends Mixins(CameraMixin) {
   requestTime = 0
   timeSmoothing = 0.6
   requestTimeSmoothing = 0.1
-  url?: URL
 
   handleImageLoad () {
     const fpsTarget = (!document.hasFocus() && this.camera.targetFpsIdle) || this.camera.targetFps || 10
@@ -55,13 +54,17 @@ export default class MjpegstreamerAdaptiveCamera extends Mixins(CameraMixin) {
       this.$emit('frames-per-second', framesPerSecond)
 
       this.$nextTick(() => {
-        if (!this.url) return
+        const cameraImageSource = this.cameraImageSource
 
-        this.url.searchParams.set('cacheBust', Date.now().toString())
+        if (cameraImageSource) {
+          const url = new URL(cameraImageSource)
 
-        this.requestStartTime = performance.now()
+          url.searchParams.set('cacheBust', Date.now().toString())
 
-        this.cameraImageSource = this.url.toString()
+          this.requestStartTime = performance.now()
+
+          this.cameraImageSource = url.toString()
+        }
       })
     } else {
       this.stopPlayback()
@@ -75,7 +78,6 @@ export default class MjpegstreamerAdaptiveCamera extends Mixins(CameraMixin) {
 
     url.searchParams.set('cacheBust', Date.now().toString())
 
-    this.url = url
     this.cameraImageSource = url.toString()
 
     const rawUrl = this.buildAbsoluteUrl(this.camera.urlStream || '')
@@ -88,7 +90,6 @@ export default class MjpegstreamerAdaptiveCamera extends Mixins(CameraMixin) {
   stopPlayback () {
     this.cameraImageSource = ''
     this.cameraImage.src = ''
-    this.url = undefined
   }
 }
 </script>

--- a/src/components/widgets/camera/services/MjpegstreamerAdaptiveCamera.vue
+++ b/src/components/widgets/camera/services/MjpegstreamerAdaptiveCamera.vue
@@ -18,6 +18,7 @@ export default class MjpegstreamerAdaptiveCamera extends Mixins(CameraMixin) {
   readonly cameraImage!: HTMLImageElement
 
   cameraImageSource = ''
+  cameraImageSourceUrl: URL | null = null
   requestStartTime = performance.now()
   startTime = performance.now()
   time = 0
@@ -53,32 +54,28 @@ export default class MjpegstreamerAdaptiveCamera extends Mixins(CameraMixin) {
 
       this.$emit('frames-per-second', framesPerSecond)
 
-      this.$nextTick(() => {
-        const cameraImageSource = this.cameraImageSource
-
-        if (cameraImageSource) {
-          const url = new URL(cameraImageSource)
-
-          url.searchParams.set('cacheBust', Date.now().toString())
-
-          this.requestStartTime = performance.now()
-
-          this.cameraImageSource = url.toString()
-        }
-      })
+      this.$nextTick(() => this.updateCameraImageSource())
     } else {
       this.stopPlayback()
     }
   }
 
+  updateCameraImageSource () {
+    const url = this.cameraImageSourceUrl
+
+    if (url) {
+      url.searchParams.set('cacheBust', Date.now().toString())
+
+      this.requestStartTime = performance.now()
+
+      this.cameraImageSource = url.toString()
+    }
+  }
+
   startPlayback () {
-    const url = this.buildAbsoluteUrl(this.camera.urlSnapshot || '')
+    this.cameraImageSourceUrl = this.buildAbsoluteUrl(this.camera.urlSnapshot || '')
 
-    this.requestStartTime = performance.now()
-
-    url.searchParams.set('cacheBust', Date.now().toString())
-
-    this.cameraImageSource = url.toString()
+    this.updateCameraImageSource()
 
     const rawUrl = this.buildAbsoluteUrl(this.camera.urlStream || '')
 
@@ -88,6 +85,7 @@ export default class MjpegstreamerAdaptiveCamera extends Mixins(CameraMixin) {
   }
 
   stopPlayback () {
+    this.cameraImageSourceUrl = null
     this.cameraImageSource = ''
     this.cameraImage.src = ''
   }


### PR DESCRIPTION
Resolves an error when destroying an adaptive MJPEG camera feed:
![image](https://github.com/fluidd-core/fluidd/assets/25269274/341e9cbd-5190-42cc-bbef-ec908a256e9e)

Profiling showed this also improves `handleRefresh` performance by ~15% (1.97ms vs 1.67ms).