### PR TITLE
feat: adds print in progress status layout setting

### DIFF
--- a/src/components/settings/GeneralSettings.vue
+++ b/src/components/settings/GeneralSettings.vue
@@ -170,6 +170,20 @@
       <v-divider />
 
       <app-setting
+        :title="$t('app.setting.label.print_in_progress_layout')"
+      >
+        <v-select
+          v-model="printInProgressLayout"
+          filled
+          dense
+          hide-details="auto"
+          :items="availablePrintInProgressLayouts"
+        />
+      </app-setting>
+
+      <v-divider />
+
+      <app-setting
         :title="$t('app.setting.label.enable_diagnostics')"
         :sub-title="$t('app.setting.tooltip.diagnostics_performance')"
       >
@@ -190,6 +204,7 @@ import type { VInput } from '@/types'
 import { SupportedLocales, DateFormats, TimeFormats } from '@/globals'
 import type { OutputPin } from '@/store/printer/types'
 import type { Device } from '@/store/power/types'
+import type { PrintInProgressLayout } from '@/store/config/types'
 
 @Component({
   components: {}
@@ -370,6 +385,31 @@ export default class GeneralSettings extends Mixins(StateMixin) {
       value: [...new Set(value)].sort((a, b) => a.localeCompare(b)),
       server: true
     })
+  }
+
+  get printInProgressLayout (): PrintInProgressLayout {
+    return this.$store.state.config.uiSettings.general.printInProgressLayout as PrintInProgressLayout
+  }
+
+  set printInProgressLayout (value: PrintInProgressLayout) {
+    this.$store.dispatch('config/saveByPath', {
+      path: 'uiSettings.general.printInProgressLayout',
+      value,
+      server: true
+    })
+  }
+
+  get availablePrintInProgressLayouts () {
+    return [
+      {
+        value: 'default',
+        text: this.$t('app.general.label.default')
+      },
+      {
+        value: 'compact',
+        text: this.$t('app.general.label.compact')
+      }
+    ]
   }
 
   get enableDiagnostics () {

--- a/src/components/widgets/status/StatusTab.vue
+++ b/src/components/widgets/status/StatusTab.vue
@@ -13,36 +13,53 @@
 
     <v-card-text v-if="visible">
       <v-row>
-        <!-- Only show the circular progress for mdAndUp since its more compact now -->
-        <v-col
-          v-if="progressVisible && $vuetify.breakpoint.mdAndUp"
-          cols="auto"
-          align-self="center"
-        >
-          <v-row>
-            <v-btn
-              text
-              class="progress-button mx-2"
-              @click="handleViewThumbnail"
+        <template v-if="progressVisible">
+          <v-col
+            v-if="printInProgressLayout === 'default' && $vuetify.breakpoint.lgAndUp"
+            cols="auto"
+            align-self="center"
+          >
+            <v-progress-circular
+              :rotate="-90"
+              :size="90"
+              :width="7"
+              :value="estimates.progress"
+              color="primary"
             >
-              <v-progress-circular
-                :rotate="-90"
-                :size="90"
-                :width="7"
-                :value="estimates.progress"
-                color="primary"
+              <span class="percentComplete focus--text">{{ estimates.progress }}%</span>
+            </v-progress-circular>
+          </v-col>
+
+          <v-col
+            v-else-if="printInProgressLayout === 'compact' && $vuetify.breakpoint.mdAndUp"
+            cols="auto"
+            align-self="center"
+          >
+            <v-row>
+              <v-btn
+                text
+                class="progress-button mx-2"
+                @click="handleViewThumbnail"
               >
-                <img
-                  class="progress-button-image"
-                  :src="thumbnail"
+                <v-progress-circular
+                  :rotate="-90"
+                  :size="90"
+                  :width="7"
+                  :value="estimates.progress"
+                  color="primary"
                 >
-              </v-progress-circular>
-            </v-btn>
-          </v-row>
-          <v-row justify="center">
-            <span class="primary--text">{{ estimates.progress }}%</span>
-          </v-row>
-        </v-col>
+                  <img
+                    class="progress-button-image"
+                    :src="thumbnail"
+                  >
+                </v-progress-circular>
+              </v-btn>
+            </v-row>
+            <v-row justify="center">
+              <span class="primary--text">{{ estimates.progress }}%</span>
+            </v-row>
+          </v-col>
+        </template>
 
         <v-col align-self="center">
           <!-- Visible dependent on knowing the file, message or mdAndDown -->
@@ -179,6 +196,24 @@
             </v-col>
           </v-row>
         </v-col>
+
+        <v-col
+          v-if="thumbVisible && printInProgressLayout === 'default'"
+          cols="auto"
+          align-self="center"
+          class="pa-0"
+        >
+          <v-btn
+            text
+            height="100%"
+            @click="handleViewThumbnail"
+          >
+            <img
+              class="print-thumb"
+              :src="thumbnail"
+            >
+          </v-btn>
+        </v-col>
       </v-row>
     </v-card-text>
 
@@ -201,6 +236,7 @@ import FilesMixin from '@/mixins/files'
 import ToolheadMixin from '@/mixins/toolhead'
 import FilePreviewDialog from '../filesystem/FilePreviewDialog.vue'
 import type { TimeEstimates } from '@/store/printer/types'
+import type { PrintInProgressLayout } from '@/store/config/types'
 
 @Component({
   components: {
@@ -259,6 +295,10 @@ export default class StatusTab extends Mixins(StateMixin, FilesMixin, ToolheadMi
       this.thumbnail &&
       this.$vuetify.breakpoint.lgAndUp
     )
+  }
+
+  get printInProgressLayout (): PrintInProgressLayout {
+    return this.$store.state.config.uiSettings.general.printInProgressLayout as PrintInProgressLayout
   }
 
   /**
@@ -387,6 +427,11 @@ export default class StatusTab extends Mixins(StateMixin, FilesMixin, ToolheadMi
 </script>
 
 <style lang="scss" scoped>
+  .print-thumb {
+    display: block;
+    max-height: 110px;
+  }
+
   .filename {
     white-space: nowrap;
     overflow: hidden;

--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -251,6 +251,7 @@ app:
       confirm: Confirm
       cross: Cross
       circle: Circle
+      compact: Compact
       current_password: Current password
       current_user: Current user
       default: Default
@@ -585,6 +586,7 @@ app:
       optional: Optional
       power_toggle_in_top_nav: Power toggle in top navigation
       primary_color: Primary color
+      print_in_progress_layout: Print in Progress layout
       printer_name: Printer Name
       reset: Reset settings
       retraction_icon_size: Retraction Icon Size

--- a/src/store/config/state.ts
+++ b/src/store/config/state.ts
@@ -60,6 +60,7 @@ export const defaultState = (): ConfigState => {
         showBedScrewsAdjustDialogAutomatically: true,
         showScrewsTiltAdjustDialogAutomatically: true,
         forceMoveToggleWarning: true,
+        printInProgressLayout: 'default',
         enableDiagnostics: false,
         thumbnailSize: 32
       },

--- a/src/store/config/types.ts
+++ b/src/store/config/types.ts
@@ -96,6 +96,7 @@ export interface GeneralConfig {
   showBedScrewsAdjustDialogAutomatically: boolean;
   showScrewsTiltAdjustDialogAutomatically: boolean;
   forceMoveToggleWarning: boolean;
+  printInProgressLayout: PrintInProgressLayout;
   enableDiagnostics: boolean;
   thumbnailSize: number;
 }
@@ -105,6 +106,8 @@ export type ToolheadControlStyle = 'cross' | 'bars' | 'circle'
 export type TextSortOrder = 'default' | 'numeric-prefix' | 'version'
 
 export type CameraFullscreenAction = 'embed' | 'rawstream';
+
+export type PrintInProgressLayout = 'default' | 'compact'
 
 // Config stored in moonraker db
 export interface ThemeConfig {


### PR DESCRIPTION
This is a follow up on [this request](https://github.com/fluidd-core/fluidd/pull/1252#issuecomment-1889149738), specifically it adds a new setting to allow selecting the Print in Progress layout:

## New Print in Progress layout setting

![image](https://github.com/fluidd-core/fluidd/assets/85504/e7f6e38e-a6b5-4e06-bcdb-440bff9b80eb)

## Default

![image](https://github.com/fluidd-core/fluidd/assets/85504/41287ea9-9e49-4eb4-a594-f158ed6a9356)

## Compact

![image](https://github.com/fluidd-core/fluidd/assets/85504/60685f6d-5a0f-49d1-a965-6116a3d70da8)
