### PR TITLE
feat(spoolman): add remaining filament display unit setting

### DIFF
--- a/src/components/settings/SpoolmanSettings.vue
+++ b/src/components/settings/SpoolmanSettings.vue
@@ -77,6 +77,23 @@
       </app-setting>
 
       <v-divider />
+      <app-setting
+        :title="$tc('app.spoolman.setting.remaining_filament_unit')"
+      >
+        <v-select
+          v-model="remainingFilamentUnit"
+          filled
+          dense
+          single-line
+          hide-details="auto"
+          :items="[
+            {text: $tc('app.spoolman.label.weight'), value: 'weight'},
+            {text: $tc('app.spoolman.label.length'), value: 'length'}
+          ]"
+        />
+      </app-setting>
+
+      <v-divider />
       <app-setting :title="$t('app.setting.label.reset')">
         <app-btn
           outlined
@@ -187,6 +204,18 @@ export default class SpoolmanSettings extends Mixins(StateMixin) {
   set warnOnFilamentTypeMismatch (value: boolean) {
     this.$store.dispatch('config/saveByPath', {
       path: 'uiSettings.spoolman.warnOnFilamentTypeMismatch',
+      value,
+      server: true
+    })
+  }
+
+  get remainingFilamentUnit () {
+    return this.$store.state.config.uiSettings.spoolman.remainingFilamentUnit
+  }
+
+  set remainingFilamentUnit (value: string) {
+    this.$store.dispatch('config/saveByPath', {
+      path: 'uiSettings.spoolman.remainingFilamentUnit',
       value,
       server: true
     })

--- a/src/components/widgets/spoolman/SpoolSelectionDialog.vue
+++ b/src/components/widgets/spoolman/SpoolSelectionDialog.vue
@@ -129,9 +129,13 @@
                     {{ item.filament_name }}
                   </div>
                   <div class="flex-row">
-                    <small>
+                    <small v-if="remainingFilamentUnit === 'weight'">
                       <b>{{ $filters.getReadableWeightString(item.remaining_weight) }}</b>
                       / {{ $filters.getReadableWeightString(item.filament.weight) }}
+                    </small>
+                    <small v-else-if="remainingFilamentUnit === 'length'">
+                      <b>{{ $filters.getReadableLengthString(item.remaining_length) }}</b>
+                      / {{ $filters.getReadableLengthString($filters.convertFilamentWeightToLength(item.filament.weight ?? 0, item.filament.density, item.filament.diameter)) }}
                     </small>
                   </div>
                 </div>
@@ -359,6 +363,10 @@ export default class SpoolSelectionDialog extends Mixins(StateMixin, BrowserMixi
     return cameras
   }
 
+  get remainingFilamentUnit () {
+    return this.$store.state.config.uiSettings.spoolman.remainingFilamentUnit
+  }
+
   handleQRCodeDetected (id: number) {
     this.cameraScanSource = null
     this.selectedSpoolId = id
@@ -465,8 +473,7 @@ export default class SpoolSelectionDialog extends Mixins(StateMixin, BrowserMixi
         if (this.warnOnNotEnoughFilament) {
           let remainingLength = spool.remaining_length
           if (!remainingLength && spool.remaining_weight) {
-            // l[mm] = m[g]/D[g/cm³]/A[mm²]*(1000mm³/cm³)
-            remainingLength = spool.remaining_weight / spool.filament.density / (Math.PI * (spool.filament.diameter / 2) ** 2) * 1000
+            remainingLength = this.$filters.convertFilamentWeightToLength(spool.remaining_weight, spool.filament.density, spool.filament.diameter)
           }
 
           if (typeof remainingLength === 'number' && requiredLength >= remainingLength) {

--- a/src/components/widgets/spoolman/SpoolmanCard.vue
+++ b/src/components/widgets/spoolman/SpoolmanCard.vue
@@ -117,9 +117,13 @@
               :label="$t('app.spoolman.label.remaining_weight')"
               :label-width="labelWidth"
             >
-              <span>
+              <span v-if="remainingFilamentUnit === 'weight'">
                 {{ $filters.getReadableWeightString(activeSpool.remaining_weight) }}
                 <small>/ {{ $filters.getReadableWeightString(activeSpool.filament.weight) }}</small>
+              </span>
+              <span v-else-if="remainingFilamentUnit === 'length'">
+                {{ $filters.getReadableLengthString(activeSpool.remaining_length) }}
+                <small>/ {{ $filters.getReadableLengthString($filters.convertFilamentWeightToLength(activeSpool.filament.weight ?? 0, activeSpool.filament.density, activeSpool.filament.diameter)) }}</small>
               </span>
             </status-label>
             <status-label
@@ -245,6 +249,10 @@ export default class SpoolmanCard extends Mixins(StateMixin) {
         name: macro.name.toUpperCase()
       }))
       .sort((a, b) => a.name.localeCompare(b.name))
+  }
+
+  get remainingFilamentUnit () {
+    return this.$store.state.config.uiSettings.spoolman.remainingFilamentUnit
   }
 
   getSpoolById (id: number): Spool | undefined {

--- a/src/locales/de.yaml
+++ b/src/locales/de.yaml
@@ -756,7 +756,7 @@ app:
         suchen
       canbus_warning: Nur unzugewiesene CAN-Bus-Knoten werden erkannt.<br>Es ist empfohlen,
         nur ein unzugewiesenes Gerät an den CAN-Bus anzuschließen, um Kommunikationsprobleme
-        zu vermeiden.<br>Mehr Informationen finden Sie <a target="_blank" 
+        zu vermeiden.<br>Mehr Informationen finden Sie <a target="_blank"
         href="https://moonraker.readthedocs.io/en/latest/web_api/#query-unassigned-canbus-uuids">hier.</a>
   tool:
     btn:
@@ -900,6 +900,8 @@ app:
       remaining_weight: Verbleibend
       vendor: Hersteller
       id: ID
+      weight: Gewicht
+      length: Länge
     msg:
       no_spool: >-
         Sie haben keine Spule ausgewählt.
@@ -948,6 +950,7 @@ app:
       warn_on_filament_type_mismatch: >-
         Warnung anzeigen, wenn der Filamenttyp der Spule nicht mit dem im Slicer ausgewählten
         übereinstimmt
+      remaining_filament_unit: Verbleibendes Filament anzeigen als
   job_queue:
     msg:
       confirm: Sind Sie sicher? Hierdurch wird die gesamte Druckwarteschlange geleert

--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -867,6 +867,8 @@ app:
       material: Material
       remaining_weight: Remaining
       vendor: Vendor
+      weight: Weight
+      length: Length
     msg:
       no_spool: >-
         You haven't selected a spool.
@@ -909,6 +911,7 @@ app:
         Show a warning when the selected spool doesn't have enough filament left on it to finish the print
       warn_on_filament_type_mismatch: >-
         Show a warning when the spool's filament type and the one selected in the slicer don't match
+      remaining_filament_unit: Show remaining filament as
   sensors:
     title:
       sensors: Sensors

--- a/src/plugins/filters.ts
+++ b/src/plugins/filters.ts
@@ -267,7 +267,11 @@ export const Filters = {
   /**
    * Formats a number representing mm to human readable distance.
    */
-  getReadableLengthString (lengthInMm: number, showMicrons = false) {
+  getReadableLengthString (lengthInMm: number | undefined | null, showMicrons = false) {
+    if (lengthInMm === undefined || lengthInMm === null) {
+      return '-'
+    }
+
     if (lengthInMm >= 1000) return (lengthInMm / 1000).toFixed(2) + ' m'
     if (lengthInMm > 100) return (lengthInMm / 10).toFixed(1) + ' cm'
     if (lengthInMm < 0.1 && showMicrons) return (lengthInMm * 1000).toFixed(0) + ' μm'
@@ -424,6 +428,14 @@ export const Filters = {
    */
   routeTo (router: VueRouter, path: string) {
     if (router.currentRoute.fullPath !== path) router.push(path)
+  },
+
+  /**
+   * Converts a given weight (in grams) to its corresponding length (in mm)
+   */
+  convertFilamentWeightToLength (weight: number, density: number, diameter: number) {
+    // l[mm] = m[g]/D[g/cm³]/A[mm²]*(1000mm³/cm³)
+    return weight / density / (Math.PI * (diameter / 2) ** 2) * 1000
   }
 }
 

--- a/src/store/config/state.ts
+++ b/src/store/config/state.ts
@@ -162,7 +162,8 @@ export const defaultState = (): ConfigState => {
         selectionDialogSortOrder: {
           key: 'last_used',
           desc: false
-        }
+        },
+        remainingFilamentUnit: 'weight'
       }
     }
   }

--- a/src/store/config/types.ts
+++ b/src/store/config/types.ts
@@ -40,7 +40,8 @@ export interface SpoolmanConfig {
   selectionDialogSortOrder: {
     key: string | null;
     desc: boolean | null;
-  }
+  },
+  remainingFilamentUnit: 'weight' | 'length'
 }
 
 export interface HostConfig {


### PR DESCRIPTION
Adds a new spoolman setting to select the display unit (weight (g) or length (m)) of the remaining (and total) filament on a spool:

![grafik](https://github.com/fluidd-core/fluidd/assets/25269274/35a12d86-be98-41a7-bd74-d69c4f709d77)


**Weight (default)**
![Screen Shot 2024-06-02 at 13 34 19](https://github.com/fluidd-core/fluidd/assets/25269274/46f1c7a4-2dec-4ada-981a-6ab6bccbcfac)
![Screen Shot 2024-06-02 at 13 34 30](https://github.com/fluidd-core/fluidd/assets/25269274/89a822bf-580e-4255-a82a-fecc8b87e343)


**Length**
![Screen Shot 2024-06-02 at 13 34 46](https://github.com/fluidd-core/fluidd/assets/25269274/5876d0df-b432-4d5f-a0a0-31cfa36e40f4)
![Screen Shot 2024-06-02 at 13 34 56](https://github.com/fluidd-core/fluidd/assets/25269274/69ed32b4-e977-40fa-97e0-0fa785d02930)

---

Closes #1442