### PR TITLE
feat: adds Danger Klipper config support

### DIFF
--- a/src/components/widgets/filesystem/setupMonaco.ts
+++ b/src/components/widgets/filesystem/setupMonaco.ts
@@ -93,7 +93,12 @@ async function setupMonaco () {
   const app = getVueApp()
 
   monaco.editor.registerCommand('fluidd_open_docs', (_, service: CodeLensSupportedService, hash: string) => {
-    const serviceKey = service.replace(/-/g, '_')
+    const serviceKey = (
+      service === 'klipper'
+        ? app.$store.getters['printer/getKlippyApp']
+        : service
+    ).toLowerCase().replace(/-/g, '_')
+
     const url = app.$t(`app.file_system.url.${serviceKey}_config`, { hash }).toString()
 
     window.open(url)

--- a/src/globals.ts
+++ b/src/globals.ts
@@ -227,7 +227,14 @@ export const Globals = Object.freeze({
     { filename: 'mooncord-webcam.json', service: 'webcamd', link: 'https://github.com/eliteSchwein/mooncord' },
     { prefix: 'mooncord', service: 'MoonCord', link: 'https://github.com/eliteSchwein/mooncord' },
     { filename: 'telegram.conf', service: 'moonraker-telegram-bot', link: 'https://github.com/nlef/moonraker-telegram-bot/wiki/Sample-config' },
-    { suffix: '.cfg', service: 'klipper', link: 'https://www.klipper3d.org/Config_Reference.html' }
+    {
+      suffix: '.cfg',
+      service: 'klipper',
+      link: 'https://www.klipper3d.org/Config_Reference.html',
+      linkOverride: {
+        'danger-klipper': 'https://dangerklipper.io/Config_Reference.html'
+      }
+    }
   ],
   FILE_DATA_TRANSFER_TYPES: {
     files: 'x-fluidd-files',

--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -111,6 +111,7 @@ app:
       root_disabled: '{root} root is not available. Please check your logs.'
     url:
       klipper_config: 'https://www.klipper3d.org/Config_Reference.html#%{hash}'
+      danger_klipper_config: 'https://dangerklipper.io/Config_Reference.html#%{hash}'
       moonraker_config: 'https://moonraker.readthedocs.io/en/latest/configuration/#%{hash}'
       moonraker_telegram_bot_config: 'https://github.com/nlef/moonraker-telegram-bot/wiki/Sample-config#%{hash}'
       crowsnest_config: 'https://crowsnest.mainsail.xyz/configuration/%{hash}-section'

--- a/src/store/printer/getters.ts
+++ b/src/store/printer/getters.ts
@@ -63,6 +63,21 @@ export const getters: GetterTree<PrinterState, RootState> = {
     return 'Unknown'
   },
 
+  getKlippyApp: (state) => {
+    const supportedKlippyApps = [
+      'Klipper',
+      'Danger-Klipper'
+    ]
+
+    const app = state.printer.info.app
+
+    if (supportedKlippyApps.includes(app)) {
+      return app
+    }
+
+    return 'Klipper'
+  },
+
   /**
    * Returns a string value indicating the state of the printer.
    */

--- a/src/store/server/getters.ts
+++ b/src/store/server/getters.ts
@@ -3,6 +3,7 @@ import type { ServerInfo, ServerConfig, ServerState, SystemInfo, ServerSystemSta
 import type { RootState } from '../types'
 import { Globals } from '@/globals'
 import { gte, valid } from 'semver'
+import isKeyOf from '@/util/is-key-of'
 
 export const getters: GetterTree<ServerState, RootState> = {
   /**
@@ -66,7 +67,7 @@ export const getters: GetterTree<ServerState, RootState> = {
    * Maps configuration files to an object representing a config doc link,
    * along with a service name.
    */
-  getConfigMapByFilename: (state, getters, rootState) => (filename: string) => {
+  getConfigMapByFilename: (state, getters, rootState, rootGetters) => (filename: string) => {
     const configMap = Globals.CONFIG_SERVICE_MAP
 
     // First, see if can find an exact match.
@@ -80,6 +81,17 @@ export const getters: GetterTree<ServerState, RootState> = {
     // Finally, try suffixes.
     if (!item) {
       item = configMap.find(o => o.suffix && filename.endsWith(o.suffix.toLowerCase()))
+    }
+
+    if (
+      item?.service === 'klipper' &&
+      item.linkOverride
+    ) {
+      const app = rootGetters['printer/getKlippyApp'].toLowerCase()
+
+      if (isKeyOf(app, item.linkOverride)) {
+        item.link = item.linkOverride[app]
+      }
     }
 
     if (item) {


### PR DESCRIPTION
Checks if we are running on [Danger-Klipper](https://dangerklipper.io) and if so, use its website for documentation.

Note: given the popularity of Klipper, there are now quite a few "flavors" proliferating, but we have **no plans to add indiscriminate support to any of these Klipper forks.**

However, Danger Klipper is now the main Klipper fork and is gaining significant traction, hence why we are specifically adding config support for it here.

Resolves #1349