### PR TITLE
feat: hides thermal sensors starting with "_"

### DIFF
--- a/docs/customize/hide_outputs.md
+++ b/docs/customize/hide_outputs.md
@@ -1,18 +1,18 @@
 ---
 layout: default
-title: Hide macros, output pins and fans
+title: Hide macros, output pins, fans and sensors
 parent: Customize
 nav_order: 3
 permalink: /customize/hide
 ---
 
-# Hide macros, output pins and fans
+# Hide macros, output pins, fans and sensors
 {: .no_toc }
 
 ---
 
-Fluidd allows you to hide macros, output pins and fans by prefixing them
-with an underscore (`_`).
+Fluidd allows you to hide macros, output pins, fans and sensors by prefixing
+them with an underscore (`_`).
 
 By doing this - you're removing them from Fluidd. This can be handy in
 situations where you have a large quantiy of macros, or whereby you have an
@@ -29,6 +29,11 @@ gcode:
 ```yaml
 [output_pin _BEEPER]
 pin: z:P1.30
+```
+
+```yaml
+[temperature_sensor _MCU]
+sensor_type: MCU
 ```
 
 Macros can also be hidden directly from the Fluidd settings by toggling their

--- a/src/store/printer/getters.ts
+++ b/src/store/printer/getters.ts
@@ -696,9 +696,9 @@ export const getters: GetterTree<PrinterState, RootState> = {
     const sensors = Object.keys(state.printer)
       .reduce((groups, item) => {
         const [type, nameFromSplit] = item.split(' ', 2)
+        const name = nameFromSplit ?? item
 
-        if (supportedSensors.includes(type)) {
-          const name = nameFromSplit ?? item
+        if (supportedSensors.includes(type) && !name.startsWith('_')) {
           const prettyName = supportedDrivers.includes(type)
             ? i18n.t('app.general.label.stepper_driver',
               {
@@ -775,19 +775,11 @@ export const getters: GetterTree<PrinterState, RootState> = {
       ]
     ]
 
-    const filterByPrefix = [
-      'temperature_fan'
-    ]
-
     const printerKeys = Object.keys(state.printer)
 
     const sensors = keyGroups.flatMap(keyGroup => {
       const keyGroupRegExpArray = keyGroup
-        .map(x => new RegExp(
-          filterByPrefix.includes(x)
-            ? `^${x}(?! _)`
-            : `^${x}`)
-        )
+        .map(x => new RegExp(`^${x}(?! _)`))
 
       return printerKeys
         .filter(key => keyGroupRegExpArray.some(x => x.test(key)))


### PR DESCRIPTION
Automatically hide any temperature sensor (or related item) that starts with "_", just like we already do for macros, output pins and fans.

Resolves #1440