### PR TITLE
feat: print progress estimation improvements

### DIFF
--- a/src/components/settings/GeneralSettings.vue
+++ b/src/components/settings/GeneralSettings.vue
@@ -464,11 +464,19 @@ export default class GeneralSettings extends Mixins(StateMixin) {
     return [
       {
         value: 'file',
-        text: this.$t('app.setting.timer_options.file')
+        text: this.$t('app.setting.timer_options.relative_file_position')
+      },
+      {
+        value: 'fileAbsolute',
+        text: this.$t('app.setting.timer_options.absolute_file_position')
       },
       {
         value: 'slicer',
         text: this.$t('app.setting.timer_options.slicer_m73')
+      },
+      {
+        value: 'filament',
+        text: this.$t('app.setting.timer_options.filament')
       }
     ]
   }

--- a/src/locales/de.yaml
+++ b/src/locales/de.yaml
@@ -662,8 +662,8 @@ app:
       print_progress_calculation: Druckfortschritt-Berechnung
     timer_options:
       duration: Nur Dauer
-      filament: Filament-Schätzung
-      file: Datei-Schätzung
+      filament: Filament
+      file: Datei
       slicer: Slicer
       slicer_m73: Slicer (M73)
     title:

--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -634,9 +634,11 @@ app:
       show_bed_screws_adjust_dialog_automatically: Show Bed Screws Adjust dialog automatically
       show_screws_tilt_adjust_dialog_automatically: Show Screws Tilt Adjust dialog automatically
     timer_options:
+      absolute_file_position: Absolute file position
       duration: Duration only
-      filament: Filament Estimation
-      file: File Estimation
+      filament: Filament
+      file: File
+      relative_file_position: Relative file position
       slicer: Slicer
       slicer_m73: Slicer (M73)
     title:

--- a/src/locales/tr.yaml
+++ b/src/locales/tr.yaml
@@ -668,8 +668,8 @@ app:
         otomatik olarak göster
     timer_options:
       duration: Süre sadece
-      filament: Filament Tahmini
-      file: Dosya Tahmini
+      filament: Filament
+      file: Dosya
       slicer: Dilimleyici
       slicer_m73: Dilimleyici (M73)
     title:

--- a/src/store/config/types.ts
+++ b/src/store/config/types.ts
@@ -115,7 +115,7 @@ export type PrintInProgressLayout = 'default' | 'compact'
 
 export type ColorPickerValueRange = 'absolute' | 'percentage'
 
-export type PrintProgressCalculation = 'file' | 'slicer'
+export type PrintProgressCalculation = 'file' | 'fileAbsolute' | 'slicer' | 'filament'
 
 export type PrintEtaCalculation = 'file' | 'slicer'
 

--- a/src/store/printer/getters.ts
+++ b/src/store/printer/getters.ts
@@ -128,7 +128,7 @@ export const getters: GetterTree<PrinterState, RootState> = {
 
     const fullFilename = path ? `${path}/${filename}` : filename
 
-    if (filament_used && filament_total && fullFilename === statsFilename) {
+    if (filament_used != null && filament_total && fullFilename === statsFilename) {
       return filament_used / filament_total
     }
 


### PR DESCRIPTION
- Restores the filament estimation calculation code
- Allows selection of absolute file position progress (`virtual_sdcard.progress` from Klipper)
- If relative file position progress selected and not available, fallback to `virtual_sdcard.progress`