### PR TITLE
fix(spoolman): dialog title

### DIFF
--- a/src/components/widgets/spoolman/SpoolSelectionDialog.vue
+++ b/src/components/widgets/spoolman/SpoolSelectionDialog.vue
@@ -6,7 +6,9 @@
     title-shadow
   >
     <template #title>
-      <span class="focus--text">$tc('app.spoolman.title.spool_selection', targetMacro ? 2 : 1, { macro: targetMacro })</span>
+      <span class="focus--text">
+        {{ $tc('app.spoolman.title.spool_selection', targetMacro ? 2 : 1, { macro: targetMacro }) }}
+      </span>
 
       <v-spacer />
 


### PR DESCRIPTION
Adds missing Vue.js expression brackets.

![image](https://github.com/fluidd-core/fluidd/assets/85504/f8e8497d-6ad6-47d2-a377-2ea82dd9270a)

Fixes #1351