### PR TITLE
feat(FileSystem): allow filtering Moonraker temp upload files

### DIFF
--- a/src/components/widgets/filesystem/FileSystem.vue
+++ b/src/components/widgets/filesystem/FileSystem.vue
@@ -407,6 +407,12 @@ export default class FileSystem extends Mixins(StateMixin, FilesMixin, ServicesM
             }
             break
 
+          case 'moonraker_temporary_upload_files':
+            if (file.name.endsWith('.mru')) {
+              return false
+            }
+            break
+
           case 'klipper_backup_files':
             if (file.type === 'file' && file.filename.match(/^printer-\d{8}_\d{6}\.cfg$/)) {
               return false

--- a/src/components/widgets/filesystem/FileSystemFilterMenu.vue
+++ b/src/components/widgets/filesystem/FileSystemFilterMenu.vue
@@ -120,6 +120,13 @@ export default class FileSystemFilterMenu extends Vue {
       })
     }
 
+    if (rootFilterTypes.includes('moonraker_temporary_upload_files')) {
+      filters.push({
+        type: 'moonraker_temporary_upload_files',
+        text: this.$tc('app.file_system.filters.label.moonraker_temporary_upload_files')
+      })
+    }
+
     if (rootFilterTypes.includes('rolled_log_files')) {
       filters.push({
         type: 'rolled_log_files',

--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -76,6 +76,7 @@ app:
         hidden_files_folders: Filter hidden files and folders
         klipper_backup_files: Filter Klipper backup files
         moonraker_backup_files: Filter Moonraker backup files
+        moonraker_temporary_upload_files: Filter Moonraker temporary upload files
         rolled_log_files: Filter rolled log files
     label:
       dir_name: Directory name

--- a/src/store/files/getters.ts
+++ b/src/store/files/getters.ts
@@ -112,7 +112,7 @@ export const getters: GetterTree<FilesState, RootState> = {
           accepts: ['.gcode', '.g', '.gc', '.gco', '.ufp', '.nc'],
           canView,
           canConfigure: true,
-          filterTypes: ['hidden_files', 'print_start_time']
+          filterTypes: ['hidden_files', 'print_start_time', 'moonraker_temporary_upload_files']
         }
       case 'config':
         return {
@@ -120,7 +120,7 @@ export const getters: GetterTree<FilesState, RootState> = {
           accepts: ['.conf', '.cfg', '.md', '.css', '.jpg', '.jpeg', '.png', '.gif'],
           canView,
           canConfigure: false,
-          filterTypes: ['hidden_files', 'klipper_backup_files', 'moonraker_backup_files', 'crowsnest_backup_files']
+          filterTypes: ['hidden_files', 'klipper_backup_files', 'moonraker_backup_files', 'moonraker_temporary_upload_files', 'crowsnest_backup_files']
         }
       case 'config_examples':
         return {
@@ -152,7 +152,7 @@ export const getters: GetterTree<FilesState, RootState> = {
           accepts: [],
           canView,
           canConfigure: false,
-          filterTypes: ['hidden_files']
+          filterTypes: ['hidden_files', 'moonraker_temporary_upload_files']
         }
       default:
         return {

--- a/src/store/files/types.ts
+++ b/src/store/files/types.ts
@@ -108,7 +108,7 @@ export interface FilesUpload extends FileDownload {
   cancelled: boolean; // in a cancelled state, don't show - nor try to upload.
 }
 
-export type FileFilterType = 'print_start_time' | 'hidden_files' | 'klipper_backup_files' | 'rolled_log_files' | 'moonraker_backup_files' | 'crowsnest_backup_files'
+export type FileFilterType = 'print_start_time' | 'hidden_files' | 'klipper_backup_files' | 'rolled_log_files' | 'moonraker_backup_files' | 'moonraker_temporary_upload_files' | 'crowsnest_backup_files'
 
 export type FileBrowserEntry = AppFile | AppFileWithMeta | AppDirectory
 


### PR DESCRIPTION
Adds a new optional file system filter for Moonraker temporary upload files (.mru)

![image](https://github.com/user-attachments/assets/db5ef84a-ab20-4887-9089-7e87d45e1716)

Resolves #1503