### PR TITLE
feat: increase Z precision to 3 decimals

### DIFF
--- a/src/components/ui/AppNamedSlider.vue
+++ b/src/components/ui/AppNamedSlider.vue
@@ -96,7 +96,9 @@ import type { InputValidationRules } from 'vuetify'
 import type { VForm } from '@/types'
 import BrowserMixin from '@/mixins/browser'
 
-@Component({})
+@Component({
+  inheritAttrs: false
+})
 export default class AppNamedSlider extends Mixins(BrowserMixin) {
   @VModel({ type: Number, required: true })
     inputValue!: number

--- a/src/components/ui/AppTextField.vue
+++ b/src/components/ui/AppTextField.vue
@@ -6,6 +6,10 @@
     <v-text-field
       v-bind="$attrs"
       v-model="currentValue"
+      :class="{
+        'v-input--width-small': small,
+        'v-input--width-x-small': xSmall
+      }"
       v-on="filteredListeners"
       @focus="handleFocus"
       @blur="handleBlur"
@@ -21,12 +25,20 @@
 
 <script lang="ts">
 import type { VForm } from '@/types'
-import { Component, Vue, VModel, Watch, Ref } from 'vue-property-decorator'
+import { Component, Vue, VModel, Watch, Ref, Prop } from 'vue-property-decorator'
 
-@Component({})
+@Component({
+  inheritAttrs: false
+})
 export default class AppTextField extends Vue {
   @VModel()
     inputValue!: unknown
+
+  @Prop({ type: Boolean })
+  readonly small?: boolean
+
+  @Prop({ type: Boolean })
+  readonly xSmall?: boolean
 
   @Ref('form')
   readonly form!: VForm

--- a/src/components/widgets/thermals/TemperatureTargets.vue
+++ b/src/components/widgets/thermals/TemperatureTargets.vue
@@ -90,7 +90,7 @@
               single-line
               hide-details="auto"
               suffix="°C"
-              class="v-input--width-x-small"
+              x-small
               @submit="setHeaterTargetTemp(item.name, +$event)"
             />
           </td>
@@ -173,7 +173,7 @@
               single-line
               hide-details="auto"
               suffix="°C"
-              class="v-input--width-x-small"
+              x-small
               @submit="setFanTargetTemp(item.name, +$event)"
             />
           </td>

--- a/src/components/widgets/toolhead/ToolheadPosition.vue
+++ b/src/components/widgets/toolhead/ToolheadPosition.vue
@@ -9,57 +9,66 @@
         cols="3"
         class="pr-1"
       >
-        <v-text-field
+        <app-text-field
           :color="(forceMove) ? 'error' : 'primary'"
           :label="`X [ ${livePosition[0].toFixed(2)} ]`"
+          :rules="[
+            $rules.required,
+            $rules.numberValid
+          ]"
           outlined
           hide-details
           dense
-          class="v-input--width-small"
+          small
           type="number"
           :disabled="!klippyReady || (!xHomed && !xForceMove)"
           :readonly="printerBusy"
           :value="(useGcodeCoords) ? gcodePosition[0].toFixed(2) : toolheadPosition[0].toFixed(2)"
-          @change="moveAxisTo('X', $event)"
-          @focus="$event.target.select()"
+          @submit="moveAxisTo('X', +$event)"
         />
       </v-col>
       <v-col
         cols="3"
         class="pr-1 pl-1"
       >
-        <v-text-field
+        <app-text-field
           :color="(forceMove) ? 'error' : 'primary'"
           :label="`Y [ ${livePosition[1].toFixed(2)} ]`"
+          :rules="[
+            $rules.required,
+            $rules.numberValid
+          ]"
           outlined
           hide-details
           dense
-          class="v-input--width-small"
+          small
           type="number"
           :disabled="!klippyReady || (!yHomed && !yForceMove)"
           :readonly="printerBusy"
           :value="(useGcodeCoords) ? gcodePosition[1].toFixed(2) : toolheadPosition[1].toFixed(2)"
-          @change="moveAxisTo('Y', $event)"
-          @focus="$event.target.select()"
+          @submit="moveAxisTo('Y', +$event)"
         />
       </v-col>
       <v-col
         cols="3"
         class="pr-1 pl-1"
       >
-        <v-text-field
+        <app-text-field
           :color="(forceMove) ? 'error' : 'primary'"
-          :label="`Z [ ${livePosition[2].toFixed(2)} ]`"
+          :label="`Z [ ${livePosition[2].toFixed(3)} ]`"
+          :rules="[
+            $rules.required,
+            $rules.numberValid
+          ]"
           outlined
           hide-details
           dense
-          class="v-input--width-small"
+          small
           type="number"
           :disabled="!klippyReady || (!zHomed && !zForceMove)"
           :readonly="printerBusy"
-          :value="(useGcodeCoords) ? gcodePosition[2].toFixed(2) : toolheadPosition[2].toFixed(2)"
-          @change="moveAxisTo('Z', $event)"
-          @focus="$event.target.select()"
+          :value="(useGcodeCoords) ? gcodePosition[2].toFixed(3) : toolheadPosition[2].toFixed(3)"
+          @submit="moveAxisTo('Z', +$event)"
         />
       </v-col>
       <v-col
@@ -113,6 +122,14 @@ import { Component, Mixins } from 'vue-property-decorator'
 import StateMixin from '@/mixins/state'
 import ToolheadMixin from '@/mixins/toolhead'
 
+type Axis = 'X' | 'Y' | 'Z'
+
+const axisIndexMap: Record<Axis, number> = {
+  X: 0,
+  Y: 1,
+  Z: 2
+}
+
 @Component({})
 export default class ToolheadPosition extends Mixins(StateMixin, ToolheadMixin) {
   get gcodePosition () {
@@ -159,17 +176,19 @@ export default class ToolheadPosition extends Mixins(StateMixin, ToolheadMixin) 
     this.sendGcode(`G9${value}`)
   }
 
-  moveAxisTo (axis: string, pos: string) {
-    const axisIndexMap: any = { X: 0, Y: 1, Z: 2 }
-    const currentPos = (this.useGcodeCoords)
-      ? this.gcodePosition[axisIndexMap[axis]]
-      : this.toolheadPosition[axisIndexMap[axis]]
-    if (parseInt(currentPos) !== parseInt(pos)) {
-      const rate = (axis.toLowerCase() === 'z')
+  moveAxisTo (axis: Axis, pos: number) {
+    const axisIndex = axisIndexMap[axis]
+    const currentPos = this.useGcodeCoords
+      ? this.gcodePosition[axisIndex]
+      : this.toolheadPosition[axisIndex]
+
+    if (currentPos !== pos) {
+      const rate = axis === 'Z'
         ? this.$store.state.config.uiSettings.general.defaultToolheadZSpeed
         : this.$store.state.config.uiSettings.general.defaultToolheadXYSpeed
+
       if (this.forceMove) {
-        const accel = (axis.toLowerCase() === 'z')
+        const accel = axis === 'Z'
           ? this.$store.getters['printer/getPrinterSettings']('printer.max_z_accel')
           : this.$store.state.printer.printer.toolhead.max_accel
         this.sendGcode(`FORCE_MOVE STEPPER=stepper_${axis.toLowerCase()} DISTANCE=${pos} VELOCITY=${rate} ACCEL=${accel}`)


### PR DESCRIPTION
Increases the precision of Z from 2 to 3 decimal places.

**Note:** this also changes the current behavior of executing the change on lost-focus to only do it on <kbd>Enter</kbd> key pressed - just like every single other input on the dashboard!

Resolves #1502