### PR TITLE
feat: adds setting for files and folders drag & drop

### DIFF
--- a/src/components/settings/FileBrowserSettings.vue
+++ b/src/components/settings/FileBrowserSettings.vue
@@ -17,6 +17,19 @@
           :items="availableTextSortOrders"
         />
       </app-setting>
+
+      <v-divider />
+
+      <app-setting
+        :title="$t('app.setting.label.drag_and_drop_functionality_for_files_and_folders')"
+      >
+        <v-switch
+          v-model="filesAndFoldersDragAndDrop"
+          hide-details
+          class="mb-5"
+          @click.native.stop
+        />
+      </app-setting>
     </v-card>
   </div>
 </template>
@@ -54,6 +67,18 @@ export default class FileEditorSettings extends Vue {
         text: this.$t('app.general.label.version_sort')
       }
     ]
+  }
+
+  get filesAndFoldersDragAndDrop (): boolean {
+    return this.$store.state.config.uiSettings.general.filesAndFoldersDragAndDrop
+  }
+
+  set filesAndFoldersDragAndDrop (value: boolean) {
+    this.$store.dispatch('config/saveByPath', {
+      path: 'uiSettings.general.filesAndFoldersDragAndDrop',
+      value,
+      server: true
+    })
   }
 }
 </script>

--- a/src/components/widgets/filesystem/FileSystemBrowser.vue
+++ b/src/components/widgets/filesystem/FileSystemBrowser.vue
@@ -354,6 +354,10 @@ export default class FileSystemBrowser extends Mixins(FilesMixin) {
     return this.$store.state.config.uiSettings.general.textSortOrder
   }
 
+  get filesAndFoldersDragAndDrop (): boolean {
+    return this.$store.state.config.uiSettings.general.filesAndFoldersDragAndDrop
+  }
+
   get draggedItems () {
     if (this.dragItem) {
       const filteredSelectedItems = this.selected
@@ -430,6 +434,7 @@ export default class FileSystemBrowser extends Mixins(FilesMixin) {
   // Determines if a row is currently in a draggable state or not.
   isItemDraggable (item: FileBrowserEntry) {
     return (
+      this.filesAndFoldersDragAndDrop &&
       item.name !== '..' &&
       this.files.length > 0 &&
       (

--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -648,6 +648,7 @@ app:
       date_format: Date format
       time_format: Time format
       text_sort_order: Text sort order
+      drag_and_drop_functionality_for_files_and_folders: Drag-and-drop functionality for files and folders
       force_move_toggle_warning: Require confirm when activating FORCE_MOVE
       show_manual_probe_dialog_automatically: Show Manual Probe dialog automatically
       show_bed_screws_adjust_dialog_automatically: Show Bed Screws Adjust dialog automatically

--- a/src/store/config/state.ts
+++ b/src/store/config/state.ts
@@ -49,6 +49,7 @@ export const defaultState = (): ConfigState => {
         timeFormat: 'iso',
         enableKeyboardShortcuts: true,
         textSortOrder: 'default',
+        filesAndFoldersDragAndDrop: true,
         showRateOfChange: false,
         showRelativeHumidity: true,
         showBarometricPressure: true,

--- a/src/store/config/types.ts
+++ b/src/store/config/types.ts
@@ -86,6 +86,7 @@ export interface GeneralConfig {
   timeFormat: string;
   enableKeyboardShortcuts: boolean;
   textSortOrder: TextSortOrder;
+  filesAndFoldersDragAndDrop: boolean;
   showRateOfChange: boolean;
   showRelativeHumidity: boolean;
   showBarometricPressure: boolean;


### PR DESCRIPTION
Adds a new setting that enables or disables drag & drop of files and folders in the File Browser.

![image](https://github.com/user-attachments/assets/72726f2b-d9f2-4185-858f-6241ec8610af)

Resolves #1521