### PR TITLE
feat: restore positioning mode after extrude/move

### DIFF
--- a/src/components/widgets/toolhead/ExtruderMoves.vue
+++ b/src/components/widgets/toolhead/ExtruderMoves.vue
@@ -138,16 +138,20 @@ export default class ExtruderMoves extends Mixins(StateMixin, ToolheadMixin) {
 
   sendRetractGcode (amount: number, rate: number, wait?: string) {
     if (this.valid) {
-      const gcode = `M83
-G1 E-${amount} F${rate * 60}`
+      const gcode = `SAVE_GCODE_STATE NAME=_ui_retract
+M83
+G1 E-${amount} F${rate * 60}
+RESTORE_GCODE_STATE NAME=_ui_retract`
       this.sendGcode(gcode, wait)
     }
   }
 
   sendExtrudeGcode (amount: number, rate: number, wait?: string) {
     if (this.valid) {
-      const gcode = `M83
-G1 E${amount} F${rate * 60}`
+      const gcode = `SAVE_GCODE_STATE NAME=_ui_retract
+M83
+G1 E${amount} F${rate * 60}
+RESTORE_GCODE_STATE NAME=_ui_retract`
       this.sendGcode(gcode, wait)
     }
   }

--- a/src/components/widgets/toolhead/ExtruderMoves.vue
+++ b/src/components/widgets/toolhead/ExtruderMoves.vue
@@ -31,7 +31,7 @@
         <app-btn
           :disabled="!klippyReady || !extruderReady || !valid"
           block
-          @click="sendRetractGcode(extrudeLength, extrudeSpeed, $waits.onExtrude)"
+          @click="retract"
         >
           {{ $t('app.general.btn.retract') }}
           <v-icon>$chevronUp</v-icon>
@@ -68,7 +68,7 @@
         <app-btn
           :disabled="!klippyReady || !extruderReady || !valid"
           block
-          @click="sendExtrudeGcode(extrudeLength, extrudeSpeed, $waits.onExtrude)"
+          @click="extrude"
         >
           {{ $t('app.general.btn.extrude') }}
           <v-icon>$chevronDown</v-icon>
@@ -136,24 +136,12 @@ export default class ExtruderMoves extends Mixins(StateMixin, ToolheadMixin) {
     return this.$rules.numberLessThanOrEqual(this.maxExtrudeSpeed)(value)
   }
 
-  sendRetractGcode (amount: number, rate: number, wait?: string) {
-    if (this.valid) {
-      const gcode = `SAVE_GCODE_STATE NAME=_ui_retract
-M83
-G1 E-${amount} F${rate * 60}
-RESTORE_GCODE_STATE NAME=_ui_retract`
-      this.sendGcode(gcode, wait)
-    }
+  retract () {
+    this.sendExtrudeGcode(-this.extrudeLength, this.extrudeSpeed, this.$waits.onExtrude)
   }
 
-  sendExtrudeGcode (amount: number, rate: number, wait?: string) {
-    if (this.valid) {
-      const gcode = `SAVE_GCODE_STATE NAME=_ui_retract
-M83
-G1 E${amount} F${rate * 60}
-RESTORE_GCODE_STATE NAME=_ui_retract`
-      this.sendGcode(gcode, wait)
-    }
+  extrude () {
+    this.sendExtrudeGcode(this.extrudeLength, this.extrudeSpeed, this.$waits.onExtrude)
   }
 
   mounted () {

--- a/src/components/widgets/toolhead/ExtruderMoves.vue
+++ b/src/components/widgets/toolhead/ExtruderMoves.vue
@@ -137,11 +137,15 @@ export default class ExtruderMoves extends Mixins(StateMixin, ToolheadMixin) {
   }
 
   retract () {
-    this.sendExtrudeGcode(-this.extrudeLength, this.extrudeSpeed, this.$waits.onExtrude)
+    if (this.valid) {
+      this.sendExtrudeGcode(-this.extrudeLength, this.extrudeSpeed, this.$waits.onExtrude)
+    }
   }
 
   extrude () {
-    this.sendExtrudeGcode(this.extrudeLength, this.extrudeSpeed, this.$waits.onExtrude)
+    if (this.valid) {
+      this.sendExtrudeGcode(this.extrudeLength, this.extrudeSpeed, this.$waits.onExtrude)
+    }
   }
 
   mounted () {

--- a/src/components/widgets/toolhead/ToolheadControlBarsAxis.vue
+++ b/src/components/widgets/toolhead/ToolheadControlBarsAxis.vue
@@ -78,9 +78,10 @@ export default class ToolheadControlBarsAxis extends Mixins(StateMixin, Toolhead
   }
 
   sendMoveGcode (distance: number) {
-    this.sendGcode(`G91
+    this.sendGcode(`SAVE_GCODE_STATE NAME=_ui_movement
+G91
 G1 ${this.axis}${distance} F${this.rate * 60}
-G90`)
+RESTORE_GCODE_STATE NAME=_ui_movement`)
   }
 
   sendHomeGcode () {

--- a/src/components/widgets/toolhead/ToolheadControlBarsAxis.vue
+++ b/src/components/widgets/toolhead/ToolheadControlBarsAxis.vue
@@ -9,14 +9,14 @@
         color="primary"
         :disabled="!klippyReady || printerPrinting || !homed"
         class="d-flex"
-        @click="sendMoveGcode($event)"
+        @click="moveBy($event)"
       >
         <app-btn
           :color="!homed ? 'primary' : undefined"
           :disabled="!klippyReady || printerPrinting"
           :loading="hasWait(wait)"
           class="flex-grow-1"
-          @click="sendHomeGcode"
+          @click="home"
         >
           <v-icon
             small-icon
@@ -77,14 +77,11 @@ export default class ToolheadControlBarsAxis extends Mixins(StateMixin, Toolhead
       : this.$store.state.config.uiSettings.general.defaultToolheadXYSpeed
   }
 
-  sendMoveGcode (distance: number) {
-    this.sendGcode(`SAVE_GCODE_STATE NAME=_ui_movement
-G91
-G1 ${this.axis}${distance} F${this.rate * 60}
-RESTORE_GCODE_STATE NAME=_ui_movement`)
+  moveBy (distance: number) {
+    this.sendMoveGcode(`${this.axis}${distance}`, this.rate)
   }
 
-  sendHomeGcode () {
+  home () {
     this.sendGcode(`G28 ${this.axis}`, this.wait)
   }
 }

--- a/src/components/widgets/toolhead/ToolheadControlCircle.vue
+++ b/src/components/widgets/toolhead/ToolheadControlCircle.vue
@@ -735,9 +735,10 @@ export default class ToolheadControlCircle extends Mixins(StateMixin, ToolheadMi
         : this.$store.state.printer.printer.toolhead.max_accel
       this.sendGcode(`FORCE_MOVE STEPPER=stepper_${axis.toLowerCase()} DISTANCE=${distance} VELOCITY=${rate} ACCEL=${accel}`)
     } else {
-      this.sendGcode(`G91
+      this.sendGcode(`SAVE_GCODE_STATE NAME=_ui_movement
+G91
 G1 ${axis}${distance} F${rate * 60}
-G90`)
+RESTORE_GCODE_STATE NAME=_ui_movement`)
     }
   }
 
@@ -765,7 +766,10 @@ G90`)
     const bedCenter = this.bedCenter
     const rate = this.$store.state.config.uiSettings.general.defaultToolheadXYSpeed
 
-    this.sendGcode(`G1 X${bedCenter.x} Y${bedCenter.y} F${rate * 60}`)
+    this.sendGcode(`SAVE_GCODE_STATE NAME=_ui_movement
+G90
+G1 X${bedCenter.x} Y${bedCenter.y} F${rate * 60}
+RESTORE_GCODE_STATE NAME=_ui_movement`)
   }
 }
 </script>

--- a/src/components/widgets/toolhead/ToolheadControlCircle.vue
+++ b/src/components/widgets/toolhead/ToolheadControlCircle.vue
@@ -19,7 +19,7 @@
             <a
               class="cc-btn outer"
               :class="zStepClasses"
-              @click="sendMoveGcode('Z', stepsZ[3], false)"
+              @click="moveAxisBy('Z', stepsZ[3], false)"
             >
               <path
                 d="m408.5,121.331V6.998c0-3.313-2.686-5.998-5.998-5.998h-38.003c-3.313,0-5.998,2.686-5.998,5.998v114.333h50Z"
@@ -30,7 +30,7 @@
             <a
               class="cc-btn outer"
               :class="zStepClasses"
-              @click="sendMoveGcode('Z', stepsZ[3], true)"
+              @click="moveAxisBy('Z', stepsZ[3], true)"
             >
               <path
                 d="m358.5,221.331v118.664c0,3.316,2.688,6.005,6.005,6.005h37.991c3.316,0,6.005-2.688,6.005-6.005v-118.664h-50Z"
@@ -52,7 +52,7 @@
             <a
               class="cc-btn outer-mid"
               :class="zStepClasses"
-              @click="sendMoveGcode('Z', stepsZ[2], false)"
+              @click="moveAxisBy('Z', stepsZ[2], false)"
             >
               <path
                 d="m408.5,38.274c-8.108-1.489-16.462-2.274-25-2.274s-16.892.785-25,2.274v83.057h50V38.274Z"
@@ -63,7 +63,7 @@
             <a
               class="cc-btn outer-mid"
               :class="zStepClasses"
-              @click="sendMoveGcode('Z', stepsZ[2], true)"
+              @click="moveAxisBy('Z', stepsZ[2], true)"
             >
               <path
                 d="m358.5,308.726c8.108,1.489,16.462,2.274,25,2.274s16.892-.785,25-2.274v-87.395h-50v87.395Z"
@@ -85,7 +85,7 @@
             <a
               class="cc-btn inner-mid"
               :class="zStepClasses"
-              @click="sendMoveGcode('Z', stepsZ[1], false)"
+              @click="moveAxisBy('Z', stepsZ[1], false)"
             >
               <path
                 d="m408.5,74.077c-8.002-2.006-16.376-3.077-25-3.077s-16.998,1.071-25,3.077v47.255h50v-47.255Z"
@@ -96,7 +96,7 @@
             <a
               class="cc-btn inner-mid"
               :class="zStepClasses"
-              @click="sendMoveGcode('Z', stepsZ[1], true)"
+              @click="moveAxisBy('Z', stepsZ[1], true)"
             >
               <path
                 d="m358.5,272.923c8.002,2.006,16.376,3.077,25,3.077s16.998-1.071,25-3.077v-51.592h-50v51.592Z"
@@ -118,7 +118,7 @@
             <a
               class="cc-btn inner"
               :class="zStepClasses"
-              @click="sendMoveGcode('Z', stepsZ[0], false)"
+              @click="moveAxisBy('Z', stepsZ[0], false)"
             >
               <path
                 d="m383.5,106c-8.836,0-17.266,1.715-25,4.802v26.262c0,.531.211,1.04.586,1.416l6.262,6.262c.621.621,1.584.782,2.351.354,4.677-2.609,10.064-4.096,15.8-4.096s11.123,1.488,15.8,4.096c.767.428,1.73.267,2.351-.354l6.262-6.262c.375-.375.586-.885.586-1.416v-26.262c-7.734-3.087-16.164-4.802-25-4.802Z"
@@ -129,7 +129,7 @@
             <a
               class="cc-btn inner"
               :class="zStepClasses"
-              @click="sendMoveGcode('Z', stepsZ[0], true)"
+              @click="moveAxisBy('Z', stepsZ[0], true)"
             >
               <path
                 d="m383.5,206c-5.736,0-11.123-1.488-15.8-4.096-.767-.428-1.73-.267-2.351.354l-6.262,6.262c-.375.375-.586.885-.586,1.415v24.87c0,.838.513,1.6,1.298,1.895,7.376,2.77,15.358,4.3,23.702,4.3s16.326-1.53,23.702-4.3c.785-.295,1.298-1.057,1.298-1.895v-24.87c0-.531-.211-1.04-.586-1.415l-6.262-6.262c-.621-.621-1.584-.782-2.351-.354-4.677,2.609-10.064,4.096-15.8,4.096Z"
@@ -183,7 +183,7 @@
             <a
               class="cc-btn outer"
               :class="xStepClasses"
-              @click="sendMoveGcode('X', stepsXY[3], true)"
+              @click="moveAxisBy('X', stepsXY[3], true)"
             >
               <path
                 d="m132.727,143.333L49.329,59.936c-1.641-1.641-4.325-1.538-5.85.21C17.028,90.461,1,130.107,1,173.5s16.028,83.039,42.479,113.354c1.525,1.748,4.209,1.85,5.85.21l83.841-83.841c-6.389-8.398-10.188-18.874-10.188-30.24,0-11.101,3.623-21.353,9.744-29.649Z"
@@ -194,7 +194,7 @@
             <a
               class="cc-btn outer"
               :class="xStepClasses"
-              @click="sendMoveGcode('X', stepsXY[3], false)"
+              @click="moveAxisBy('X', stepsXY[3], false)"
             >
               <path
                 d="m213.239,202.632l84.427,84.427c1.643,1.643,4.332,1.541,5.859-.21,26.449-30.314,42.475-69.958,42.475-113.349s-16.026-83.035-42.475-113.349c-1.528-1.751-4.216-1.853-5.859-.21l-83.997,83.997c5.856,8.189,9.314,18.21,9.314,29.045,0,11.101-3.623,21.353-9.744,29.65Z"
@@ -205,7 +205,7 @@
             <a
               class="cc-btn outer"
               :class="yStepClasses"
-              @click="sendMoveGcode('Y', stepsXY[3], false)"
+              @click="moveAxisBy('Y', stepsXY[3], false)"
             >
               <path
                 d="m143.333,132.727c8.297-6.121,18.548-9.744,29.65-9.744,11.366,0,21.842,3.799,30.24,10.188l83.834-83.834c1.644-1.644,1.542-4.335-.21-5.863C256.533,17.025,216.89,1,173.5,1S90.467,17.025,60.153,43.473c-1.752,1.529-1.855,4.219-.21,5.863l83.39,83.39Z"
@@ -216,7 +216,7 @@
             <a
               class="cc-btn outer"
               :class="yStepClasses"
-              @click="sendMoveGcode('Y', stepsXY[3], true)"
+              @click="moveAxisBy('Y', stepsXY[3], true)"
             >
               <path
                 d="m204.986,215.593c-1.345-1.345-3.435-1.534-5.036-.506-7.781,4.995-17.034,7.896-26.967,7.896-9.684,0-18.718-2.762-26.374-7.53-1.597-.995-3.66-.795-4.991.536l-81.674,81.674c-1.644,1.644-1.542,4.335.21,5.864,30.314,26.448,69.957,42.473,113.346,42.473s83.032-16.025,113.346-42.473c1.752-1.529,1.855-4.22.21-5.864l-82.071-82.071Z"
@@ -238,7 +238,7 @@
             <a
               class="cc-btn outer-mid"
               :class="xStepClasses"
-              @click="sendMoveGcode('X', stepsXY[2], true)"
+              @click="moveAxisBy('X', stepsXY[2], true)"
             >
               <path
                 d="m132.727,143.333l-61.608-61.608c-21.833,24.34-35.119,56.504-35.119,91.774s13.286,67.435,35.119,91.774l62.052-62.052c-6.389-8.398-10.188-18.874-10.188-30.24,0-11.101,3.623-21.353,9.744-29.649Z"
@@ -249,7 +249,7 @@
             <a
               class="cc-btn outer-mid"
               :class="xStepClasses"
-              @click="sendMoveGcode('X', stepsXY[2], false)"
+              @click="moveAxisBy('X', stepsXY[2], false)"
             >
               <path
                 d="m213.239,202.632l62.642,62.642c21.833-24.34,35.119-56.504,35.119-91.774s-13.286-67.435-35.119-91.774l-62.212,62.212c5.856,8.189,9.314,18.21,9.314,29.045,0,11.101-3.623,21.353-9.744,29.65Z"
@@ -260,7 +260,7 @@
             <a
               class="cc-btn outer-mid"
               :class="yStepClasses"
-              @click="sendMoveGcode('Y', stepsXY[2], false)"
+              @click="moveAxisBy('Y', stepsXY[2], false)"
             >
               <path
                 d="m143.333,132.727c8.297-6.121,18.548-9.744,29.65-9.744,11.366,0,21.842,3.799,30.24,10.188l62.052-62.052c-24.34-21.833-56.504-35.119-91.774-35.119s-67.435,13.286-91.774,35.119l61.608,61.608Z"
@@ -271,7 +271,7 @@
             <a
               class="cc-btn outer-mid"
               :class="yStepClasses"
-              @click="sendMoveGcode('Y', stepsXY[2], true)"
+              @click="moveAxisBy('Y', stepsXY[2], true)"
             >
               <path
                 d="m202.632,213.239c-8.296,6.121-18.548,9.744-29.65,9.744-10.835,0-20.856-3.458-29.045-9.314l-62.212,62.212c24.34,21.833,56.504,35.119,91.774,35.119s67.435-13.286,91.775-35.119l-62.642-62.642Z"
@@ -293,7 +293,7 @@
             <a
               class="cc-btn inner-mid"
               :class="xStepClasses"
-              @click="sendMoveGcode('X', stepsXY[1], true)"
+              @click="moveAxisBy('X', stepsXY[1], true)"
             >
               <path
                 d="m132.727,143.333l-36.814-36.814c-15.523,17.965-24.912,41.376-24.912,66.981s9.39,49.016,24.912,66.981l37.258-37.258c-6.389-8.398-10.188-18.874-10.188-30.24,0-11.101,3.623-21.353,9.744-29.649Z"
@@ -304,7 +304,7 @@
             <a
               class="cc-btn inner-mid"
               :class="xStepClasses"
-              @click="sendMoveGcode('X', stepsXY[1], false)"
+              @click="moveAxisBy('X', stepsXY[1], false)"
             >
               <path
                 d="m213.239,202.632l37.849,37.849c15.523-17.965,24.912-41.376,24.912-66.981s-9.39-49.016-24.912-66.981l-37.419,37.419c5.856,8.189,9.314,18.21,9.314,29.045,0,11.101-3.623,21.353-9.744,29.65Z"
@@ -315,7 +315,7 @@
             <a
               class="cc-btn inner-mid"
               :class="yStepClasses"
-              @click="sendMoveGcode('Y', stepsXY[1], false)"
+              @click="moveAxisBy('Y', stepsXY[1], false)"
             >
               <path
                 d="m143.333,132.727c8.297-6.121,18.548-9.744,29.65-9.744,11.366,0,21.842,3.799,30.24,10.188l37.258-37.258c-17.965-15.523-41.376-24.912-66.981-24.912s-49.016,9.39-66.981,24.912l36.814,36.814Z"
@@ -326,7 +326,7 @@
             <a
               class="cc-btn inner-mid"
               :class="yStepClasses"
-              @click="sendMoveGcode('Y', stepsXY[1], true)"
+              @click="moveAxisBy('Y', stepsXY[1], true)"
             >
               <path
                 d="m202.632,213.239c-8.296,6.121-18.548,9.744-29.65,9.744-10.835,0-20.856-3.458-29.045-9.314l-37.419,37.419c17.965,15.523,41.376,24.912,66.981,24.912s49.016-9.39,66.981-24.912l-37.849-37.849Z"
@@ -348,7 +348,7 @@
             <a
               class="cc-btn inner"
               :class="xStepClasses"
-              @click="sendMoveGcode('X', stepsXY[0], true)"
+              @click="moveAxisBy('X', stepsXY[0], true)"
             >
               <path
                 d="m144.743,155.35l-23.97-23.97c-9.237,11.547-14.773,26.184-14.773,42.121s5.536,30.573,14.773,42.121l23.97-23.97c.621-.621.782-1.584.354-2.351-2.608-4.677-4.097-10.064-4.097-15.799s1.489-11.122,4.098-15.799c.428-.767.267-1.73-.354-2.351Z"
@@ -359,7 +359,7 @@
             <a
               class="cc-btn inner"
               :class="xStepClasses"
-              @click="sendMoveGcode('X', stepsXY[0], false)"
+              @click="moveAxisBy('X', stepsXY[0], false)"
             >
               <path
                 d="m202.257,191.65l23.97,23.97c9.237-11.547,14.773-26.184,14.773-42.121s-5.536-30.573-14.773-42.121l-23.97,23.97c-.621.621-.782,1.584-.354,2.351,2.608,4.677,4.097,10.064,4.097,15.799s-1.489,11.122-4.097,15.799c-.428.767-.267,1.73.354,2.351Z"
@@ -370,7 +370,7 @@
             <a
               class="cc-btn inner"
               :class="yStepClasses"
-              @click="sendMoveGcode('Y', stepsXY[0], false)"
+              @click="moveAxisBy('Y', stepsXY[0], false)"
             >
               <path
                 d="m155.35,144.743c.621.621,1.584.782,2.351.354,4.677-2.608,10.064-4.097,15.799-4.097s11.122,1.489,15.799,4.097c.767.428,1.73.267,2.351-.354l23.97-23.97c-11.547-9.237-26.184-14.773-42.121-14.773s-30.573,5.536-42.121,14.773l23.97,23.97Z"
@@ -381,7 +381,7 @@
             <a
               class="cc-btn inner"
               :class="yStepClasses"
-              @click="sendMoveGcode('Y', stepsXY[0], true)"
+              @click="moveAxisBy('Y', stepsXY[0], true)"
             >
               <path
                 d="m191.65,202.257c-.621-.621-1.584-.782-2.351-.354-4.677,2.608-10.064,4.098-15.799,4.098s-11.122-1.489-15.799-4.098c-.767-.428-1.73-.267-2.351.354l-23.97,23.97c11.547,9.237,26.184,14.773,42.121,14.773s30.573-5.536,42.121-14.773l-23.97-23.97Z"
@@ -720,7 +720,7 @@ export default class ToolheadControlCircle extends Mixins(StateMixin, ToolheadMi
     }
   }
 
-  sendMoveGcode (axis: Axis, distance: number, negative = false) {
+  moveAxisBy (axis: Axis, distance: number, negative = false) {
     const rate = axis === 'Z'
       ? this.$store.state.config.uiSettings.general.defaultToolheadZSpeed
       : this.$store.state.config.uiSettings.general.defaultToolheadXYSpeed
@@ -735,10 +735,7 @@ export default class ToolheadControlCircle extends Mixins(StateMixin, ToolheadMi
         : this.$store.state.printer.printer.toolhead.max_accel
       this.sendGcode(`FORCE_MOVE STEPPER=stepper_${axis.toLowerCase()} DISTANCE=${distance} VELOCITY=${rate} ACCEL=${accel}`)
     } else {
-      this.sendGcode(`SAVE_GCODE_STATE NAME=_ui_movement
-G91
-G1 ${axis}${distance} F${rate * 60}
-RESTORE_GCODE_STATE NAME=_ui_movement`)
+      this.sendMoveGcode(`${axis}${distance}`, rate)
     }
   }
 
@@ -766,10 +763,7 @@ RESTORE_GCODE_STATE NAME=_ui_movement`)
     const bedCenter = this.bedCenter
     const rate = this.$store.state.config.uiSettings.general.defaultToolheadXYSpeed
 
-    this.sendGcode(`SAVE_GCODE_STATE NAME=_ui_movement
-G90
-G1 X${bedCenter.x} Y${bedCenter.y} F${rate * 60}
-RESTORE_GCODE_STATE NAME=_ui_movement`)
+    this.sendMoveGcode(`X${bedCenter.x} Y${bedCenter.y}`, rate, true)
   }
 }
 </script>

--- a/src/components/widgets/toolhead/ToolheadControlCross.vue
+++ b/src/components/widgets/toolhead/ToolheadControlCross.vue
@@ -13,7 +13,7 @@
           :color="axisButtonColor(yHomed)"
           :disabled="axisButtonDisabled(yHomed, yHasMultipleSteppers)"
           icon="$up"
-          @click="sendMoveGcode('Y', toolheadMoveLength)"
+          @click="moveAxisBy('Y', toolheadMoveLength)"
         />
       </v-col>
       <v-col
@@ -24,7 +24,7 @@
           :color="axisButtonColor(zHomed)"
           :disabled="axisButtonDisabled(zHomed, zHasMultipleSteppers)"
           icon="$up"
-          @click="sendMoveGcode('Z', toolheadMoveLength)"
+          @click="moveAxisBy('Z', toolheadMoveLength)"
         />
       </v-col>
       <v-col
@@ -57,7 +57,7 @@
           :color="axisButtonColor(xHomed)"
           :disabled="axisButtonDisabled(xHomed, xHasMultipleSteppers)"
           icon="$left"
-          @click="sendMoveGcode('X', toolheadMoveLength, true)"
+          @click="moveAxisBy('X', toolheadMoveLength, true)"
         />
       </v-col>
       <v-col
@@ -83,7 +83,7 @@
           :color="axisButtonColor(xHomed)"
           :disabled="axisButtonDisabled(xHomed, xHasMultipleSteppers)"
           icon="$right"
-          @click="sendMoveGcode('X', toolheadMoveLength)"
+          @click="moveAxisBy('X', toolheadMoveLength)"
         />
       </v-col>
       <v-col
@@ -129,7 +129,7 @@
           :color="axisButtonColor(yHomed)"
           :disabled="axisButtonDisabled(yHomed, yHasMultipleSteppers)"
           icon="$down"
-          @click="sendMoveGcode('Y', toolheadMoveLength, true)"
+          @click="moveAxisBy('Y', toolheadMoveLength, true)"
         />
       </v-col>
       <v-col
@@ -140,7 +140,7 @@
           :color="axisButtonColor(zHomed)"
           :disabled="axisButtonDisabled(zHomed, zHasMultipleSteppers)"
           icon="$down"
-          @click="sendMoveGcode('Z', toolheadMoveLength, true)"
+          @click="moveAxisBy('Z', toolheadMoveLength, true)"
         />
       </v-col>
       <v-col
@@ -243,7 +243,7 @@ export default class ToolheadControlCross extends Mixins(StateMixin, ToolheadMix
   /**
    * Send a move gcode script.
    */
-  sendMoveGcode (axis: Axis, distance: number, negative = false) {
+  moveAxisBy (axis: Axis, distance: number, negative = false) {
     const rate = axis === 'Z'
       ? this.$store.state.config.uiSettings.general.defaultToolheadZSpeed
       : this.$store.state.config.uiSettings.general.defaultToolheadXYSpeed
@@ -258,10 +258,7 @@ export default class ToolheadControlCross extends Mixins(StateMixin, ToolheadMix
         : this.$store.state.printer.printer.toolhead.max_accel
       this.sendGcode(`FORCE_MOVE STEPPER=stepper_${axis.toLowerCase()} DISTANCE=${distance} VELOCITY=${rate} ACCEL=${accel}`)
     } else {
-      this.sendGcode(`SAVE_GCODE_STATE NAME=_ui_movement
-G91
-G1 ${axis}${distance} F${rate * 60}
-RESTORE_GCODE_STATE NAME=_ui_movement`)
+      this.sendMoveGcode(`${axis}${distance}`, rate)
     }
   }
 }

--- a/src/components/widgets/toolhead/ToolheadControlCross.vue
+++ b/src/components/widgets/toolhead/ToolheadControlCross.vue
@@ -258,9 +258,10 @@ export default class ToolheadControlCross extends Mixins(StateMixin, ToolheadMix
         : this.$store.state.printer.printer.toolhead.max_accel
       this.sendGcode(`FORCE_MOVE STEPPER=stepper_${axis.toLowerCase()} DISTANCE=${distance} VELOCITY=${rate} ACCEL=${accel}`)
     } else {
-      this.sendGcode(`G91
+      this.sendGcode(`SAVE_GCODE_STATE NAME=_ui_movement
+G91
 G1 ${axis}${distance} F${rate * 60}
-G90`)
+RESTORE_GCODE_STATE NAME=_ui_movement`)
     }
   }
 }

--- a/src/components/widgets/toolhead/ToolheadPosition.vue
+++ b/src/components/widgets/toolhead/ToolheadPosition.vue
@@ -20,7 +20,7 @@
           :disabled="!klippyReady || (!xHomed && !xForceMove)"
           :readonly="printerBusy"
           :value="(useGcodeCoords) ? gcodePosition[0].toFixed(2) : toolheadPosition[0].toFixed(2)"
-          @change="moveTo('X', $event)"
+          @change="moveAxisTo('X', $event)"
           @focus="$event.target.select()"
         />
       </v-col>
@@ -39,7 +39,7 @@
           :disabled="!klippyReady || (!yHomed && !yForceMove)"
           :readonly="printerBusy"
           :value="(useGcodeCoords) ? gcodePosition[1].toFixed(2) : toolheadPosition[1].toFixed(2)"
-          @change="moveTo('Y', $event)"
+          @change="moveAxisTo('Y', $event)"
           @focus="$event.target.select()"
         />
       </v-col>
@@ -58,7 +58,7 @@
           :disabled="!klippyReady || (!zHomed && !zForceMove)"
           :readonly="printerBusy"
           :value="(useGcodeCoords) ? gcodePosition[2].toFixed(2) : toolheadPosition[2].toFixed(2)"
-          @change="moveTo('Z', $event)"
+          @change="moveAxisTo('Z', $event)"
           @focus="$event.target.select()"
         />
       </v-col>
@@ -159,7 +159,7 @@ export default class ToolheadPosition extends Mixins(StateMixin, ToolheadMixin) 
     this.sendGcode(`G9${value}`)
   }
 
-  moveTo (axis: string, pos: string) {
+  moveAxisTo (axis: string, pos: string) {
     const axisIndexMap: any = { X: 0, Y: 1, Z: 2 }
     const currentPos = (this.useGcodeCoords)
       ? this.gcodePosition[axisIndexMap[axis]]
@@ -174,10 +174,7 @@ export default class ToolheadPosition extends Mixins(StateMixin, ToolheadMixin) 
           : this.$store.state.printer.printer.toolhead.max_accel
         this.sendGcode(`FORCE_MOVE STEPPER=stepper_${axis.toLowerCase()} DISTANCE=${pos} VELOCITY=${rate} ACCEL=${accel}`)
       } else {
-        this.sendGcode(`SAVE_GCODE_STATE NAME=_ui_movement
-G90
-G1 ${axis}${pos} F${rate * 60}
-RESTORE_GCODE_STATE NAME=_ui_movement`)
+        this.sendMoveGcode(`${axis}${pos}`, rate, true)
       }
     }
   }

