### PR TITLE
style: use Roboto font family in charts

### DIFF
--- a/src/components/widgets/bedmesh/BedMeshChart.vue
+++ b/src/components/widgets/bedmesh/BedMeshChart.vue
@@ -148,6 +148,9 @@ export default class BedMeshChart extends Mixins(BrowserMixin) {
       legend: {
         show: false
       },
+      textStyle: {
+        fontFamily: 'Roboto'
+      },
       darkMode,
       tooltip: {
         backgroundColor: labelBackground,

--- a/src/components/widgets/bedmesh/BedMeshChart.vue
+++ b/src/components/widgets/bedmesh/BedMeshChart.vue
@@ -224,7 +224,7 @@ export default class BedMeshChart extends Mixins(BrowserMixin) {
         <div>
           <span style="display:inline-block;margin-right:4px;border-radius:10px;width:10px;height:10px;background-color:${params.color};"></span>
           <span style="font-size:16px;color:#666;font-weight:400;margin-left:2px">
-            ${params.seriesName}
+            ${this.$filters.startCase(params.seriesName)}
           </span>
           <div style="clear: both"></div>
           <span style="font-size:16px;color:#666;font-weight:400;margin-left:2px">

--- a/src/components/widgets/diagnostics/DiagnosticsCard.vue
+++ b/src/components/widgets/diagnostics/DiagnosticsCard.vue
@@ -92,6 +92,9 @@ export default class DiagnosticsCard extends Mixins(BrowserMixin) {
     const options = {
       grid,
       color,
+      textStyle: {
+        fontFamily: 'Roboto'
+      },
       legend: {
         show: false
       },

--- a/src/components/widgets/thermals/ThermalChart.vue
+++ b/src/components/widgets/thermals/ThermalChart.vue
@@ -139,6 +139,9 @@ export default class ThermalChart extends Mixins(BrowserMixin) {
 
     const options = {
       grid,
+      textStyle: {
+        fontFamily: 'Roboto'
+      },
       color,
       legend: {
         show: false,

--- a/src/store/charts/getters.ts
+++ b/src/store/charts/getters.ts
@@ -77,6 +77,9 @@ export const getters: GetterTree<ChartState, RootState> = {
     return {
       color,
       grid,
+      textStyle: {
+        fontFamily: 'Roboto'
+      },
       tooltip: {
         ...tooltip,
         show: true,

--- a/src/store/charts/getters.ts
+++ b/src/store/charts/getters.ts
@@ -110,7 +110,7 @@ export const getters: GetterTree<ChartState, RootState> = {
                   <div style="white-space: nowrap;">
                     ${param.marker}
                     <span style="font-size:${fontSize}px;color:${fontColor};font-weight:400;margin-left:2px">
-                      ${param.seriesName}:
+                      ${Vue.$filters.startCase(param.seriesName)}:
                     </span>
                     <span style="float:right;margin-left:20px;font-size:${fontSize}px;color:${fontColor};font-weight:900">
                       ${param.value[yDimension]}${ySuffix}


### PR DESCRIPTION
By default, e-charts uses "Microsoft YaHei" in Windows platform and "sans-serif" otherwise.

This makes sure we use "Roboto" by default on our existing charts.

I've also ensured that we use "startcase" format on the tooltip labels.

## Examples

![image](https://github.com/fluidd-core/fluidd/assets/85504/4350e577-c225-413b-bce3-e0f81d4bc966)

![image](https://github.com/fluidd-core/fluidd/assets/85504/6958f448-b972-40ae-afb0-242bcd319e80)

![image](https://github.com/fluidd-core/fluidd/assets/85504/5179cc8e-c076-4595-a67a-1e511bbe7a2e)

Fixes #1352