### PR TITLE
feat: layout improvements for small screen

### DIFF
--- a/src/components/common/AddInstanceDialog.vue
+++ b/src/components/common/AddInstanceDialog.vue
@@ -4,17 +4,11 @@
     max-width="320"
     :save-button-disabled="!verified"
     :valid.sync="valid"
+    :title="$t('app.general.title.add_printer')"
+    :help-tooltip="$t('app.endpoint.tooltip.endpoint_examples')"
     persistent
     @save="addInstance"
   >
-    <template #title>
-      <span class="focus--text">{{ $t('app.general.title.add_printer') }}</span>
-      <v-spacer />
-      <app-inline-help bottom>
-        <span v-html="$t('app.endpoint.tooltip.endpoint_examples')" />
-      </app-inline-help>
-    </template>
-
     <v-card-text>
       <span v-html="helpTxt" />
 

--- a/src/components/common/PeripheralsDialog.vue
+++ b/src/components/common/PeripheralsDialog.vue
@@ -51,7 +51,7 @@
       </v-tooltip>
     </v-toolbar>
 
-    <v-card-text>
+    <v-card-text class="fill-height">
       <v-tabs-items
         v-model="tab"
         touchless

--- a/src/components/common/ScrewsTiltAdjustDialog.vue
+++ b/src/components/common/ScrewsTiltAdjustDialog.vue
@@ -5,7 +5,7 @@
     max-width="500"
     @save="retry"
   >
-    <div class="overflow-y-auto">
+    <v-card-text class="pa-0">
       <v-simple-table>
         <thead>
           <tr>
@@ -54,7 +54,7 @@
           </tr>
         </tbody>
       </v-simple-table>
-    </div>
+    </v-card-text>
 
     <template #actions>
       <v-spacer />

--- a/src/components/settings/auth/UserConfigDialog.vue
+++ b/src/components/settings/auth/UserConfigDialog.vue
@@ -6,7 +6,7 @@
     max-width="500"
     @save="handleSave"
   >
-    <div class="overflow-y-auto">
+    <v-card-text class="pa-0">
       <app-setting :title="$t('app.general.label.name')">
         <v-text-field
           v-model="user.username"
@@ -42,7 +42,7 @@
           ]"
         />
       </app-setting>
-    </div>
+    </v-card-text>
   </app-dialog>
 </template>
 

--- a/src/components/settings/auth/UserPasswordDialog.vue
+++ b/src/components/settings/auth/UserPasswordDialog.vue
@@ -7,19 +7,18 @@
     max-width="500"
     @save="handleSave"
   >
-    <div class="overflow-y-auto">
-      <v-card-text
-        v-if="error"
-        class="mb-0"
-      >
+    <v-card-text class="pa-0">
+      <template v-if="error">
         <v-alert
           type="error"
           text
-          class="mb-0"
+          class="mx-4 mt-4"
         >
           {{ $t('app.general.msg.wrong_password') }}
         </v-alert>
-      </v-card-text>
+
+        <v-divider />
+      </template>
 
       <app-setting :title="$t('app.general.label.current_password')">
         <v-text-field
@@ -54,7 +53,7 @@
           ]"
         />
       </app-setting>
-    </div>
+    </v-card-text>
   </app-dialog>
 </template>
 

--- a/src/components/settings/cameras/CameraConfigDialog.vue
+++ b/src/components/settings/cameras/CameraConfigDialog.vue
@@ -8,7 +8,7 @@
     :no-actions="camera.source === 'config'"
     @save="handleSave"
   >
-    <div class="overflow-y-auto">
+    <v-card-text class="pa-0">
       <app-setting :title="$t('app.setting.label.enable')">
         <v-switch
           v-model="camera.enabled"
@@ -187,7 +187,7 @@
           />
         </app-setting>
       </template>
-    </div>
+    </v-card-text>
   </app-dialog>
 </template>
 

--- a/src/components/settings/console/ConsoleFilterDialog.vue
+++ b/src/components/settings/console/ConsoleFilterDialog.vue
@@ -5,7 +5,7 @@
     max-width="500"
     @save="handleSave"
   >
-    <div class="overflow-y-auto">
+    <v-card-text class="pa-0">
       <app-setting
         :title="$t('app.setting.label.enable')"
         :r-cols="8"
@@ -73,7 +73,7 @@
           ]"
         />
       </app-setting>
-    </div>
+    </v-card-text>
   </app-dialog>
 </template>
 

