### PR TITLE
fix(gcodepreview): ignore moves without coordinates

### DIFF
--- a/src/components/widgets/gcode-preview/GcodePreview.vue
+++ b/src/components/widgets/gcode-preview/GcodePreview.vue
@@ -210,7 +210,7 @@
           </g>
 
           <g
-            v-if="getViewerOption('showRetractions') && svgPathCurrent.retractions.length > 0"
+            v-if="getViewerOption('showRetractions') && svgPathCurrent.extrusionStarts.length > 0"
             id="extrusionStarts"
           >
             <use

--- a/src/workers/parseGcode.ts
+++ b/src/workers/parseGcode.ts
@@ -120,27 +120,35 @@ const parseGcode = (gcode: string, sendProgress: (filePosition: number) => void)
     } else if (type === 'gcode') {
       switch (command) {
         case 'G0':
-        case 'G1':
-          move = {
-            ...pick(args, [
-              'x', 'y', 'z', 'e'
-            ]),
-            filePosition: toolhead.filePosition
-          } satisfies LinearMove
+        case 'G1': {
+          const values = pick(args, [
+            'x', 'y', 'z', 'e'
+          ])
+          if (Object.keys(values).length) {
+            move = {
+              ...values,
+              filePosition: toolhead.filePosition
+            } satisfies LinearMove
+          }
           break
+        }
         case 'G2':
-        case 'G3':
-          move = {
-            ...pick(args, [
-              'x', 'y', 'z', 'e',
-              'i', 'j', 'k', 'r'
-            ]),
-            direction: command === 'G2'
-              ? 'clockwise'
-              : 'counter-clockwise',
-            filePosition: toolhead.filePosition
-          } satisfies ArcMove
+        case 'G3': {
+          const values = pick(args, [
+            'x', 'y', 'z', 'e',
+            'i', 'j', 'k', 'r'
+          ])
+          if (Object.keys(values).length) {
+            move = {
+              ...values,
+              direction: command === 'G2'
+                ? 'clockwise'
+                : 'counter-clockwise',
+              filePosition: toolhead.filePosition
+            } satisfies ArcMove
+          }
           break
+        }
         case 'G10':
           move = {
             e: -fwretraction.length,


### PR DESCRIPTION
I've noticed that some files sliced by Orca Slicer have G0/G1 commands without any X, Y, Z, or E change.

Though I am not sure why these commands exist, the fact is that this introduced a bug on the Gcode Previewer, where these moves would cause extra extrusion markers to apper.

The fix here is to ignore any G0/G1/G2/G3 command that does not include at least one of the necessary coordinates change arguments.

This also includes a minor fix for the previewer code where `retractions` where incorrectly being checked for `extrusions`.

## Before

![image](https://github.com/fluidd-core/fluidd/assets/85504/11b5bca6-ecee-4fa9-8eff-0fc8b5a2d3bc)

## After

![image](https://github.com/fluidd-core/fluidd/assets/85504/1efbb93a-fa23-4ed4-b955-a9fb621ac33f)
