### PR TITLE
feat: show warning for Trinamic OTPW flag

### DIFF
--- a/src/store/helpers.ts
+++ b/src/store/helpers.ts
@@ -1,6 +1,35 @@
 import type { Commit, Dispatch } from 'vuex'
 import type { RootState } from './types'
 import { SocketActions } from '@/api/socketActions'
+import type { AppPushNotification } from './notifications/types'
+
+export const handleTrinamicDriversChange = (payload: any, state: RootState, dispatch: Dispatch) => {
+  for (const item in payload) {
+    const [type, nameFromSplit] = item.split(' ', 2)
+
+    if (
+      /^tmc\d{4}$/.exec(type) &&
+      payload[item]?.drv_status?.otpw != null &&
+      state.printer.printer?.[item]?.drv_status?.otpw == null
+    ) {
+      const name = nameFromSplit ?? item
+
+      const notification: AppPushNotification = {
+        id: `${item}-otpw`,
+        title: `Stepper driver '${name}' is over-heating`,
+        description: 'This may lead to a failed print',
+        to: 'https://www.klipper3d.org/TMC_Drivers.html#tmc-reports-error-ot1overtemperror',
+        type: 'error',
+        snackbar: true,
+        merge: true,
+        clear: true,
+        noCount: true
+      }
+
+      dispatch('notifications/pushNotification', notification, { root: true })
+    }
+  }
+}
 
 export const handleExcludeObjectChange = (payload: any, state: RootState, dispatch: Dispatch) => {
   // For every notify - if print_stats.state changes from standby -> printing,

--- a/src/store/printer/actions.ts
+++ b/src/store/printer/actions.ts
@@ -1,7 +1,7 @@
 import type { ActionTree } from 'vuex'
 import type { PrinterState } from './types'
 import type { RootState } from '../types'
-import { handlePrintStateChange, handleCurrentFileChange, handleExcludeObjectChange } from '../helpers'
+import { handlePrintStateChange, handleCurrentFileChange, handleExcludeObjectChange, handleTrinamicDriversChange } from '../helpers'
 import { handleAddChartEntry, handleSystemStatsChange, handleMcuStatsChange } from '../chart_helpers'
 import { SocketActions } from '@/api/socketActions'
 import { Globals } from '@/globals'
@@ -150,6 +150,7 @@ export const actions: ActionTree<PrinterState, RootState> = {
       handleExcludeObjectChange(payload, rootState, dispatch)
       handleSystemStatsChange(payload, rootState, commit)
       handleMcuStatsChange(payload, rootState, commit)
+      handleTrinamicDriversChange(payload, rootState, dispatch)
 
       for (const key in payload) {
         const val = payload[key]


### PR DESCRIPTION
Shows a notification message when any `TMCxxxx` driver reports an `otpw` flag (over-temperature pre warning)

![image](https://github.com/fluidd-core/fluidd/assets/85504/02b20ea0-019e-4db7-919d-d514d733ade6)

The link on the notification is currently pointing to https://www.klipper3d.org/TMC_Drivers.html#tmc-reports-error-ot1overtemperror

Resolves #1105