--- a/src/components/settings/macros/MacroSettingsDialog.vue
+++ b/src/components/settings/macros/MacroSettingsDialog.vue
@@ -7,7 +7,7 @@
     max-width="480"
     @save="handleSave"
   >
-    <div class="overflow-y-auto">
+    <v-card-text class="pa-0">
       <app-setting
         :title="$t('app.general.label.alias')"
       >
@@ -95,7 +95,7 @@
           hide-details
         />
       </app-setting>
-    </div>
+    </v-card-text>
   </app-dialog>
 </template>
 

--- a/src/components/settings/presets/PresetDialog.vue
+++ b/src/components/settings/presets/PresetDialog.vue
@@ -6,7 +6,7 @@
     :save-button-text="(preset.id !== -1) ? $t('app.general.btn.save') : $t('app.general.btn.add')"
     @save="handleSave"
   >
-    <div class="overflow-y-auto">
+    <v-card-text class="pa-0">
       <app-setting :title="$t('app.setting.label.thermal_preset_name')">
         <v-text-field
           v-model="preset.name"
@@ -21,12 +21,10 @@
 
       <v-divider />
 
-      <template
-        v-for="(item, i) in heaters"
-      >
+      <template v-for="(item, i) in heaters">
         <app-setting
           :key="`${i}heater`"
-          :title="item.name"
+          :title="$filters.startCase(item.name)"
         >
           <v-checkbox
             v-model="preset.values[item.name].active"
@@ -52,12 +50,10 @@
         <v-divider :key="i + 'heaterd'" />
       </template>
 
-      <template
-        v-for="(item, i) in fans"
-      >
+      <template v-for="(item, i) in fans">
         <app-setting
           :key="`${i}fan`"
-          :title="item.name"
+          :title="$filters.startCase(item.name)"
         >
           <v-checkbox
             v-model="preset.values[item.name].active"
@@ -93,7 +89,7 @@
           class="console-command"
         />
       </app-setting>
-    </div>
+    </v-card-text>
   </app-dialog>
 </template>
 

--- a/src/components/ui/AppDialog.vue
+++ b/src/components/ui/AppDialog.vue
@@ -3,6 +3,8 @@
     v-model="open"
     :scrollable="scrollable"
     v-bind="$attrs"
+    :fullscreen="isMobileViewport"
+    :transition="isMobileViewport ? 'dialog-bottom-transition' : undefined"
   >
     <v-form
       ref="form"
@@ -24,6 +26,19 @@
           <slot name="title">
             <span class="focus--text">{{ title }}</span>
           </slot>
+
+          <v-spacer />
+
+          <v-btn
+            fab
+            text
+            x-small
+            @click="open = false"
+          >
+            <v-icon>
+              $close
+            </v-icon>
+          </v-btn>
         </v-card-title>
 
         <v-card-subtitle
@@ -71,11 +86,12 @@
 </template>
 
 <script lang="ts">
+import BrowserMixin from '@/mixins/browser'
 import type { VForm } from '@/types'
-import { Component, Vue, Prop, VModel, Ref, PropSync } from 'vue-property-decorator'
+import { Component, Prop, VModel, Ref, PropSync, Mixins } from 'vue-property-decorator'
 
 @Component({})
