### PR TITLE
fix: hide drag overlay on mouse drag leave

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -326,7 +326,7 @@ export default class App extends Mixins(StateMixin, FilesMixin, BrowserMixin) {
 
   mounted () {
     window.addEventListener('dragover', this.handleDragOver)
-    window.addEventListener('dragenter', this.handleDragEnter)
+    window.addEventListener('dragenter', this.handleDragOver)
     window.addEventListener('dragleave', this.handleDragLeave)
     window.addEventListener('drop', this.handleDrop)
     window.addEventListener('keydown', this.handleKeyDown, false)
@@ -359,7 +359,7 @@ export default class App extends Mixins(StateMixin, FilesMixin, BrowserMixin) {
 
   beforeDestroy () {
     window.removeEventListener('dragover', this.handleDragOver)
-    window.removeEventListener('dragenter', this.handleDragEnter)
+    window.removeEventListener('dragenter', this.handleDragOver)
     window.removeEventListener('dragleave', this.handleDragLeave)
     window.removeEventListener('drop', this.handleDrop)
     window.removeEventListener('keydown', this.handleKeyDown)
@@ -384,12 +384,6 @@ export default class App extends Mixins(StateMixin, FilesMixin, BrowserMixin) {
       this.dragState = true
 
       event.dataTransfer.dropEffect = 'copy'
-    }
-  }
-
-  handleDragEnter (event: DragEvent) {
-    if (this.fileDropRoot) {
-      event.preventDefault()
     }
   }
 

--- a/src/components/ui/AppDragOverlay.vue
+++ b/src/components/ui/AppDragOverlay.vue
@@ -49,6 +49,7 @@ export default class AppDragOverlay extends Vue {
 <style lang="scss" scoped>
   .dragOverlay.v-overlay--active {
     border: dashed 3px #616161;
+    pointer-events: none !important;
   }
 
   .dragOverlay :deep(.v-overlay__content) {


### PR DESCRIPTION
The main issue here I believe was with the fact that the overlay would start with `pointer-events` enabled even though we are disabling from the root element via code, so there was a small race condition.

Setting `pointer-events: none` on the overlay styling seems to have solved that problem.

Furthermore, the `dragenter` event seems to work better using the same code as `dragover` so I made both methods use the same handler.

I've tested this on Windows 11 with the Chrome (latest), Firefox (latest) and Edge (latest dev version) and got it working perfectly on all of them.

Fixes #1450 