### PR TITLE
fix: Armbian distribution information

### DIFF
--- a/src/components/widgets/system/SystemOverviewCard.vue
+++ b/src/components/widgets/system/SystemOverviewCard.vue
@@ -58,10 +58,10 @@
               <th>{{ $t('app.system_info.label.operating_system') }}</th>
               <td>{{ distribution.name }}</td>
             </tr>
-            <tr v-if="distribution.release_info?.name">
+            <tr v-if="distributionName">
               <th>{{ $t('app.system_info.label.distribution_name') }}</th>
               <td>
-                {{ distribution.release_info.name }} {{ distribution.release_info.version_id }}
+                {{ distributionName }}
               </td>
             </tr>
             <tr v-if="distribution.like">
@@ -116,6 +116,22 @@ export default class PrinterStatsCard extends Mixins(StateMixin) {
 
   get distribution () {
     return this.systemInfo?.distribution || {} as DistroInfo
+  }
+
+  get distributionName (): string | undefined {
+    const { name, id } = this.distribution
+
+    if (name) {
+      if (name.startsWith('0.')) {
+        return undefined
+      }
+
+      return `${(
+        name.startsWith('#')
+          ? id
+          : name
+      )} ${this.distribution.release_info?.version_id} ?? ''`
+    }
   }
 
   get virtualization () {


### PR DESCRIPTION
If the `release_name` starts with "#", we will then use the `release_id` as correct name - this is a specific fix for Armbian distro but should not be a problem for other distros.

Fixes #1385 