### PR TITLE
fix: item name format and capitalization

### DIFF
--- a/src/components/common/PeripheralsDialog.vue
+++ b/src/components/common/PeripheralsDialog.vue
@@ -15,7 +15,7 @@
           :key="peripheralGroup.type"
         >
           <div>
-            {{ $filters.startCase(peripheralGroup.type) }}
+            {{ $filters.prettyCase(peripheralGroup.type) }}
             <v-chip
               small
               link
@@ -85,7 +85,7 @@
               <v-col>
                 <v-card outlined>
                   <v-card-title>{{ device.device_name }}</v-card-title>
-                  <v-card-subtitle>{{ $filters.startCase(device.device_type) }}</v-card-subtitle>
+                  <v-card-subtitle>{{ $filters.prettyCase(device.device_type) }}</v-card-subtitle>
 
                   <v-card-text>
                     <v-row>

--- a/src/components/settings/presets/PresetDialog.vue
+++ b/src/components/settings/presets/PresetDialog.vue
@@ -24,7 +24,7 @@
       <template v-for="(item, i) in heaters">
         <app-setting
           :key="`${i}heater`"
-          :title="$filters.startCase(item.name)"
+          :title="$filters.prettyCase(item.name)"
         >
           <v-checkbox
             v-model="preset.values[item.name].active"
@@ -53,7 +53,7 @@
       <template v-for="(item, i) in fans">
         <app-setting
           :key="`${i}fan`"
-          :title="$filters.startCase(item.name)"
+          :title="$filters.prettyCase(item.name)"
         >
           <v-checkbox
             v-model="preset.values[item.name].active"

