### PR TITLE
feat: view rendered Markdown files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,8 @@
         "hls.js": "^1.5.6",
         "jwt-decode": "^4.0.0",
         "lodash-es": "^4.17.21",
+        "marked": "^12.0.0",
+        "marked-base-url": "^1.1.3",
         "md5": "^2.3.0",
         "monaco-editor": "^0.46.0",
         "monaco-editor-textmate": "^4.0.0",
@@ -9689,6 +9691,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/marked": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-12.0.0.tgz",
+      "integrity": "sha512-Vkwtq9rLqXryZnWaQc86+FHLC6tr/fycMfYAhiOIXkrNmeGAyhSxjqu0Rs1i0bBqw5u0S7+lV9fdH2ZSVaoa0w==",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/marked-base-url": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/marked-base-url/-/marked-base-url-1.1.3.tgz",
+      "integrity": "sha512-KuQV8EIR/RCdov4KPcw7hdMaugxoKGx8kYprsOhNMwLybX+OqZNRSOMwmjS9Bdyj+i+e/fg5/RkDMS6PMzG7rQ==",
+      "peerDependencies": {
+        "marked": ">= 4 < 13"
       }
     },
     "node_modules/matchit": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,8 @@
     "hls.js": "^1.5.6",
     "jwt-decode": "^4.0.0",
     "lodash-es": "^4.17.21",
+    "marked": "^12.0.0",
+    "marked-base-url": "^1.1.3",
     "md5": "^2.3.0",
     "monaco-editor": "^0.46.0",
     "monaco-editor-textmate": "^4.0.0",

--- a/src/components/widgets/filesystem/FilePreviewDialog.vue
+++ b/src/components/widgets/filesystem/FilePreviewDialog.vue
@@ -170,5 +170,13 @@ video, img {
   :deep(img) {
     max-width: 100% !important;
   }
+
+  :deep(table) {
+    border-collapse: collapse;
+    th, td {
+      border: 1px solid;
+      padding: 2px 6px;
+    }
+  }
 }
 </style>

--- a/src/components/widgets/filesystem/FilePreviewDialog.vue
+++ b/src/components/widgets/filesystem/FilePreviewDialog.vue
@@ -166,17 +166,26 @@ video, img {
   max-height: calc(90vh - 144px);
 }
 
-.markdown-container {
-  :deep(img) {
+:deep(.markdown-container) {
+  img {
     max-width: 100% !important;
   }
 
-  :deep(table) {
+  table {
     border-collapse: collapse;
+
     th, td {
       border: 1px solid;
       padding: 2px 6px;
     }
+  }
+
+  pre > code {
+    display: block;
+  }
+
+  * {
+    margin-bottom: 1em;
   }
 }
 </style>

--- a/src/components/widgets/filesystem/FileSystem.vue
+++ b/src/components/widgets/filesystem/FileSystem.vue
@@ -125,6 +125,7 @@
       :type="filePreviewState.type"
       :width="filePreviewState.width"
       :readonly="filePreviewState.readonly"
+      :path="currentPath"
       @remove="handleRemove"
       @download="handleDownload"
     />

--- a/src/globals.ts
+++ b/src/globals.ts
@@ -502,6 +502,11 @@ export const SupportedImageFormats = Object.freeze([
   '.webp'
 ])
 
+export const SupportedMarkdownFormats = Object.freeze([
+  '.md',
+  '.mardown'
+])
+
 export const SupportedVideoFormats = Object.freeze([
   '.mp4',
   '.mpeg',

--- a/src/store/config/state.ts
+++ b/src/store/config/state.ts
@@ -74,7 +74,7 @@ export const defaultState = (): ConfigState => {
       },
       editor: {
         confirmDirtyEditorClose: true,
-        autoEditExtensions: ['.cfg', '.conf', '.ini', '.log', '.md', '.sh', '.txt'],
+        autoEditExtensions: ['.cfg', '.conf', '.ini', '.log', '.sh', '.txt'],
         restoreViewState: 'session',
         codeLens: true
       },

--- a/src/store/files/getters.ts
+++ b/src/store/files/getters.ts
@@ -2,7 +2,7 @@ import type { GetterTree } from 'vuex'
 import type { AppDirectory, AppFileWithMeta, FileBrowserEntry, FilesState, RootProperties } from './types'
 import type { RootState } from '../types'
 import type { HistoryItem } from '../history/types'
-import { SupportedImageFormats, SupportedVideoFormats } from '@/globals'
+import { SupportedImageFormats, SupportedMarkdownFormats, SupportedVideoFormats } from '@/globals'
 
 export const getters: GetterTree<FilesState, RootState> = {
   /**
@@ -101,6 +101,7 @@ export const getters: GetterTree<FilesState, RootState> = {
   getRootProperties: () => (root: string): RootProperties => {
     const canView = [
       ...SupportedImageFormats,
+      ...SupportedMarkdownFormats,
       ...SupportedVideoFormats
     ]
 


### PR DESCRIPTION
Allows viewing of rendered Markdown (*.md and *.markdown) files.

## Context menu for Markdown files

![image](https://github.com/fluidd-core/fluidd/assets/85504/152faf2d-23ee-4c68-9948-1ecccf94ef43)

## Markdown viewer desktop

![image](https://github.com/fluidd-core/fluidd/assets/85504/8b930811-7f39-4469-b4e0-9cc8d806f2b5)

## Markdown viewer mobile

![image](https://github.com/fluidd-core/fluidd/assets/85504/e77ea94d-844f-4e76-8c86-64b9d41ab228)

Resolves #656