### PR TITLE
fix: file path on upload

### DIFF
--- a/src/mixins/files.ts
+++ b/src/mixins/files.ts
@@ -161,11 +161,9 @@ export default class FilesMixin extends Vue {
    * @param options Axios request options
    */
   async uploadFile (file: File, path: string, root: string, andPrint: boolean, options?: AxiosRequestConfig) {
-    // let filename = file.name.replace(' ', '_')
-    let filepath = `${path}${file.name}`
-    filepath = (filepath.startsWith('/'))
-      ? filepath
-      : '/' + filepath
+    const filepath = path
+      ? `${path}/${file.name}`
+      : file.name
 
     const abortController = new AbortController()
 
@@ -205,7 +203,9 @@ export default class FilesMixin extends Vue {
   getFullPathAndFile (rootPath: string, file: File | FileWithPath): [string, File] {
     if ('path' in file) {
       return [
-        `${rootPath}/${file.path}`,
+        [rootPath, file.path]
+          .filter(path => !!path)
+          .join('/'),
         file.file
       ]
     } else {
@@ -222,10 +222,10 @@ export default class FilesMixin extends Vue {
     for (const file of files) {
       const [fullPath, fileObject] = this.getFullPathAndFile(path, file)
 
-      let filepath = `${fullPath}${fileObject.name}`
-      filepath = (filepath.startsWith('/'))
-        ? filepath
-        : '/' + filepath
+      const filepath = fullPath
+        ? `${fullPath}/${fileObject.name}`
+        : fileObject.name
+
       this.$store.dispatch('files/updateFileUpload', {
         filepath,
         size: fileObject.size,
@@ -244,10 +244,10 @@ export default class FilesMixin extends Vue {
     for (const file of files) {
       const [fullPath, fileObject] = this.getFullPathAndFile(path, file)
 
-      let filepath = `${fullPath}${fileObject.name}`
-      filepath = (filepath.startsWith('/'))
-        ? filepath
-        : '/' + filepath
+      const filepath = fullPath
+        ? `${fullPath}/${fileObject.name}`
+        : fileObject.name
+
       const fileState = this.$store.state.files.uploads.find((u: FilesUpload) => u.filepath === filepath)
 
       if (fileState && !fileState?.cancelled) {

--- a/src/util/file-system-entry.ts
+++ b/src/util/file-system-entry.ts
@@ -59,7 +59,9 @@ export const convertFilesToFilesWithPath = (files: File[] | FileList) => {
   return [...files]
     .map((file): FileWithPath => ({
       file,
-      path: file.webkitRelativePath.slice(0, -file.name.length)
+      path: file.webkitRelativePath === file.name
+        ? ''
+        : file.webkitRelativePath.slice(0, -file.name.length - 1)
     }))
 }
 
@@ -89,7 +91,9 @@ export const getFilesFromFileSystemEntries = async (entries: readonly FileSystem
         for (const entry of subEntries) {
           items.push({
             entry,
-            path: item.path + item.entry.name + '/'
+            path: item.path
+              ? `${item.path}/${item.entry.name}`
+              : item.entry.name
           })
         }
       }


### PR DESCRIPTION
Main issue here is that some helper methods sometimes returned a "\" terminated path, which would then lead to these weird differences.

I made sure that these methods do not return a terminated "/"

Fixes #1325