### PR TITLE
fix: don't use separator for gcode macros

### DIFF
--- a/src/components/widgets/macros/MacroBtn.vue
+++ b/src/components/widgets/macros/MacroBtn.vue
@@ -98,6 +98,10 @@ export default class MacroBtn extends Mixins(StateMixin) {
     return ['m117', 'm118'].includes(this.macro.name)
   }
 
+  get isMacroForGcodeCommand () {
+    return /^[gm]\d+$/i.test(this.macro.name)
+  }
+
   get filteredListeners () {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { click, ...listeners } = this.$listeners
@@ -114,12 +118,15 @@ export default class MacroBtn extends Mixins(StateMixin) {
    */
   get runCommand () {
     const command = this.macro.name.toUpperCase()
+    const paramSeparator = this.isMacroForGcodeCommand
+      ? ''
+      : '='
 
     if (this.params) {
       const params = this.isMacroWithRawParam
         ? this.params.message.value.toString()
         : Object.entries(this.params)
-          .map(([key, param]) => `${key.toUpperCase()}=${param.value}`)
+          .map(([key, param]) => `${key.toUpperCase()}${paramSeparator}${param.value}`)
           .join(' ')
 
       if (params) {


### PR DESCRIPTION
For any `Gn` or `Mn` macro (where `n` is one of more digits), we will not add `=` as a parameter separator as these are considered overrides of classic G-code commands

Resolves #1481