--- a/src/components/widgets/bedmesh/BedMeshChart.vue
+++ b/src/components/widgets/bedmesh/BedMeshChart.vue
@@ -162,7 +162,7 @@ export default class BedMeshChart extends Mixins(BrowserMixin) {
               <div>
                 <span style="display:inline-block;margin-right:4px;border-radius:10px;width:10px;height:10px;background-color:${params.color};"></span>
                 <span style="font-size:16px;color:${fontColor};font-weight:400;margin-left:2px">
-                  ${this.$filters.startCase(params.seriesName)}
+                  ${this.$filters.prettyCase(params.seriesName)}
                 </span>
                 <div style="clear: both"></div>
                 <span style="font-size:16px;color:${fontColor};font-weight:400;margin-left:2px">

--- a/src/components/widgets/camera/CameraItem.vue
+++ b/src/components/widgets/camera/CameraItem.vue
@@ -116,7 +116,7 @@ export default class CameraItem extends Vue {
 
   get cameraComponent () {
     if (this.camera.service) {
-      const componentName = `${this.$filters.startCase(this.camera.service).replace(/ /g, '')}Camera`
+      const componentName = `${this.$filters.prettyCase(this.camera.service).replace(/ /g, '')}Camera`
 
       if (componentName in CameraComponents) {
         return CameraComponents[componentName]

--- a/src/components/widgets/sensors/Sensors.vue
+++ b/src/components/widgets/sensors/Sensors.vue
@@ -5,7 +5,7 @@
       :key="sensor.id"
     >
       <v-col>
-        {{ $filters.startCase(sensor.friendly_name) }}
+        {{ $filters.prettyCase(sensor.friendly_name) }}
 
         <v-chip
           v-for="(value, key) in sensor.values"
@@ -13,7 +13,7 @@
           small
           class="ml-2"
         >
-          {{ $filters.startCase(key.toString()) }}: {{ Math.round(value * 100) / 100 }}
+          {{ $filters.prettyCase(key.toString()) }}: {{ Math.round(value * 100) / 100 }}
         </v-chip>
       </v-col>
     </v-row>

--- a/src/components/widgets/thermals/ThermalChart.vue
+++ b/src/components/widgets/thermals/ThermalChart.vue
@@ -177,7 +177,7 @@ export default class ThermalChart extends Mixins(BrowserMixin) {
                   <div>
                     ${param.marker}
                     <span style="font-size:${fontSize}px;color:${fontColor};font-weight:400;margin-left:2px">
-                      ${this.$filters.startCase(name)}:
+                      ${this.$filters.prettyCase(name)}:
                     </span>
                     <span style="float:right;margin-left:20px;font-size:${fontSize}px;color:${fontColor};font-weight:900">
                       ${param.value[param.seriesName].toFixed(2)}<small>°C</small>`

--- a/src/plugins/filters.ts
+++ b/src/plugins/filters.ts
@@ -1,6 +1,6 @@
 import _Vue from 'vue'
 import VueRouter from 'vue-router'
-import { camelCase, startCase, capitalize, isFinite } from 'lodash-es'
+import { camelCase, startCase, capitalize, isFinite, upperFirst } from 'lodash-es'
 import type { ApiConfig, TextSortOrder } from '@/store/config/types'
 import { TinyColor } from '@ctrl/tinycolor'
 import { DateFormats, Globals, TimeFormats, Waits, type DateTimeFormat } from '@/globals'
@@ -209,6 +209,19 @@ export const Filters = {
     const today = new Date()
 
     return date.getFullYear() === today.getFullYear()
+  },
+
+  upperFirst: (value: string) => {
+    return upperFirst(value)
+  },
+
+  prettyCase: (value: string) => {
+    return value
+      .replace(/_/g, ' ')
+      .split(' ')
+      .filter(x => x)
+      .map(Filters.upperFirst)
+      .join(' ')
   },
 
   /**

--- a/src/store/charts/getters.ts
+++ b/src/store/charts/getters.ts
@@ -110,7 +110,7 @@ export const getters: GetterTree<ChartState, RootState> = {
                   <div style="white-space: nowrap;">
                     ${param.marker}
                     <span style="font-size:${fontSize}px;color:${fontColor};font-weight:400;margin-left:2px">
-                      ${Vue.$filters.startCase(param.seriesName)}:
+                      ${Vue.$filters.prettyCase(param.seriesName)}:
                     </span>
                     <span style="float:right;margin-left:20px;font-size:${fontSize}px;color:${fontColor};font-weight:900">
                       ${param.value[yDimension]}${ySuffix}

--- a/src/store/printer/getters.ts
+++ b/src/store/printer/getters.ts
@@ -384,7 +384,7 @@ export const getters: GetterTree<PrinterState, RootState> = {
 
       steppers.push({
         name,
-        prettyName: Vue.$filters.startCase(name),
+        prettyName: Vue.$filters.prettyCase(name),
         key: item,
         enabled: state.printer.stepper_enable?.steppers[item],
         ...e,
@@ -497,7 +497,7 @@ export const getters: GetterTree<PrinterState, RootState> = {
             : e
 
           const color = Vue.$colorset.next(getKlipperType(e), e)
-          const prettyName = Vue.$filters.startCase(name)
+          const prettyName = Vue.$filters.prettyCase(name)
 
           r.push({
             ...heater,
@@ -649,7 +649,7 @@ export const getters: GetterTree<PrinterState, RootState> = {
       ) {
         const prettyName = name === 'fan'
           ? 'Part Fan' // If we know its the part fan.
-          : Vue.$filters.startCase(name)
+          : Vue.$filters.prettyCase(name)
 
         const color = (applyColor.includes(type))
           ? Vue.$colorset.next(getKlipperType(pin), pin)
@@ -720,9 +720,9 @@ export const getters: GetterTree<PrinterState, RootState> = {
                 name:
                   name.startsWith('stepper_')
                     ? name.substring(8).toUpperCase()
-                    : Vue.$filters.startCase(name)
+                    : Vue.$filters.prettyCase(name)
               })
-            : Vue.$filters.startCase(name)
+            : Vue.$filters.prettyCase(name)
           const color = Vue.$colorset.next(getKlipperType(item), item)
           const config = getters.getPrinterSettings(item)
 
@@ -824,7 +824,7 @@ export const getters: GetterTree<PrinterState, RootState> = {
 
       const fine = config[`screw${index}_fine_adjust`]
       const name = config[`screw${index}_name`]
-      const prettyName = Vue.$filters.startCase(name || i18n.t('app.general.label.screw_number', { index: index + 1 }))
+      const prettyName = Vue.$filters.prettyCase(name || i18n.t('app.general.label.screw_number', { index: index + 1 }))
 
       screws.push({
         key,
@@ -855,7 +855,7 @@ export const getters: GetterTree<PrinterState, RootState> = {
 
       const coords = config[key]
       const name = config[`${key}_name`]
-      const prettyName = Vue.$filters.startCase(name || i18n.t('app.general.label.screw_number', { index: index + 1 }))
+      const prettyName = Vue.$filters.prettyCase(name || i18n.t('app.general.label.screw_number', { index: index + 1 }))
       const [hours, minutes] = result.adjust
         .split(':')
         .map(Number)

--- a/src/store/server/actions.ts
+++ b/src/store/server/actions.ts
@@ -141,7 +141,7 @@ export const actions: ActionTree<ServerState, RootState> = {
       EventBus.$emit(message, { type: 'error' })
     } else if (payload?.rolled_over && payload.rolled_over.length) {
       const applications = payload.rolled_over
-        .map(Vue.$filters.startCase)
+        .map(Vue.$filters.prettyCase)
         .join(', ')
       const message = i18n.tc('app.general.msg.rolledover_logs', 0, { applications })
 


### PR DESCRIPTION
Fluidd item names/labels format currently removes any non-letter/digit and adds spaces between then, which is incorrect.

The new approach works like this:

- Replace any `_` with ` ` (single space)
- Split string by single space
- Remove any empty entry (resulted from multiple consecutive spaces)
- Capitalize the first letter of each part of the splited string
- Join the result, separating the items with a single space

## Before

![image](https://github.com/user-attachments/assets/0204d8c0-81a0-42bf-aca2-bccea613b533)

## After

![image](https://github.com/user-attachments/assets/d1d48269-4d8d-463e-87cf-4c62562dc077)

Fixes #1460