### PR TITLE
fix: don't override `gcode_macro` variables with stale values

### DIFF
--- a/src/store/macros/getters.ts
+++ b/src/store/macros/getters.ts
@@ -25,8 +25,8 @@ export const getters: GetterTree<MacrosState, RootState> = {
           disabledWhilePrinting: false,
           color: '',
           categoryId: '0',
-          variables,
           ...stored,
+          variables,
           ...{ config }
         }
 


### PR DESCRIPTION
> When a macro is edited via the UI it saves a copy of it in the database, which is then used to override some default settings. It looks like this also overrides the macros variables, so they will never change as far as the UI is concerned.

Fixes #1269 not showing up