### PR TITLE
feat: allow user selection of device camera

### DIFF
--- a/src/components/widgets/camera/CameraItem.vue
+++ b/src/components/widgets/camera/CameraItem.vue
@@ -11,8 +11,10 @@
         :camera="camera"
         :crossorigin="crossorigin"
         class="camera-image"
-        @raw-camera-url="rawCameraUrl = $event"
-        @frames-per-second="framesPerSecond = $event"
+        @update:camera-name="cameraName = $event"
+        @update:camera-name-menu-items="cameraNameMenuItems = $event"
+        @update:raw-camera-url="rawCameraUrl = $event"
+        @update:frames-per-second="framesPerSecond = $event"
         @playback="setupFrameEvents()"
       />
     </template>
@@ -20,12 +22,57 @@
       Camera service not supported!
     </div>
 
-    <div
-      v-if="camera.name"
-      class="camera-name"
-    >
-      {{ camera.name }}
-    </div>
+    <template v-if="cameraName || camera.name">
+      <v-menu
+        v-if="cameraNameMenuItems.length > 0"
+        top
+        offset-y
+        transition="slide-y-reverse-transition"
+      >
+        <template #activator="{ on, attrs, value }">
+          <div
+            v-bind="attrs"
+            class="camera-name"
+            v-on="on"
+          >
+            {{ cameraName || camera.name }}
+            <v-icon
+              small
+              class="ml-1"
+              :class="{ 'rotate-180': value }"
+            >
+              $chevronDown
+            </v-icon>
+          </div>
+        </template>
+        <v-list dense>
+          <v-list-item
+            v-for="(item, index) in cameraNameMenuItems"
+            :key="index"
+            @click="cameraNameMenuItemClick(item.value)"
+          >
+            <v-list-item-icon>
+              <v-icon>
+                $camera
+              </v-icon>
+            </v-list-item-icon>
+            <v-list-item-content>
+              <v-list-item-title>
+                {{ item.text }}
+              </v-list-item-title>
+            </v-list-item-content>
+          </v-list-item>
+        </v-list>
+      </v-menu>
+
+      <div
+        v-else
+        class="camera-name"
+      >
+        {{ cameraName || camera.name }}
+      </div>
+    </template>
+
     <div
       v-if="framesPerSecond"
       class="camera-frames"
