### PR TITLE
fix: console warning when multiple update sources have warnings

### DIFF
--- a/src/components/settings/VersionSettings.vue
+++ b/src/components/settings/VersionSettings.vue
@@ -128,7 +128,7 @@
         <template v-if="'anomalies' in component">
           <v-alert
             v-for="(anomaly, index) in component.anomalies ?? []"
-            :key="`anomaly-${index}`"
+            :key="`anomaly-${component.key}-${index}`"
             dense
             icon="$info"
             text

--- a/src/components/settings/VersionSettings.vue
+++ b/src/components/settings/VersionSettings.vue
@@ -115,7 +115,7 @@
         <template v-if="'warnings' in component">
           <v-alert
             v-for="(warning, index) in component.warnings ?? []"
-            :key="`warning-${index}`"
+            :key="`warning-${component.key}-${index}`"
             dense
             type="warning"
             text


### PR DESCRIPTION
Resolves a console warning when multiple update sources have active warnings:
![image](https://github.com/fluidd-core/fluidd/assets/25269274/271b8a37-7dc2-4f96-b1ff-8c33a787890e)