-export default class AppDialog extends Vue {
+export default class AppDialog extends Mixins(BrowserMixin) {
   @VModel({ type: Boolean })
     open?: boolean
 

--- a/src/components/ui/AppDialog.vue
+++ b/src/components/ui/AppDialog.vue
@@ -23,22 +23,49 @@
             'collapsable-card-title': titleShadow
           }"
         >
-          <slot name="title">
-            <span class="focus--text">{{ title }}</span>
-          </slot>
-
-          <v-spacer />
-
-          <v-btn
-            fab
-            text
-            x-small
-            @click="open = false"
+          <v-row
+            no-gutters
+            class="flex-nowrap"
           >
-            <v-icon>
-              $close
-            </v-icon>
-          </v-btn>
+            <v-col
+              align-self="center"
+              class="text-no-wrap"
+            >
+              <slot name="title">
+                <span class="focus--text">{{ title }}</span>
+                <app-inline-help
+                  v-if="helpTooltip"
+                  bottom
+                  small
+                  :tooltip="helpTooltip"
+                />
+              </slot>
+            </v-col>
+
+            <v-col
+              cols="auto"
+              align-self="center"
+            >
+              <slot name="menu" />
+            </v-col>
+
+            <v-col
+              cols="auto"
+              align-self="center"
+            >
+              <v-btn
+                fab
+                text
+                x-small
+                class="ml-1"
+                @click="open = false"
+              >
+                <v-icon>
+                  $close
+                </v-icon>
+              </v-btn>
+            </v-col>
+          </v-row>
         </v-card-title>
 
         <v-card-subtitle
@@ -100,6 +127,9 @@ export default class AppDialog extends Mixins(BrowserMixin) {
 
   @Prop({ type: String })
   readonly title?: string
+
+  @Prop({ type: String })
+  readonly helpTooltip?: string
 
   @Prop({ type: String })
   readonly subTitle?: string

--- a/src/components/ui/AppSetting.vue
+++ b/src/components/ui/AppSetting.vue
@@ -109,6 +109,10 @@ export default class AppSetting extends Vue {
     padding-right: 12px;
   }
 
+  .col.setting-title {
+    font-size: initial;
+  }
+
   .col.setting-title > .setting-sub-title {
     font-size: 0.875rem;
   }

--- a/src/components/ui/AppSetting.vue
+++ b/src/components/ui/AppSetting.vue
@@ -2,18 +2,24 @@
   <v-row
     no-gutters
     v-bind="$attrs"
-    :class="classes"
-    class="setting"
+    :class="{
+      'sc-link': hasClick
+    }"
+    class="app-setting-control"
     v-on="$listeners"
   >
     <div
-      v-if="accentColor && accentColor !== ''"
-      :style="`background-color: ${accentColor};`"
-      class="setting__accent-color"
+      v-if="accentColor"
+      :style="{
+        'background-color': accentColor
+      }"
+      class="sc-color"
     />
+
     <v-col
-      :cols="cols[0]"
-      class="setting-title"
+      cols="12"
+      :sm="cols[0]"
+      class="sc-label text-body-1 pr-0 pr-sm-3 pb-0 pb-sm-3"
       align-self="center"
     >
       <slot name="title">
@@ -21,16 +27,18 @@
       </slot>
       <div
         v-if="hasSubTitle"
-        class="setting-sub-title secondary--text"
+        class="text-body-2 secondary--text"
       >
         <slot name="sub-title">
           {{ subTitle }}
         </slot>
       </div>
     </v-col>
+
     <v-col
-      :cols="cols[1]"
-      class="setting-controls"
+      cols="12"
+      :sm="cols[1]"
+      class="sc-content py-3"
       align-self="center"
     >
       <slot />
@@ -73,89 +81,62 @@ export default class AppSetting extends Vue {
       this.subTitle
     )
   }
-
-  get classes () {
-    return {
-      setting__link: this.hasClick
-    }
-  }
 }
 </script>
 
 <style lang="scss" scoped>
