### PR TITLE
ci: break release workflow into separate jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,10 +12,6 @@ on:
       - develop
       - master
 
-permissions:
-  id-token: write
-  contents: read
-
 jobs:
   build:
     name: Build
@@ -112,6 +108,9 @@ jobs:
     needs: build
     if: ${{ github.ref == 'refs/heads/develop' }}
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,10 +5,6 @@ on:
     tags:
       - 'v*'
 
-permissions:
-  id-token: write
-  contents: read
-
 jobs:
   build:
     name: Build
@@ -86,6 +82,12 @@ jobs:
           asset_name: fluidd.zip
           asset_content_type: application/zip
 
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: fluidd-${{ github.ref }}.zip
+          path: ./dist
+
       - name: Publish Release
         uses: eregon/publish-release@v1
         env:
@@ -93,9 +95,25 @@ jobs:
         with:
           release_id: ${{ steps.create_release.outputs.id }}
 
+  publish-web:
+    name: Deploy to Host
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download fluidd.zip
+        uses: actions/download-artifact@v4
+        with:
+          name: fluidd-${{ github.ref }}.zip
+          path: ./dist
+
       - name: Prepare Deploy
         run: |
-          rm ./dist/fluidd.zip
           cp ./server/config.json ./dist/config.json
 
       - uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: fluidd-${{ github.ref }}.zip
+          name: fluidd-${{ github.sha }}.zip
           path: ./dist
 
       - name: Publish Release
@@ -109,7 +109,7 @@ jobs:
       - name: Download fluidd.zip
         uses: actions/download-artifact@v4
         with:
-          name: fluidd-${{ github.ref }}.zip
+          name: fluidd-${{ github.sha }}.zip
           path: ./dist
 
       - name: Prepare Deploy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,8 +42,7 @@ jobs:
       - name: Create Artifact
         run: |
           cd ./dist
-          zip -r fluidd.zip ./
-          cd ..
+          zip -r ../fluidd.zip ./
 
       - name: Get version from tag
         id: tag_name
@@ -78,7 +77,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./dist/fluidd.zip
+          asset_path: ./fluidd.zip
           asset_name: fluidd.zip
           asset_content_type: application/zip
 


### PR DESCRIPTION
The PR [#1433](https://github.com/fluidd-core/fluidd/pull/1433) breaks the Docker image upload due to the permission changes added for the OIDC integration.
As discussed over Discord, this PR moves the permissions to the job level. 
To accommodate this, the release action has been split into two jobs.


Signed-off-by: Rogerio Goncalves <rogerlz@gmail.com>