### PR TITLE
style(Console): single auto-complete console entry

### DIFF
--- a/src/components/widgets/console/ConsoleCommand.vue
+++ b/src/components/widgets/console/ConsoleCommand.vue
@@ -135,11 +135,11 @@ export default class ConsoleCommand extends Vue {
 
       if (commands.length === 1) {
         this.emitChange(commands[0])
-      } else {
-        commands.forEach(command => {
-          const message = `// ${command}: ${availableCommands[command].help ?? ''}`
-          this.$store.dispatch('console/onAddConsoleEntry', { message, type: 'response' })
-        })
+      } else if (commands.length > 0) {
+        const message = commands
+          .map(command => `// ${command}: ${availableCommands[command].help ?? ''}`)
+          .join('\n')
+        this.$store.dispatch('console/onAddConsoleEntry', { message, type: 'response' })
       }
     }
   }


### PR DESCRIPTION
Use a single entry to show the auto-complete options, thus making it easier to read.

This also matches the output format we get from `HELP` command, so makes it more "familiar".

## Before

![image](https://github.com/user-attachments/assets/917cae5e-5d8f-4442-9126-1258991c9e1b)

## After

![image](https://github.com/user-attachments/assets/16dc513c-4fee-4c02-99ce-143da1de0a66)
