### PR TITLE
feat: hides macro parameters starting with "_"

### DIFF
--- a/src/util/__tests__/gcode-macro-params.spec.ts
+++ b/src/util/__tests__/gcode-macro-params.spec.ts
@@ -1,4 +1,15 @@
-import { gcodeMacroParamDefault } from '../gcode-macro-params'
+import gcodeMacroParams, { gcodeMacroParamDefault } from '../gcode-macro-params'
+
+describe('gcodeMacroParams', () => {
+  it.each([
+    ['{% set ENABLE = params.ENABLE %}', [{ name: 'ENABLE', value: '' }]],
+    ['{% set ENABLE = params.ENABLE | default(1) %}', [{ name: 'ENABLE', value: '1' }]],
+    ['{% set ENABLE = params._ENABLE %}', []],
+    ['{% set ENABLE = params._ENABLE | default(1) %}', []]
+  ])('Expects params of "%s", to be %s', (param, expected) => {
+    expect(gcodeMacroParams(param)).toStrictEqual(expected)
+  })
+})
 
 describe('gcodeMacroParamDefault', () => {
   it.each([

--- a/src/util/gcode-macro-params.ts
+++ b/src/util/gcode-macro-params.ts
@@ -1,5 +1,5 @@
-const paramRegExp = /params\.(\w+)(.*)/gi
-const defaultValueRegExp = /\|\s*default\s*\(\s*((["'])(?:\\\2|.)*?\2|-?[0-9][^,)]*)/i
+const paramRegExp = /params\.([^_]\w*)(.*)/gi
+const defaultValueRegExp = /\|\s*default\s*\(\s*((["'])(?:\\\2|.)*?\2|-?\d[^,)]*)/i
 
 export const gcodeMacroParamDefault = (param: string) => {
   const valueMatch = defaultValueRegExp.exec(param)


### PR DESCRIPTION
Hide any macro parameter that starts with "_"