@@ -78,6 +125,8 @@ export default class CameraItem extends Vue {
 
   rawCameraUrl: string | null = null
   framesPerSecond: string | null = null
+  cameraName: string | null = null
+  cameraNameMenuItems: { text: string, value: string }[] = []
 
   mounted () {
     this.setupFrameEvents()
@@ -100,14 +149,20 @@ export default class CameraItem extends Vue {
     }
 
     if (animate) {
-      requestAnimationFrame(() => this.handleFrame(this.componentInstance.animating))
+      requestAnimationFrame(() => this.handleFrame(this.componentInstance?.animating ?? false))
     }
+  }
+
+  cameraNameMenuItemClick (value: string) {
+    this.componentInstance.menuItemClick(value)
   }
 
   @Watch('camera')
   onCamera () {
     this.rawCameraUrl = ''
     this.framesPerSecond = ''
+    this.cameraName = ''
+    this.cameraNameMenuItems = []
   }
 
   get fullscreenMode (): CameraFullscreenAction {

--- a/src/components/widgets/camera/services/DeviceCamera.vue
+++ b/src/components/widgets/camera/services/DeviceCamera.vue
@@ -10,20 +10,128 @@
 <script lang="ts">
 import { Component, Ref, Mixins } from 'vue-property-decorator'
 import CameraMixin from '@/mixins/camera'
+import consola from 'consola'
 
 @Component({})
 export default class DeviceCamera extends Mixins(CameraMixin) {
   @Ref('streamingElement')
   readonly cameraVideo!: HTMLVideoElement
 
-  startPlayback () {
-    navigator.mediaDevices.getUserMedia({ video: true })
-      .then(stream => (this.cameraVideo.srcObject = stream))
-      .then(() => this.$emit('playback'))
+  cameraNameMenuItems: { text: string, value: string }[] = []
+
+  async startPlayback () {
+    const stream = await this.getUserMedia()
+
+    this.cameraVideo.srcObject = stream
+    this.$emit('playback')
+
+    this.$emit('update:camera-name', await this.getDeviceLabel())
   }
 
   stopPlayback () {
+    try {
+      const stream = this.cameraVideo.srcObject as MediaStream
+
+      if (stream) {
+        for (const track of stream.getTracks()) {
+          track.stop()
+          stream.removeTrack(track)
+        }
+      }
+    } catch (e) {
+      consola.error('[Device Camera] failed to stop and remove all tracks', e)
+    }
+
     this.cameraVideo.srcObject = null
+  }
+
+  async getUserMedia () {
+    const selectedDeviceCamera = this.getSelectedDeviceCamera()
+
+    try {
+      const key: keyof MediaTrackConstraints = ['environment', 'user'].includes(selectedDeviceCamera)
+        ? 'facingMode'
+        : 'deviceId'
+
+      return await navigator.mediaDevices.getUserMedia({
+        video: {
+          [key]: selectedDeviceCamera
+        }
+      })
+    } catch (e) {
+      consola.error(`[Device Camera] failed to select device ${selectedDeviceCamera}`, e)
+
+      this.setSelectedDeviceCamera(null)
+
+      return await navigator.mediaDevices.getUserMedia({
+        video: {
+          facingMode: 'environment'
+        }
+      })
+    }
+  }
+
+  async enumerateDevices () {
+    try {
+      const devices = await navigator.mediaDevices.enumerateDevices()
+
+      return devices
+        .filter(device => device.kind === 'videoinput')
+    } catch (e) {
+      consola.error('[Device Camera] failed to enumerate devices', e)
+
+      return []
+    }
+  }
+
+  async getDeviceLabel () {
+    if (this.cameraNameMenuItems.length === 0) {
+      const devices = await this.enumerateDevices()
+
+      this.cameraNameMenuItems = [
+        {
+          text: this.$tc('app.general.label.environment_facing'),
+          value: 'environment'
+        },
+        {
+          text: this.$tc('app.general.label.user_facing'),
+          value: 'user'
+        },
+        ...devices
+          .map(device => ({
+            text: device.label,
+            value: device.deviceId
+          }))
+      ]
+
+      this.$emit('update:camera-name-menu-items', this.cameraNameMenuItems)
+    }
+
+    const selectedDeviceCamera = this.getSelectedDeviceCamera()
+
+    return this.cameraNameMenuItems
+      .find(item => item.value === selectedDeviceCamera)?.text
+  }
+
+  getSelectedDeviceCamera () {
+    return localStorage.getItem('deviceCamera.selectedCamera') ?? 'environment'
+  }
+
+  setSelectedDeviceCamera (value?: string | null) {
+    if (value) {
+      localStorage.setItem('deviceCamera.selectedCamera', value)
+    } else {
+      localStorage.removeItem('deviceCamera.selectedCamera')
+    }
+  }
+
+  menuItemClick (value: string) {
+    if (this.getSelectedDeviceCamera() !== value) {
+      this.setSelectedDeviceCamera(value)
+
+      this.stopPlayback()
+      this.startPlayback()
+    }
   }
 }
 </script>

--- a/src/components/widgets/camera/services/IframeCamera.vue
+++ b/src/components/widgets/camera/services/IframeCamera.vue
@@ -26,7 +26,7 @@ export default class IframeCamera extends Mixins(CameraMixin) {
 
     this.cameraIFrameSource = url
 
-    this.$emit('raw-camera-url', url)
+    this.$emit('update:raw-camera-url', url)
   }
 
   stopPlayback () {

--- a/src/components/widgets/camera/services/IpstreamCamera.vue
+++ b/src/components/widgets/camera/services/IpstreamCamera.vue
@@ -25,7 +25,7 @@ export default class IpstreamCamera extends Mixins(CameraMixin) {
 
     this.cameraVideoSource = url
 
-    this.$emit('raw-camera-url', url)
+    this.$emit('update:raw-camera-url', url)
   }
 
   stopPlayback () {

--- a/src/components/widgets/camera/services/MjpegstreamerAdaptiveCamera.vue
+++ b/src/components/widgets/camera/services/MjpegstreamerAdaptiveCamera.vue
@@ -52,7 +52,7 @@ export default class MjpegstreamerAdaptiveCamera extends Mixins(CameraMixin) {
     if (!document.hidden) {
       const framesPerSecond = Math.round(1000 / this.time).toString().padStart(2, '0')
 
-      this.$emit('frames-per-second', framesPerSecond)
+      this.$emit('update:frames-per-second', framesPerSecond)
 
       this.$nextTick(() => this.updateCameraImageSource())
     } else {
@@ -81,7 +81,7 @@ export default class MjpegstreamerAdaptiveCamera extends Mixins(CameraMixin) {
 
     rawUrl.searchParams.set('cacheBust', Date.now().toString())
 
-    this.$emit('raw-camera-url', rawUrl.toString())
+    this.$emit('update:raw-camera-url', rawUrl.toString())
   }
 
   stopPlayback () {

--- a/src/components/widgets/camera/services/MjpegstreamerCamera.vue
+++ b/src/components/widgets/camera/services/MjpegstreamerCamera.vue
@@ -25,7 +25,7 @@ export default class MjpegstreamerCamera extends Mixins(CameraMixin) {
 
     this.cameraImageSource = url.toString()
 
-    this.$emit('raw-camera-url', this.cameraImageSource)
+    this.$emit('update:raw-camera-url', this.cameraImageSource)
   }
 
   stopPlayback () {

--- a/src/components/widgets/camera/services/WebrtcCamerastreamerCamera.vue
+++ b/src/components/widgets/camera/services/WebrtcCamerastreamerCamera.vue
@@ -108,6 +108,7 @@ export default class WebrtcCamerastreamerCamera extends Mixins(CameraMixin) {
     this.pc?.close()
     this.pc = null
     this.cameraVideo.src = ''
+    this.cameraVideo.srcObject = null
   }
 }
 </script>

--- a/src/components/widgets/camera/services/WebrtcGo2RtcCamera.vue
+++ b/src/components/widgets/camera/services/WebrtcGo2RtcCamera.vue
@@ -59,7 +59,7 @@ export default class WebrtcGo2RtcCamera extends Mixins(CameraMixin) {
     this.ws.onmessage = this.onWebSocketMessage
     this.ws.onclose = this.onWebSocketClose
 
-    this.$emit('raw-camera-url', url)
+    this.$emit('update:raw-camera-url', url.toString())
   }
 
   async onWebSocketOpen () {

--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -258,11 +258,13 @@ app:
       current_password: Current password
       current_user: Current user
       default: Default
+      device: Device
       disabled_while_printing: Disabled while printing
       edit_camera: Edit Camera
       edit_filter: Edit Filter
       edit_preset: Edit Preset
       edit_user: Edit user
+      environment_facing: Environment Facing
       extrude_length: Extrude Length
       extrude_speed: Extrude Speed
       filament: Filament
@@ -332,6 +334,7 @@ app:
       unretract_speed: Unretract Speed
       upload_and_print: Upload and Print
       used: used
+      user_facing: User Facing
       username: Username
       velocity: Velocity
       version_sort: Version sort

--- a/src/mixins/camera.ts
+++ b/src/mixins/camera.ts
@@ -1,6 +1,7 @@
 import Vue from 'vue'
 import { Component, Prop, Ref, Watch } from 'vue-property-decorator'
 import type { WebcamConfig } from '@/store/webcams/types'
+import consola from 'consola'
 
 @Component
 export default class CameraMixin extends Vue {
@@ -115,5 +116,9 @@ export default class CameraMixin extends Vue {
 
   stopPlayback () {
     // noop
+  }
+
+  menuItemClick (value: string) {
+    consola.debug('Menu item click', value)
   }
 }


### PR DESCRIPTION
When Device camera is selected in Spoolman, we will now show a small menu where the camera name is to allow the user to change the device camera:

![image](https://github.com/user-attachments/assets/20cf2747-2f10-4a9b-87b1-3d75d01e5e30)

By default, we will select the "environment facing" camera (on the phone/tablet that will be the back camera if available, on a computer it will be whatever camera it can find)

The last camera selected will be stored in the browser local storage so that it gets picked up again next time - without affecting other browsers/devices.

Resolves #1541