### PR TITLE
fix: make color picker use v-model and propsync

### DIFF
--- a/src/components/settings/ThemeSettings.vue
+++ b/src/components/settings/ThemeSettings.vue
@@ -45,9 +45,8 @@
 
         <app-color-picker
           v-if="theme"
-          :primary="themeColor"
+          v-model="themeColor"
           :title="$t('app.setting.btn.select_theme')"
-          @change="handleChangeThemeColor"
         />
       </app-setting>
 
@@ -79,7 +78,6 @@
 <script lang="ts">
 import { Component, Mixins } from 'vue-property-decorator'
 import StateMixin from '@/mixins/state'
-import { IroColor } from '@irojs/iro-core'
 import type { ThemePreset, ThemeConfig } from '@/store/config/types'
 import ThemePicker from '../ui/AppColorPicker.vue'
 
@@ -116,12 +114,10 @@ export default class ThemeSettings extends Mixins(StateMixin) {
     return this.theme.color
   }
 
-  handleChangeThemeColor (value: { channel: string; color: IroColor }) {
-    const color = value.color.hexString
-
-    if (this.theme.color.toLowerCase() !== color.toLowerCase()) {
+  set themeColor (value: string) {
+    if (this.theme.color.toLowerCase() !== value.toLowerCase()) {
       this.updateTheme({
-        color
+        color: value
       })
     }
   }

--- a/src/components/settings/macros/MacroSettingsDialog.vue
+++ b/src/components/settings/macros/MacroSettingsDialog.vue
@@ -50,9 +50,8 @@
           {{ $t('app.setting.btn.reset') }}
         </app-btn>
         <app-color-picker
+          v-model="color"
           :title="$t('app.general.btn.set_color')"
-          :primary="color"
-          @change="handleColorChange"
         />
       </app-setting>
 
@@ -103,7 +102,6 @@
 <script lang="ts">
 import type { Macro } from '@/store/macros/types'
 import { Component, Vue, Prop, VModel } from 'vue-property-decorator'
-import type { IroColor } from '@irojs/iro-core'
 
 @Component({})
 export default class MacroMoveDialog extends Vue {
@@ -131,11 +129,11 @@ export default class MacroMoveDialog extends Vue {
     if (this.newMacro && this.newMacro.color !== '') {
       return this.newMacro.color
     }
-    return this.$vuetify.theme.currentTheme.secondary
+    return this.$vuetify.theme.currentTheme.secondary?.toString()
   }
 
-  handleColorChange (color: { channel: string, color: IroColor }) {
-    if (this.newMacro) this.newMacro.color = color.color.hexString
+  set color (value: string | undefined) {
+    if (this.newMacro) this.newMacro.color = value
   }
 
   handleResetColor () {

--- a/src/components/widgets/diagnostics/config/MetricsConfigStep.vue
+++ b/src/components/widgets/diagnostics/config/MetricsConfigStep.vue
@@ -75,7 +75,7 @@
 
               <app-setting :title="$t('app.setting.label.line_color')">
                 <app-color-picker
-                  :primary="metric.style.lineColor"
+                  :value="metric.style.lineColor"
                   :title="metric.name"
                   dot
                   @change="handleColorChange('lineColor', metric, $event)"
@@ -99,7 +99,7 @@
 
               <app-setting :title="$t('app.setting.label.fill_color')">
                 <app-color-picker
-                  :primary="metric.style.fillColor ?? metric.style.lineColor"
+                  :value="metric.style.fillColor ?? metric.style.lineColor"
                   :title="metric.name"
                   dot
                   @change="handleColorChange('fillColor', metric, $event)"

--- a/src/components/widgets/diagnostics/config/MetricsConfigStep.vue
+++ b/src/components/widgets/diagnostics/config/MetricsConfigStep.vue
@@ -78,7 +78,7 @@
                   :value="metric.style.lineColor"
                   :title="metric.name"
                   dot
-                  @change="handleColorChange('lineColor', metric, $event)"
+                  @input="metric.style.lineColor = $event"
                 />
               </app-setting>
 
@@ -102,7 +102,7 @@
                   :value="metric.style.fillColor ?? metric.style.lineColor"
                   :title="metric.name"
                   dot
-                  @change="handleColorChange('fillColor', metric, $event)"
+                  @input="metric.style.fillColor = $event"
                 />
               </app-setting>
 
@@ -158,7 +158,7 @@
 
 <script lang="ts">
 import { Component, Vue, Prop } from 'vue-property-decorator'
-import type { DiagnosticsCardConfig, Metric } from '@/store/diagnostics/types'
+import type { DiagnosticsCardConfig } from '@/store/diagnostics/types'
 import MetricsCollectorConfig from './MetricsCollectorConfig.vue'
 import { defaultState } from '@/store/layout/state'
 
@@ -179,10 +179,6 @@ export default class MetricsConfigStep extends Vue {
     { text: this.$t('app.setting.label.dotted'), value: 'dotted' },
     { text: this.$t('app.setting.label.dashed'), value: 'dashed' }
   ]
-
-  handleColorChange (prop: 'lineColor' | 'fillColor', metric: Metric, event: any) {
-    metric.style[prop] = event.color.hexString
-  }
 
   addMetric (axis: number) {
     const defaultCard = defaultState().layouts.diagnostics.container1[0] as DiagnosticsCardConfig

--- a/src/components/widgets/outputs/OutputLed.vue
+++ b/src/components/widgets/outputs/OutputLed.vue
@@ -12,12 +12,11 @@
     </v-col>
     <v-col class="ml-auto py-0 text-right">
       <app-color-picker
-        :primary="primaryColor"
-        :white="whiteColor"
+        v-model="primaryColor"
+        :white.sync="whiteValue"
         :title="led.prettyName"
         :supported-channels="supportedChannels"
         dot
-        @change="handleColorChange"
       />
     </v-col>
   </v-row>
@@ -29,14 +28,24 @@ import { IroColor } from '@irojs/iro-core'
 import StateMixin from '@/mixins/state'
 import type { Led } from '@/store/printer/types'
 
-type Channel = 'r' | 'g' | 'b' | 'w'
+type Rgbw = {
+  r: number,
+  g: number,
+  b: number,
+  w: number
+}
 
 @Component({})
 export default class OutputLed extends Mixins(StateMixin) {
   @Prop({ type: Object, required: true })
   readonly led!: Led
 
-  channelLookup: Record<Channel, string> = { r: 'RED', g: 'GREEN', b: 'BLUE', w: 'WHITE' }
+  channelLookup: Record<keyof Rgbw, string> = {
+    r: 'RED',
+    g: 'GREEN',
+    b: 'BLUE',
+    w: 'WHITE'
+  }
 
   get supportedChannels (): string {
     const { type, config } = this.led
@@ -49,8 +58,7 @@ export default class OutputLed extends Mixins(StateMixin) {
       case 'dotstar':
         return 'RGB'
 
-      case 'led':
-      {
+      case 'led': {
         const channels = []
 
         if ('red_pin' in config) channels.push('R')
@@ -65,47 +73,9 @@ export default class OutputLed extends Mixins(StateMixin) {
     return 'RBGW'
   }
 
-  get currentColor () {
-    return this.convertFromNumberArray(this.led.color_data[0])
-  }
-
-  get primaryColor () {
-    const color = new IroColor(this.currentColor)
-
-    return color.hexString
-  }
-
-  get whiteColor () {
-    if (!this.supportedChannels.includes('W')) {
-      return undefined
-    }
-
-    const currentColor = this.currentColor
-    const color = new IroColor({
-      r: currentColor.w,
-      g: currentColor.w,
-      b: currentColor.w
-    })
-
-    return color.hexString
-  }
-
-  handleColorChange (value: { channel: string; color: IroColor }) {
-    const selectedColor = value.color.rgb
-
-    const newColor: Record<Channel, number> = {
-      ...this.currentColor,
-      ...(value.channel === 'primary' ? selectedColor : { w: selectedColor.r })
-    }
-
-    const supportedChannels = this.supportedChannels.toLowerCase().split('') as Channel[]
-    const colorsString = supportedChannels.map(channel => `${this.channelLookup[channel]}=${Math.round(newColor[channel] * 1000 / 255) / 1000}`).join(' ')
-
-    this.sendGcode(`SET_LED LED=${this.led.name} ${colorsString}`)
-  }
-
-  convertFromNumberArray (colorData: number[]) : Record<Channel, number> {
-    const [r, g, b, w] = colorData.map(value => value * 255)
+  get color (): Rgbw {
+    const [r, g, b, w] = this.led.color_data[0]
+      .map(value => Math.round(value * 255))
 
     return {
       r,
@@ -113,6 +83,48 @@ export default class OutputLed extends Mixins(StateMixin) {
       b,
       w
     }
+  }
+
+  get primaryColor (): string {
+    const color = new IroColor(this.color)
+
+    return color.hexString
+  }
+
+  set primaryColor (value: string) {
+    const { r, g, b } = new IroColor(value).rgb
+
+    const newColor: Rgbw = {
+      ...this.color,
+      r,
+      g,
+      b
+    }
+
+    this.sendColor(newColor)
+  }
+
+  get whiteValue () {
+    return this.color.w
+  }
+
+  set whiteValue (value: number) {
+    const newColor: Rgbw = {
+      ...this.color,
+      w: value
+    }
+
+    this.sendColor(newColor)
+  }
+
+  sendColor (color: Rgbw) {
+    const supportedChannels = this.supportedChannels.toLowerCase().split('') as (keyof Rgbw)[]
+
+    const colorsString = supportedChannels
+      .map(channel => ` ${this.channelLookup[channel]}=${Math.round(color[channel] * 1000 / 255) / 1000}`)
+      .join('')
+
+    this.sendGcode(`SET_LED LED=${this.led.name}${colorsString}`)
   }
 }
 </script>

--- a/src/store/diagnostics/types.ts
+++ b/src/store/diagnostics/types.ts
@@ -31,7 +31,7 @@ export interface Metric {
 export interface MetricStyle {
   lineColor: string
   lineStyle: 'solid' | 'dashed' | 'dotted'
-  fillColor?: string
+  fillColor: string | null
   fillOpacity: number
   displayLegend: boolean
 }

--- a/src/store/layout/actions.ts
+++ b/src/store/layout/actions.ts
@@ -12,7 +12,7 @@ export const actions: ActionTree<LayoutState, RootState> = {
     commit('setReset')
   },
 
-  async initLayout ({ commit }, payload) {
+  async initLayout ({ commit }, payload: LayoutState) {
     commit('setInitLayout', payload)
   },
 

--- a/src/store/layout/mutations.ts
+++ b/src/store/layout/mutations.ts
@@ -2,6 +2,7 @@ import Vue from 'vue'
 import type { MutationTree } from 'vuex'
 import { defaultState as getDefaultState } from './state'
 import type { LayoutConfig, LayoutState, Layouts } from './types'
+import type { DiagnosticsCardContainer } from '../diagnostics/types'
 
 export const mutations: MutationTree<LayoutState> = {
   /**
@@ -22,28 +23,46 @@ export const mutations: MutationTree<LayoutState> = {
       const defaultState = getDefaultState()
 
       // add new layouts
-      for (const [layout, defaultComponents] of Object.entries(defaultState.layouts)) {
-        if (!payload.layouts[layout]) {
-          payload.layouts[layout] = defaultComponents
+      for (const [layoutKey, defaultLayout] of Object.entries(defaultState.layouts)) {
+        if (!payload.layouts[layoutKey]) {
+          payload.layouts[layoutKey] = defaultLayout
         }
       }
 
       // migrate existing layouts
-      const migratableLayouts = ['dashboard']
-      for (const layout of Object.keys(payload.layouts)) {
-        const migratableLayout = migratableLayouts.find(migration => layout.startsWith(migration))
-        if (migratableLayout) {
-          const defaultComponents = defaultState.layouts[migratableLayout]
-          const defaultComponentIds = Object.values(defaultComponents).flat().map(card => card.id)
-          const currentComponentIds = Object.values(payload.layouts[layout]).flat().map(card => card.id)
+      const migratableLayoutKeys = ['dashboard']
 
-          for (const [container, defaultContainerComponents] of Object.entries(defaultComponents)) {
-            const currentContainerComponents = payload.layouts[layout][container] || []
+      for (const layoutKey of Object.keys(payload.layouts)) {
+        const migratableLayoutKey = migratableLayoutKeys.find(key => layoutKey.startsWith(key))
 
-            payload.layouts[layout][container] = [
+        if (migratableLayoutKey) {
+          const defaultLayout = defaultState.layouts[migratableLayoutKey]
+          const defaultComponentIds = Object.values(defaultLayout).flat().map(card => card.id)
+          const currentLayout = payload.layouts[layoutKey]
+          const currentComponentIds = Object.values(currentLayout).flat().map(card => card.id)
+
+          for (const [containerKey, defaultContainerComponents] of Object.entries(defaultLayout)) {
+            const currentContainerComponents = currentLayout[containerKey] || []
+
+            currentLayout[containerKey] = [
               ...currentContainerComponents.filter(component => defaultComponentIds.includes(component.id)),
               ...defaultContainerComponents.filter(component => !currentComponentIds.includes(component.id))
             ]
+          }
+        }
+
+        // diagnostics specific layout updates
+        if (layoutKey.startsWith('diagnostics')) {
+          const diagnostics = payload.layouts[layoutKey] as DiagnosticsCardContainer
+
+          for (const diagnosticsCardConfigs of Object.values(diagnostics)) {
+            for (const diagnosticsCardConfig of diagnosticsCardConfigs) {
+              for (const axis of diagnosticsCardConfig.axes) {
+                for (const metric of axis.metrics) {
+                  metric.style.fillColor = metric.style.fillColor ?? null
+                }
+              }
+            }
           }
         }
       }

--- a/src/store/layout/state.ts
+++ b/src/store/layout/state.ts
@@ -48,11 +48,11 @@ export const defaultState = (): LayoutState => {
             metrics: [{
               collector: 'printer.motion_report.live_velocity',
               name: 'Velocity',
-              style: { lineStyle: 'solid', lineColor: '#2196f3', fillOpacity: 0, displayLegend: true }
+              style: { lineStyle: 'solid', lineColor: '#2196f3', fillColor: null, fillOpacity: 0, displayLegend: true }
             }, {
               collector: 'printer.toolhead.max_velocity',
               name: 'Max Velocity',
-              style: { lineStyle: 'dotted', lineColor: '#0075d2', fillOpacity: 0, displayLegend: false }
+              style: { lineStyle: 'dotted', lineColor: '#0075d2', fillColor: null, fillOpacity: 0, displayLegend: false }
             }]
           }, {
             enabled: true,
@@ -63,11 +63,11 @@ export const defaultState = (): LayoutState => {
               collector: 'printer.motion_report.live_extruder_velocity * Math.PI * ' +
                 '(printer.configfile.settings.extruder.filament_diameter / 2) ** 2',
               name: 'Flow',
-              style: { lineStyle: 'solid', lineColor: '#b12f36', fillOpacity: 5, displayLegend: true }
+              style: { lineStyle: 'solid', lineColor: '#b12f36', fillColor: null, fillOpacity: 5, displayLegend: true }
             }, {
               collector: '12',
               name: 'Max Flow',
-              style: { lineStyle: 'dashed', lineColor: '#820007', fillOpacity: 0, displayLegend: false }
+              style: { lineStyle: 'dashed', lineColor: '#820007', fillColor: null, fillOpacity: 0, displayLegend: false }
             }]
           }]
         }]


### PR DESCRIPTION
This PR refactors the `AppIroColorPicker` and `AppColorPicker` to use v-model and propsync where possible, thus making the control easier to consume, and fixing the reported issue.

Note: following up on what we already do with our custom input controls, changing the value on the text input boxes will not take effect unless <kbd>Enter</kbd> is pressed.

Fixes #1372