### PR TITLE
feat: show all fan and pin values as percentages

### DIFF
--- a/src/components/ui/AppNamedSwitch.vue
+++ b/src/components/ui/AppNamedSwitch.vue
@@ -12,6 +12,8 @@
       v-model="inputValue"
       class="mt-0"
       :disabled="disabled || loading"
+      :true-value="trueValue"
+      :false-value="falseValue"
       hide-details
       v-on="$listeners"
     />
@@ -34,5 +36,11 @@ export default class AppNamedSwitch extends Vue {
 
   @Prop({ type: Boolean })
   readonly loading?: boolean
+
+  @Prop({ })
+  readonly trueValue?: unknown
+
+  @Prop({ })
+  readonly falseValue?: unknown
 }
 </script>

--- a/src/components/widgets/outputs/OutputFan.vue
+++ b/src/components/widgets/outputs/OutputFan.vue
@@ -52,7 +52,7 @@ export default class OutputFan extends Mixins(StateMixin, BrowserMixin) {
   get prettyValue () {
     return (this.value === 0)
       ? this.$t('app.general.label.off')
-      : this.$t('app.general.label.on')
+      : `${this.value} %`
   }
 
   get value () {

--- a/src/components/widgets/outputs/OutputPin.vue
+++ b/src/components/widgets/outputs/OutputPin.vue
@@ -2,12 +2,12 @@
   <div>
     <app-named-slider
       v-if="pwm"
+      suffix="%"
       :label="pin.prettyName"
       :min="0"
-      :max="pin.scale"
-      :step="0.01"
+      :max="100"
       :value="value"
-      :reset-value="pin.config.value || 0"
+      :reset-value="resetValue"
       :disabled="!klippyReady"
       :locked="isMobileViewport"
       :loading="hasWait(`${$waits.onSetOutputPin}${pin.name}`)"
@@ -51,14 +51,20 @@ export default class OutputPin extends Mixins(StateMixin, BrowserMixin) {
   }
 
   get value () {
-    return Math.round(this.pin.value * this.pin.scale * 100) / 100
+    return Math.round(this.pin.value * 100)
   }
 
-  handleChange (target: number) {
-    if (!this.pwm) {
+  get resetValue () {
+    return Math.round(this.pin.resetValue / this.pin.scale * 100)
+  }
+
+  handleChange (target: number | boolean) {
+    if (typeof target === 'boolean') {
       target = target
         ? this.pin.scale
         : 0
+    } else {
+      target = Math.round(target * this.pin.scale) / 100
     }
 
     this.sendGcode(`SET_PIN PIN=${this.pin.name} VALUE=${target}`, `${this.$waits.onSetOutputPin}${this.pin.name}`)

--- a/src/store/printer/getters.ts
+++ b/src/store/printer/getters.ts
@@ -665,9 +665,10 @@ export const getters: GetterTree<PrinterState, RootState> = {
         if (outputPins.includes(type)) {
           output = {
             ...output,
-            pwm: (config && config.pwm) ? config.pwm : false,
-            scale: (config && config.scale) ? config.scale : 1,
-            controllable: (config && config.static_value) ? false : (controllable.includes(type))
+            pwm: config?.pwm ?? false,
+            scale: config?.scale ?? 1,
+            resetValue: config?.value ?? 0,
+            controllable: config?.static_value ? false : controllable.includes(type)
           }
         }
 

--- a/src/store/printer/types.ts
+++ b/src/store/printer/types.ts
@@ -106,17 +106,18 @@ export interface OutputPin extends OutputType<OutputPinConfig> {
   scale: number;
   static: number;
   value: number;
+  resetValue: number;
 }
 
 export interface OutputPinConfig {
-  [index: string]: string | undefined;
-  pwm?: string;
-  static_value?: string;
-  value?: string;
-  shutdown_value?: string;
-  cycle_time?: string;
-  hardware_pwm?: string;
-  scale?: string;
+  [index: string]: string | number | boolean | undefined;
+  pwm?: boolean;
+  static_value?: number;
+  value?: number;
+  shutdown_value?: number;
+  cycle_time?: number;
+  hardware_pwm?: boolean;
+  scale?: number;
 }
 
 export interface Sensor {


### PR DESCRIPTION
Ideally, limited scale values in the front-end should be presented as a percentage instead of the Klipper value - that is for config and console purposes.

The changes in this pull request are as follows:

- non-controllable (read-only) fans and output pins will show "Off" when value is 0, otherwise presents the value on a scale of 0% to 100%.
- controllable pwm output-pins will always present the value on a scale of 0% to 100%.

## Before

![image](https://github.com/fluidd-core/fluidd/assets/85504/4e6f129b-36a1-47f3-8312-4534f3518daa)

## After

![image](https://github.com/fluidd-core/fluidd/assets/85504/f0bb7dd6-1613-4a7c-8d5b-ba60b30482cf)

### Partial test config used for the above:

```ini
[heater_fan heater_fan]
pin: PD4
off_below: 0.2
shutdown_speed: 0.0
max_power: 0.6
fan_speed: 0.85

[output_pin test_pwm_pin]
pin: PD7
pwm: True
value: 0.6
scale: 0.8
cycle_time: 0.1
```