### PR TITLE
fix(Charts): allow resetting chart store only

### DIFF
--- a/src/components/widgets/thermals/TemperatureTargets.vue
+++ b/src/components/widgets/thermals/TemperatureTargets.vue
@@ -260,10 +260,6 @@ import type { ChartData, ChartSelectedLegends } from '@/store/charts/types'
   }
 })
 export default class TemperatureTargets extends Mixins(StateMixin) {
-  get extruder () {
-    return this.$store.state.printer.printer.extruder
-  }
-
   get heaters () {
     return this.$store.getters['printer/getHeaters']
   }

--- a/src/mixins/services.ts
+++ b/src/mixins/services.ts
@@ -20,13 +20,7 @@ export default class ServicesMixin extends Vue {
    * Resets the UI when restarting/resetting Klipper
    */
   async _klipperReset () {
-    this.$store.commit('socket/setAcceptNotifications', false)
-    await this.$store.dispatch('server/resetKlippy', undefined, { root: true })
-    await this.$store.dispatch('reset', [
-      'printer',
-      'charts',
-      'wait'
-    ], { root: true })
+    await this.$store.dispatch('resetKlippy', undefined, { root: true })
   }
 
   /**

--- a/src/store/charts/actions.ts
+++ b/src/store/charts/actions.ts
@@ -13,6 +13,10 @@ export const actions: ActionTree<ChartState, RootState> = {
     commit('setReset')
   },
 
+  async resetChartStore ({ commit }) {
+    commit('setResetChartStore')
+  },
+
   /**
    * Loads stored server data for the past 20 minutes.
    */

--- a/src/store/charts/mutations.ts
+++ b/src/store/charts/mutations.ts
@@ -17,6 +17,15 @@ export const mutations: MutationTree<ChartState> = {
     Object.assign(state, defaultState())
   },
 
+  setResetChartStore (state) {
+    const { chart, ready } = defaultState()
+
+    Object.assign(state, {
+      chart,
+      ready
+    })
+  },
+
   /**
    * Init the chart store from db
    */

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -93,6 +93,19 @@ export default new Vuex.Store<RootState>({
       commit('config/setAppReady', true)
     },
 
+    async resetKlippy ({ dispatch, commit }) {
+      commit('socket/setAcceptNotifications', false)
+
+      await Promise.all([
+        dispatch('server/resetKlippy'),
+        dispatch('charts/resetChartStore'),
+        dispatch('reset', [
+          'printer',
+          'wait'
+        ])
+      ])
+    },
+
     /**
      * A void action. Some socket commands may not need processing.
      */

--- a/src/store/socket/actions.ts
+++ b/src/store/socket/actions.ts
@@ -157,7 +157,9 @@ export const actions: ActionTree<SocketState, RootState> = {
   /**
    * This is fired when, for example - the service is stopped.
    */
-  async notifyKlippyDisconnected () {
+  async notifyKlippyDisconnected ({ dispatch }) {
+    await dispatch('resetKlippy', undefined, { root: true })
+
     SocketActions.serverInfo()
   },
 


### PR DESCRIPTION
Ensures we ONLY clear the chart data on reset, and not the whole chart state (that includes the selected sensors and heaters!)

Fixes #1297 