### PR TITLE
feat: adds Adjust Dashboard Layout sidebar button

### DIFF
--- a/src/components/common/SystemLayout.vue
+++ b/src/components/common/SystemLayout.vue
@@ -1,5 +1,8 @@
 <template>
-  <v-list dense>
+  <v-list
+    v-if="canEditLayout"
+    dense
+  >
     <v-subheader>{{ $t('app.general.label.layout') }}</v-subheader>
 
     <v-list-item @click.prevent="layoutMode = !layoutMode">
@@ -22,6 +25,10 @@ import StateMixin from '@/mixins/state'
 
 @Component({})
 export default class SystemLayout extends Mixins(StateMixin) {
+  get canEditLayout () {
+    return this.$route.meta?.dashboard ?? false
+  }
+
   get layoutMode (): boolean {
     return this.$store.state.config.layoutMode
   }

--- a/src/components/layout/AppNavDrawer.vue
+++ b/src/components/layout/AppNavDrawer.vue
@@ -112,6 +112,30 @@
             {{ $t('app.general.title.settings') }}
           </app-nav-item>
         </div>
+
+        <template
+          v-if="!isMobileViewport && canEditLayout"
+          #append
+        >
+          <v-tooltip right>
+            <template #activator="{ attrs, on }">
+              <app-btn
+                icon
+                large
+                :color="layoutMode ? 'primary' : undefined"
+                style="margin: 6px"
+                v-bind="attrs"
+                v-on="on"
+                @click="layoutMode = !layoutMode"
+              >
+                <v-icon>$apps</v-icon>
+              </app-btn>
+            </template>
+            <span>
+              {{ $t('app.general.btn.adjust_layout') }}
+            </span>
+          </v-tooltip>
+        </template>
       </v-navigation-drawer>
 
       <router-view
@@ -151,6 +175,18 @@ export default class AppNavDrawer extends Mixins(StateMixin, BrowserMixin) {
 
   get showSubNavigation () {
     return this.hasSubNavigation && this.socketConnected && this.authenticated
+  }
+
+  get canEditLayout () {
+    return this.$route.meta?.dashboard ?? false
+  }
+
+  get layoutMode (): boolean {
+    return this.$store.state.config.layoutMode
+  }
+
+  set layoutMode (val: boolean) {
+    this.$store.commit('config/setLayoutMode', val)
   }
 }
 </script>

--- a/src/components/ui/AppTextFieldWithCopy.vue
+++ b/src/components/ui/AppTextFieldWithCopy.vue
@@ -15,7 +15,6 @@
           <app-btn
             v-bind="attrs"
             icon
-            text
             class="btn-copy"
             @click="handleCopy"
             v-on="on"

--- a/src/components/widgets/filesystem/FileSystemUploadDialog.vue
+++ b/src/components/widgets/filesystem/FileSystemUploadDialog.vue
@@ -51,7 +51,6 @@
             <app-btn
               color="error"
               icon
-              text
               :disabled="file.complete || file.percent === 100 || file.cancelled"
               @click="$emit('cancel', file)"
             >

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -45,7 +45,11 @@ const routes: Array<RouteConfig> = [
     path: '/',
     name: 'home',
     component: Dashboard,
-    ...defaultRouteConfig
+    ...defaultRouteConfig,
+    meta: {
+      ...defaultRouteConfig.meta,
+      dashboard: true
+    }
   },
   {
     path: '/console',
@@ -69,7 +73,11 @@ const routes: Array<RouteConfig> = [
     path: '/diagnostics',
     name: 'diagnostics',
     component: Diagnostics,
-    ...defaultRouteConfig
+    ...defaultRouteConfig,
+    meta: {
+      ...defaultRouteConfig.meta,
+      dashboard: true
+    }
   },
   {
     path: '/timelapse',
@@ -181,6 +189,7 @@ const router = new VueRouter({
 
 router.beforeEach((to, from, next) => {
   router.app?.$store.commit('config/setContainerColumnCount', 2)
+  router.app?.$store.commit('config/setLayoutMode', false)
   next()
 })
 


### PR DESCRIPTION
Adds a new Adjust Dashboard Layout button to the navigation sidebar, only visible on desktop mode (will not show on mobile)

The button will also only show for the Home and the Diagnostics pages as these are the only 2 editable dashboards we currently have (I've also applied this change to the existing Adjust Dashboard Layout on the right sidebar)

## Preview

![image](https://github.com/user-attachments/assets/9c71d2ed-477c-4434-b805-404242ac3dad)

Resolves #1545