-  .setting {
-    // align-items: center;
+  .app-setting-control {
     display: flex;
     flex: 1 1 100%;
-    letter-spacing: normal;
     min-height: 48px;
     outline: none;
     padding: 0 16px;
     position: relative;
     text-decoration: none;
-  }
 
-  .setting > .col {
-    padding: 12px 0;
-  }
+    &.sc-link {
+      cursor: pointer;
+      user-select: none;
+    }
 
-  .col.setting-title {
-    // display: flex;
-    // flex: 0 1 auto;
-    // justify-content: space-between;
-    // align-items: center;
-    padding-top: 12px;
-    padding-bottom: 12px;
-    padding-right: 12px;
-  }
+    &.sc-link:hover::before {
+      opacity: 0.08;
+    }
 
-  .col.setting-title {
-    font-size: initial;
-  }
+    &.sc-link::before {
+      background-color: currentColor;
+      bottom: 0;
+      content: "";
+      left: 0;
+      opacity: 0;
+      pointer-events: none;
+      position: absolute;
+      right: 0;
+      top: 0;
+      transition: 0.3s cubic-bezier(0.25, 0.8, 0.5, 1);
+    }
 
-  .col.setting-title > .setting-sub-title {
-    font-size: 0.875rem;
-  }
+    .sc-accent {
+      display: block;
+      position: absolute;
+      left: 0;
+      width: 3px;
+      height: 100%;
+    }
 
-  .setting__link {
-    cursor: pointer;
-    user-select: none;
-  }
+    .sc-label {
+      padding: 12px 0;
+    }
 
-  .setting__link:hover::before {
-    opacity: 0.08;
-  }
+    .sc-content {
+      display: inline-flex;
+      align-self: center;
+      justify-content: flex-end;
+      align-items: center;
+    }
 
-  .setting__link::before {
-    background-color: currentColor;
-    bottom: 0;
-    content: "";
-    left: 0;
-    opacity: 0;
-    pointer-events: none;
-    position: absolute;
-    right: 0;
-    top: 0;
-    transition: 0.3s cubic-bezier(0.25, 0.8, 0.5, 1);
-  }
-
-  .setting__accent-color {
-    display: block;
-    position: absolute;
-    left: 0;
-    width: 3px;
-    height: 100%;
-    // border-radius: 6px 0 0 6px;
- }
-
-  .setting-controls {
-    display: inline-flex;
-    align-self: center;
-    justify-content: flex-end;
-    align-items: center;
-  }
-
-  .setting-controls .v-input {
-    margin: 0 !important;
+    .sc-content .v-input {
+      margin: 0 !important;
+    }
   }
 </style>

--- a/src/components/widgets/diagnostics/DiagnosticsCardConfigDialog.vue
+++ b/src/components/widgets/diagnostics/DiagnosticsCardConfigDialog.vue
@@ -45,6 +45,8 @@
     </v-card-text>
 
     <template #actions>
+      <v-spacer v-if="isMobileViewport" />
+
       <app-btn
         v-if="config.id !== ''"
         color="error"
@@ -54,7 +56,7 @@
         {{ $t('app.general.btn.remove') }}
       </app-btn>
 
-      <v-spacer />
+      <v-spacer v-if="!isMobileViewport" />
 
       <app-btn
         color="warning"
@@ -74,14 +76,15 @@
 </template>
 
 <script lang="ts">
-import { Component, Vue, Prop, VModel } from 'vue-property-decorator'
+import { Component, Prop, VModel, Mixins } from 'vue-property-decorator'
 import type { DiagnosticsCardConfig } from '@/store/diagnostics/types'
 import CardConfigStep from './config/CardConfigStep.vue'
 import AxesConfigStep from './config/AxesConfigStep.vue'
 import MetricsConfigStep from './config/MetricsConfigStep.vue'
+import BrowserMixin from '@/mixins/browser'
 
 @Component({})
-export default class DiagnosticsCardConfigDialog extends Vue {
+export default class DiagnosticsCardConfigDialog extends Mixins(BrowserMixin) {
   @VModel({ type: Boolean })
     open?: boolean
 

--- a/src/components/widgets/filesystem/FileSystemToolbar.vue
+++ b/src/components/widgets/filesystem/FileSystemToolbar.vue
@@ -140,7 +140,7 @@
       v-if="roots && roots.length > 1"
       #extension
     >
-      <v-tabs>
+      <v-tabs show-arrows>
         <v-tab
           v-for="(root, index) in roots"
           :key="index"

--- a/src/components/widgets/spoolman/SpoolSelectionDialog.vue
+++ b/src/components/widgets/spoolman/SpoolSelectionDialog.vue
@@ -3,15 +3,10 @@
     v-model="open"
     scrollable
     :max-width="isMobileViewport ? '90vw' : '75vw'"
+    :title="$tc('app.spoolman.title.spool_selection', targetMacro ? 2 : 1, { macro: targetMacro })"
     title-shadow
   >
-    <template #title>
-      <span class="focus--text">
-        {{ $tc('app.spoolman.title.spool_selection', targetMacro ? 2 : 1, { macro: targetMacro }) }}
-      </span>
-
-      <v-spacer />
-
+    <template #menu>
       <v-menu
         v-if="availableCameras.length > 1"
         left
@@ -97,7 +92,7 @@
       />
     </v-toolbar>
 
-    <v-card-text class="pt-0">
+    <v-card-text class="fill-height pt-0">
       <v-data-table
         :items="availableSpools"
         :headers="visibleHeaders"
@@ -160,21 +155,20 @@
     </v-card-text>
 
     <template #actions>
+      <v-spacer v-if="isMobileViewport" />
+
       <app-btn
         v-if="spoolmanURL"
         :href="spoolmanURL"
         target="_blank"
+        color="primary"
+        text
+        type="button"
       >
-        <v-icon
-          small
-          class="mr-2"
-        >
-          $edit
-        </v-icon>
-        {{ isMobileViewport ? '' : $tc('app.spoolman.btn.manage_spools') }}
+        {{ $t('app.spoolman.btn.manage_spools') }}
       </app-btn>
 
-      <v-spacer />
+      <v-spacer v-if="!isMobileViewport" />
 
       <app-btn
         text
@@ -187,9 +181,6 @@
         color="primary"
         @click="handleSelectSpool"
       >
-        <v-icon class="mr-2">
-          {{ filename ? '$printer' : '$send' }}
-        </v-icon>
         {{ filename ? $t('app.general.btn.print') : $tc('app.spoolman.btn.select', targetMacro ? 2 : 1, { macro: targetMacro }) }}
       </app-btn>
     </template>

--- a/src/components/widgets/status/PauseAtLayerDialog.vue
+++ b/src/components/widgets/status/PauseAtLayerDialog.vue
@@ -6,7 +6,7 @@
     :save-button-text="$t('app.general.btn.accept')"
     @save="sendAccept"
   >
-    <div class="overflow-y-auto">
+    <v-card-text class="pa-0">
       <template v-if="setPauseNextLayerMacro">
         <app-setting :title="$t('app.general.label.pause_at_next_layer')">
           <v-switch
@@ -74,7 +74,7 @@
           </app-setting>
         </template>
       </template>
-    </div>
+    </v-card-text>
   </app-dialog>
 </template>
 

--- a/src/components/widgets/system/McuInformationDialog.vue
+++ b/src/components/widgets/system/McuInformationDialog.vue
@@ -5,7 +5,7 @@
     max-width="500"
     no-actions
   >
-    <div class="overflow-y-auto">
+    <v-card-text class="pa-0">
       <v-card flat>
         <v-card-title>{{ $t('app.system_info.label.constants') }}</v-card-title>
 
@@ -37,7 +37,7 @@
           </tbody>
         </v-simple-table>
       </v-card>
-    </div>
+    </v-card-text>
   </app-dialog>
 </template>
 

--- a/src/components/widgets/timelapse/TimelapseRenderSettingsDialog.vue
+++ b/src/components/widgets/timelapse/TimelapseRenderSettingsDialog.vue
@@ -5,7 +5,7 @@
     max-width="640"
     :no-actions="!renderable"
   >
-    <div class="overflow-y-auto">
+    <v-card-text class="pa-0">
       <app-setting
         :title="$t('app.timelapse.setting.variable_fps')"
         :sub-title="subtitleIfBlocked(variableFpsBlocked)"
@@ -180,7 +180,7 @@
           @click.native.stop
         />
       </app-setting>
-    </div>
+    </v-card-text>
 
     <template #actions>
       <v-spacer />


### PR DESCRIPTION
Improves layout in small screens:

- dialogs will be shown in full-screen.
- setting entries will break in 2 lines (title + content)

This will fix the problem with large dialogs (one can now scroll without affecting the background) and dismiss without a button (a close button is now shown on all dialogs).

## Settings page

Before | After
--- | ---
![image](https://github.com/fluidd-core/fluidd/assets/85504/770f4416-9de5-470c-aa0f-c3c4e0b27234) | ![image](https://github.com/fluidd-core/fluidd/assets/85504/9152b5ce-a151-48d4-a79b-4b8698b5b4fc)

## Add User dialog

Before | After
--- | ---
![image](https://github.com/fluidd-core/fluidd/assets/85504/2f397a80-055f-4364-b97b-b59e5b9527a0) | ![image](https://github.com/fluidd-core/fluidd/assets/85504/c0a62821-02da-4955-aebd-97db6174ee20)

## Bed Screws Adjust dialog

Before | After
--- | ---
![image](https://github.com/fluidd-core/fluidd/assets/85504/569a8516-8b6f-4090-8f0e-bfa689034267) | ![image](https://github.com/fluidd-core/fluidd/assets/85504/16f9912f-a17c-4c26-abcf-78940689664f)

## Add Camera dialog

Before | After
--- | ---
![image](https://github.com/fluidd-core/fluidd/assets/85504/0f646c79-fe0c-4908-b79b-fe0ff7c7c437) | ![image](https://github.com/fluidd-core/fluidd/assets/85504/273c9844-f7b8-44d2-8117-9bd65c859a2d)

## Spool Selection dialog

Before | After
--- | ---
![image](https://github.com/fluidd-core/fluidd/assets/85504/89d6b4cd-38e7-4178-931c-1d9585cb90fb) | ![image](https://github.com/fluidd-core/fluidd/assets/85504/056b11e8-c41d-4b14-a863-d2ef09a57006)

Before | After
--- | ---
![image](https://github.com/fluidd-core/fluidd/assets/85504/8c055b40-8765-4435-801b-2dea054edcdf) | ![image](https://github.com/fluidd-core/fluidd/assets/85504/ee99dc3f-0ab2-458d-932c-10a9a1e4de85)