### PR TITLE
feat: adds link to components in software updates

### DIFF
--- a/src/components/settings/VersionSettings.vue
+++ b/src/components/settings/VersionSettings.vue
@@ -57,10 +57,32 @@
       <v-divider />
 
       <template v-for="(component, i) in components">
-        <app-setting
-          :key="`component-${component.key}-${component.name}`"
-          :title="packageTitle(component)"
-        >
+        <app-setting :key="`component-${component.key}-${component.name}`">
+          <template #title>
+            {{ packageTitle(component) }}
+            <v-tooltip
+              v-if="'remote_url' in component"
+              bottom
+            >
+              <template #activator="{ attrs, on }">
+                <a
+                  v-bind="attrs"
+                  :href="component.remote_url"
+                  target="_blank"
+                  v-on="on"
+                >
+                  <v-icon
+                    small
+                    right
+                  >
+                    $openInNew
+                  </v-icon>
+                </a>
+              </template>
+              <span>{{ component.remote_url }}</span>
+            </v-tooltip>
+          </template>
+
           <template #sub-title>
             <span v-if="component.key !== 'system' && 'full_version_string' in component">
               {{ component.full_version_string }}
@@ -83,7 +105,6 @@
           >
             <template #activator="{ attrs, on }">
               <app-btn
-                v-if="hasUpdate(component.key) && !inError(component)"
                 v-bind="attrs"
                 color="primary"
                 icon
@@ -97,8 +118,8 @@
               </app-btn>
             </template>
             <span v-if="'name' in component">{{ $t('app.version.tooltip.release_notes') }}</span>
-            <span v-if="'commits_behind' in component">{{ $t('app.version.tooltip.commit_history') }}</span>
-            <span v-if="'package_list' in component">{{ $t('app.version.tooltip.packages') }}</span>
+            <span v-else-if="'commits_behind' in component">{{ $t('app.version.tooltip.commit_history') }}</span>
+            <span v-else-if="'package_list' in component">{{ $t('app.version.tooltip.packages') }}</span>
           </v-tooltip>
 
           <version-status
@@ -216,12 +237,6 @@ export default class VersionSettings extends Mixins(StateMixin) {
     return (dirty || !valid)
   }
 
-  packageUrl (component: HashVersion | OSPackage | ArtifactVersion) {
-    if (component.key === 'klipper') return 'https://github.com/Klipper3d/klipper/commits/master'
-    if (component.key === 'moonraker') return 'https://github.com/Arksine/moonraker/commits/master'
-    if (component.key === 'fluidd' && 'name' in component && component.name === 'fluidd') return 'https://github.com/fluidd-core/fluidd/releases'
-  }
-
   // Will attempt to update the requirec component based on its type.
   handleUpdateComponent (key: string) {
     this.$store.dispatch('version/onUpdateStatus', { busy: true })
@@ -268,6 +283,9 @@ export default class VersionSettings extends Mixins(StateMixin) {
   }
 
   getBaseUrl (component: HashVersion | ArtifactVersion) {
+    if ('remote_url' in component && component.remote_url) {
+      return component.remote_url
+    }
     if ('owner' in component) {
       return `https://github.com/${component.owner}/${component.key}`
     }


### PR DESCRIPTION
Adds a link to components in the Software Updates panel. When clicked, it will open the repository URL on a new separate browser window/tab.

![image](https://github.com/fluidd-core/fluidd/assets/85504/c33f9fa2-467d-480b-9264-3d48a5c09122)

On hover, a tooltip with the URL is shown.

![image](https://github.com/fluidd-core/fluidd/assets/85504/6a26c2c5-9524-42cf-a323-14938e58bfbd)

Resolves #1313