### PR TITLE
feat: backup and restore settings

### DIFF
--- a/src/components/layout/AppSettingsNav.vue
+++ b/src/components/layout/AppSettingsNav.vue
@@ -44,7 +44,7 @@ export default class AppSettingsNav extends Vue {
       { name: this.$tc('app.setting.title.camera', 2), hash: '#camera', visible: true },
       { name: this.$t('app.setting.title.tool'), hash: '#toolhead', visible: true },
       { name: this.$t('app.setting.title.thermal_presets'), hash: '#presets', visible: true },
-      { name: this.$t('app.setting.title.gcode_preview'), icon: '$cubeScan', hash: '#gcodePreview', visible: true },
+      { name: this.$t('app.setting.title.gcode_preview'), hash: '#gcodePreview', visible: true },
       { name: this.$t('app.general.title.timelapse'), hash: '#timelapse', visible: this.supportsTimelapse },
       { name: this.$t('app.spoolman.title.spoolman'), hash: '#spoolman', visible: this.supportsSpoolman },
       { name: this.$t('app.version.title'), hash: '#versions', visible: this.supportsVersions }

--- a/src/components/settings/GeneralSettings.vue
+++ b/src/components/settings/GeneralSettings.vue
@@ -577,7 +577,7 @@ export default class GeneralSettings extends Mixins(StateMixin) {
         const link = document.createElement('a')
 
         link.href = `data:text/plain;charset=utf-8,${encodeURIComponent(JSON.stringify(data))}`
-        link.download = 'backup-fluidd.json'
+        link.download = `backup-fluidd-v${import.meta.env.VERSION}-${this.instanceName}.json`
         link.target = '_blank'
 
         document.body.appendChild(link)

--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -503,7 +503,9 @@ app:
       add_metric: Add Metric
       add_thermal_preset: Add Preset
       add_user: Add user
+      backup: Backup
       reset: Reset
+      restore: Restore
       select_theme: Select Theme
     camera_type_options:
       mjpegadaptive: MJPEG Adaptive
@@ -568,6 +570,7 @@ app:
       fill_color: Fill color
       fill_opacity: Fill opacity
       filter: Filter | Filters
+      fluidd_settings_in_moonraker_db: Fluidd settings in Moonraker database
       fps_target: FPS Target
       fps_idle_target: FPS Target when not in focus
       height: Height

--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -356,6 +356,9 @@ app:
       pending_configuration_sections_deleted: The following sections are marked for deletion
       rolledover_logs: >-
         The following application logs have been rolled over: %{applications}
+      not_valid_fluidd_backup_file: Not a valid Fluidd backup file!
+      fluidd_settings_backup_failed: Failed to backup Fluidd settings!
+      fluidd_settings_restore_failed: Failed to restore Fluidd settings!
     simple_form:
       error:
         arrayofnums: Only numbers

--- a/src/util/file-system-entry.ts
+++ b/src/util/file-system-entry.ts
@@ -104,3 +104,14 @@ export const getFilesFromFileSystemEntries = async (entries: readonly FileSystem
 
   return files
 }
+
+export const readFileAsTextAsync = (file: File) => {
+  return new Promise<string>((resolve, reject) => {
+    const reader = new FileReader()
+
+    reader.onload = () => resolve(reader.result as string)
+    reader.onerror = (event) => reject(event)
+
+    reader.readAsText(file, 'UTF8')
+  })
+}

--- a/src/util/fluidd-content.ts
+++ b/src/util/fluidd-content.ts
@@ -1,0 +1,36 @@
+type FluiddContent<T> = {
+  meta: {
+    app: 'Fluidd',
+    version: string,
+    type: string
+  },
+  data: T
+}
+
+export const isFluiddContent = <T>(type: string, content: unknown): content is FluiddContent<T> => {
+  return (
+    content != null &&
+    typeof (content) === 'object' &&
+    'meta' in content &&
+    content.meta != null &&
+    typeof (content.meta) === 'object' &&
+    'app' in content.meta &&
+    typeof (content.meta.app) === 'string' &&
+    content.meta.app === 'Fluidd' &&
+    'type' in content.meta &&
+    typeof (content.meta.type) === 'string' &&
+    content.meta.type === type &&
+    'data' in content
+  )
+}
+
+export const toFluiddContent = <T>(type: string, data: T): FluiddContent<T> => {
+  return {
+    meta: {
+      app: 'Fluidd',
+      version: import.meta.env.VERSION,
+      type
+    },
+    data
+  }
+}


### PR DESCRIPTION
Add a new Backup and Restore buttons to easily export and import Fluidd settings across multiple printers.

As a first implementation, this will backup/restore ALL Fluidd settings (there is no selections of specific parts of the settings).

![image](https://github.com/fluidd-core/fluidd/assets/85504/d0205fbc-b7c7-41ee-ad4f-c4576783a401)

Resolve #1113