### PR TITLE
feat(FileSystem): Filter KlipperScreen rolled logs

### DIFF
--- a/src/components/widgets/filesystem/FileSystem.vue
+++ b/src/components/widgets/filesystem/FileSystem.vue
@@ -420,7 +420,10 @@ export default class FileSystem extends Mixins(StateMixin, FilesMixin, ServicesM
             break
 
           case 'rolled_log_files':
-            if (file.type === 'file' && file.filename.match(/\.\d{4}-\d{2}-\d{2}(_\d{2}-\d{2}-\d{2})?$/)) {
+            if (file.type === 'file' && (
+              file.filename.match(/\.\d{4}-\d{2}-\d{2}(_\d{2}-\d{2}-\d{2})?$/) ||
+              file.filename.match(/\.log\.\d+/)
+            )) {
               return false
             }
             break


### PR DESCRIPTION
Include `*.log.1`, `*.log.2`, etc. files when filtering out rolled logs.

Resolves #1480