### PR TITLE
fix: Check for Meta key on keyboard shortcuts

### DIFF
--- a/src/util/event-helpers.ts
+++ b/src/util/event-helpers.ts
@@ -29,6 +29,10 @@ export const keyboardEventToKeyboardShortcut = (event: KeyboardEvent): string =>
     keys.push('Ctrl')
   }
 
+  if (event.metaKey) {
+    keys.push('Meta')
+  }
+
   if (event.altKey) {
     keys.push('Alt')
   }


### PR DESCRIPTION
Check for Meta key press (<kbd>Cmd</kbd> key in Mac, <kbd>Win</kbd> key in Windows)

Fixes #1475