### PR TITLE
fix: use Klipper can_extrude by default

### DIFF
--- a/src/mixins/toolhead.ts
+++ b/src/mixins/toolhead.ts
@@ -20,8 +20,13 @@ export default class ToolheadMixin extends Vue {
     const activeExtruder = this.activeExtruder
 
     return (
-      activeExtruder !== undefined &&
-      activeExtruder.temperature >= activeExtruder.min_extrude_temp
+      activeExtruder?.can_extrude ??
+      (
+        activeExtruder !== undefined &&
+        activeExtruder.temperature >= 0 &&
+        activeExtruder.min_extrude_temp >= 0 &&
+        activeExtruder.temperature >= activeExtruder.min_extrude_temp
+      )
     )
   }
 

--- a/src/mixins/toolhead.ts
+++ b/src/mixins/toolhead.ts
@@ -21,8 +21,6 @@ export default class ToolheadMixin extends Vue {
 
     return (
       activeExtruder !== undefined &&
-      activeExtruder.temperature >= 0 &&
-      activeExtruder.min_extrude_temp >= 0 &&
       activeExtruder.temperature >= activeExtruder.min_extrude_temp
     )
   }


### PR DESCRIPTION
<!---
Thank you for contributing to Fluidd.  Before creating your pull request please review the [contributing guidelines](https://github.com/fluidd-core/fluidd/blob/master/CONTRIBUTING.md).

Be sure that every commit in it contains a footer with your real name and a reachable email address.

Alternatively, please add your real name and a reachable email address in the footer of this Pull Request.

Your signature acknowledges that you accept the [developer certificate of origin](https://github.com/fluidd-core/fluidd/blob/master/developer-certificate-of-origin).
--->

Current conditions disabled extrusion controls on Fluidd if the klipper min_extrude_temp protection is set to a sub-zero temp.


For some context, I'm working on a ceramic printer, that does not have any heater nor thermistor on the hotend. The quick and easy way to disable any temp-related security on klipper is to set min_extrude_temp to -273.15, so that any temp detected by a connected (or in my case disconnected) thermistor won't prevent the extrusion.

While this works as expected with klipper (sending `G1 E10` does extrude), the extrusion controls on fluidd are disabled with this cheeky message: 
![image](https://github.com/fluidd-core/fluidd/assets/999188/a58287de-b466-4ee2-8efe-4b342576f94e)



Note: I haven't looked at how min_extrude_temp is fetched by fluidd, maybe a value of 0 has a special meaning (i.e. a default value when undefined / could not be fetched?)