### PR TITLE
fix: group and wrap tool change commands

### DIFF
--- a/src/components/widgets/toolhead/ToolChangeCommands.vue
+++ b/src/components/widgets/toolhead/ToolChangeCommands.vue
@@ -1,6 +1,10 @@
 <template>
   <v-row v-if="toolChangeCommands.length > 0">
-    <v-col>
+    <v-col
+      v-for="(toolChangeCommandsGroup, index2) in toolChangeCommandsGrouped"
+      :key="index2"
+      cols="12"
+    >
       <app-btn-group
         class="app-toolchanger-control d-flex"
         :class="{
@@ -8,7 +12,7 @@
         }"
       >
         <v-tooltip
-          v-for="(macro, index) of toolChangeCommands"
+          v-for="(macro, index) of toolChangeCommandsGroup"
           :key="index"
           top
         >
@@ -55,6 +59,7 @@ import StateMixin from '@/mixins/state'
 import type { GcodeCommands } from '@/store/printer/types'
 import type { TranslateResult } from 'vue-i18n'
 import type { Spool } from '@/store/spoolman/types'
+import { chunk } from 'lodash-es'
 
 type ToolChangeCommand = {
   name: string,
@@ -97,6 +102,14 @@ export default class ToolChangeCommands extends Mixins(StateMixin) {
 
         return numberA - numberB
       })
+  }
+
+  get toolChangeCommandsGrouped (): ToolChangeCommand[][] {
+    const toolChangeCommands = this.toolChangeCommands
+
+    const cols = Math.ceil(toolChangeCommands.length / Math.ceil(toolChangeCommands.length / 6))
+
+    return chunk(toolChangeCommands, cols)
   }
 
   getSpoolById (id: number): Spool | undefined {


### PR DESCRIPTION
Attempt to group and wrap tool change commands so that it doesn't overflow and hide the buttons.

## Before

![image](https://github.com/user-attachments/assets/0332a90d-847c-4228-b4ae-6314fc397533)

## After

![image](https://github.com/user-attachments/assets/8ccf13b1-3d93-47ab-ad0a-3f98816c41bc)

Fixes #1526