--- a/src/components/widgets/toolhead/ToolheadPosition.vue
+++ b/src/components/widgets/toolhead/ToolheadPosition.vue
@@ -174,8 +174,10 @@ export default class ToolheadPosition extends Mixins(StateMixin, ToolheadMixin) 
           : this.$store.state.printer.printer.toolhead.max_accel
         this.sendGcode(`FORCE_MOVE STEPPER=stepper_${axis.toLowerCase()} DISTANCE=${pos} VELOCITY=${rate} ACCEL=${accel}`)
       } else {
-        this.sendGcode(`G90
-G1 ${axis}${pos} F${rate * 60}`)
+        this.sendGcode(`SAVE_GCODE_STATE NAME=_ui_movement
+G90
+G1 ${axis}${pos} F${rate * 60}
+RESTORE_GCODE_STATE NAME=_ui_movement`)
       }
     }
   }

--- a/src/mixins/state.ts
+++ b/src/mixins/state.ts
@@ -99,6 +99,24 @@ export default class StateMixin extends Vue {
     this.addConsoleEntry(gcode)
   }
 
+  sendMoveGcode (movementGcode: string, rate: number, absolute = false, wait?: string) {
+    const gcode = `SAVE_GCODE_STATE NAME=_ui_movement
+G9${absolute ? 0 : 1}
+G1 ${movementGcode} F${rate * 60}
+RESTORE_GCODE_STATE NAME=_ui_movement`
+
+    this.sendGcode(gcode, wait)
+  }
+
+  sendExtrudeGcode (amount: number, rate: number, wait?: string) {
+    const gcode = `SAVE_GCODE_STATE NAME=_ui_retract
+M83
+G1 E${amount} F${rate * 60}
+RESTORE_GCODE_STATE NAME=_ui_retract`
+
+    this.sendGcode(gcode, wait)
+  }
+
   addConsoleEntry (message: string) {
     this.$store.dispatch('console/onAddConsoleEntry', { message, type: 'command' })
   }


### PR DESCRIPTION
Ensure that when we move the toolhead or extruder, we use the correct absolute/relative move and then restore the previous mode after the move.

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>