### PR TITLE
refactor: uses vue2-touch-events for tap

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "vue-property-decorator": "^9.1.2",
         "vue-router": "^3.6.5",
         "vue-virtual-scroller": "^1.1.2",
+        "vue2-touch-events": "^3.2.3",
         "vuetify": "^2.7.1",
         "vuetify-confirm": "^2.0.6",
         "vuex": "^3.6.2"
@@ -13623,6 +13624,11 @@
       "peerDependencies": {
         "vue": "^2.6.11"
       }
+    },
+    "node_modules/vue2-touch-events": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/vue2-touch-events/-/vue2-touch-events-3.2.3.tgz",
+      "integrity": "sha512-WgVK0g3rgMuIh8s3WXJlR7jHEmHGpduwRvhSbCfgiN43wqBoHBJNk6oAeL+8FLz7wZVKAxl61RvJHJ4JvgFEfw=="
     },
     "node_modules/vuetify": {
       "version": "2.7.1",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "vue-property-decorator": "^9.1.2",
     "vue-router": "^3.6.5",
     "vue-virtual-scroller": "^1.1.2",
+    "vue2-touch-events": "^3.2.3",
     "vuetify": "^2.7.1",
     "vuetify-confirm": "^2.0.6",
     "vuex": "^3.6.2"

--- a/src/components/widgets/exclude-objects/ExcludeObjects.vue
+++ b/src/components/widgets/exclude-objects/ExcludeObjects.vue
@@ -22,13 +22,9 @@
         <path :d="iconCancelled" />
         <path
           v-if="!isPartExcluded(name)"
+          v-touch:tap="() => $emit('cancel', name)"
           :d="iconCircle"
           class="hitarea"
-          @click="$emit('cancel', name)"
-          @touchstart="touchedElement = name"
-          @touchend="handleTouchEnd(name)"
-          @touchcancel="touchedElement = undefined"
-          @touchmove="touchedElement = undefined"
         />
       </svg>
     </g>
@@ -44,13 +40,6 @@ import { Icons } from '@/globals'
 export default class ExcludeObjects extends Mixins(StateMixin) {
   @Prop({ type: String })
   readonly shapeRendering?: string
-
-  touchedElement?: string
-
-  handleTouchEnd (name: string) {
-    if (this.touchedElement === name) this.$emit('cancel', name)
-    this.touchedElement = undefined
-  }
 
   get parts () {
     const parts = this.$store.getters['parts/getParts']

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,6 +19,7 @@ import vuetify from './plugins/vuetify'
 import VueVirtualScroller from 'vue-virtual-scroller'
 import VueMeta from 'vue-meta'
 import VuetifyConfirm from 'vuetify-confirm'
+import Vue2TouchEvents from 'vue2-touch-events'
 import { InlineSvgPlugin } from 'vue-inline-svg'
 
 // Init.
@@ -52,6 +53,7 @@ Vue.use(VuetifyConfirm, {
   vuetify
 })
 Vue.use(InlineSvgPlugin)
+Vue.use(Vue2TouchEvents)
 
 Vue.use(HttpClientPlugin, {
   store


### PR DESCRIPTION
To fix the tap issues, we are now introducing the vue2-touch-events library.

This will deprecate #1363

Fixes #1359