### PR TITLE
feat: use correct stepper temperature label

### DIFF
--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -342,6 +342,8 @@ app:
       edit_category: Edit category
       add_category: Add category
       file_time: File
+      stepper_driver: >-
+        %{name} Driver
     msg:
       password_changed: Password changed
       wrong_password: Oops, something went wrong. Is your password correct?

--- a/src/store/printer/getters.ts
+++ b/src/store/printer/getters.ts
@@ -689,6 +689,9 @@ export const getters: GetterTree<PrinterState, RootState> = {
       'tmc2240',
       'z_thermal_adjust'
     ]
+    const supportedDrivers = [
+      'tmc2240'
+    ]
 
     const sensors = Object.keys(state.printer)
       .reduce((groups, item) => {
@@ -696,7 +699,15 @@ export const getters: GetterTree<PrinterState, RootState> = {
 
         if (supportedSensors.includes(type)) {
           const name = nameFromSplit ?? item
-          const prettyName = Vue.$filters.startCase(name)
+          const prettyName = supportedDrivers.includes(type)
+            ? i18n.t('app.general.label.stepper_driver',
+              {
+                name:
+                  name.startsWith('stepper_')
+                    ? name.substring(8).toUpperCase()
+                    : Vue.$filters.startCase(name)
+              })
+            : Vue.$filters.startCase(name)
           const color = Vue.$colorset.next(getKlipperType(item), item)
           const config = getters.getPrinterSettings(item)
 


### PR DESCRIPTION
When we added support for the TMC2240 stepper drivers back in #1133, these are using the `tmc2240 xxxxxx` for naming, which leads to have "Stepper X" or a 2nd "Extruder" entry on the list, both wrong.

Saying "Stepper X" give the idea that these are the stepper motor temperatures, when in fact these are the stepper motor driver temperatures.

So I propose that we instead show "X Driver" and "Extruder Driver" respectively.

## Before

![image](https://github.com/fluidd-core/fluidd/assets/85504/a6a3a799-2937-4228-a7b4-528050df01e2)

## After

![image](https://github.com/fluidd-core/fluidd/assets/85504/67150f6f-027a-4434-9f0a-cf6e5d67ce90)

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>