### PR TITLE
fix: null check cards on layout init

### DIFF
--- a/src/store/layout/mutations.ts
+++ b/src/store/layout/mutations.ts
@@ -32,13 +32,17 @@ export const mutations: MutationTree<LayoutState> = {
       // migrate existing layouts
       const migratableLayoutKeys = ['dashboard']
 
-      for (const layoutKey of Object.keys(payload.layouts)) {
+      for (const [layoutKey, currentLayout] of Object.entries(payload.layouts)) {
+        for (const [containerKey, components] of Object.entries(currentLayout)) {
+          currentLayout[containerKey] = components
+            .filter(card => card != null)
+        }
+
         const migratableLayoutKey = migratableLayoutKeys.find(key => layoutKey.startsWith(key))
 
         if (migratableLayoutKey) {
           const defaultLayout = defaultState.layouts[migratableLayoutKey]
           const defaultComponentIds = Object.values(defaultLayout).flat().map(card => card.id)
-          const currentLayout = payload.layouts[layoutKey]
           const currentComponentIds = Object.values(currentLayout).flat().map(card => card.id)
 
           for (const [containerKey, defaultContainerComponents] of Object.entries(defaultLayout)) {
@@ -53,7 +57,7 @@ export const mutations: MutationTree<LayoutState> = {
 
         // diagnostics specific layout updates
         if (layoutKey.startsWith('diagnostics')) {
-          const diagnostics = payload.layouts[layoutKey] as DiagnosticsCardContainer
+          const diagnostics = currentLayout as DiagnosticsCardContainer
 
           for (const diagnosticsCardConfigs of Object.values(diagnostics)) {
             for (const diagnosticsCardConfig of diagnosticsCardConfigs) {


### PR DESCRIPTION
We have had a few reports from users that Fluidd stops working after editing the dashboard layout.

It seems that somehow the layout data is getting incorrectly recorded in the database with `null` values for some cards.

![image](https://github.com/user-attachments/assets/174811a9-099e-4c74-a45e-77eed7d144d2)

Though I don't yet know the reason for this happening, the proposed fix here is to filter these `null` values out before we attempt to load the layout.

Fixes #1473 