### PR TITLE
fix: Moonraker canbus uuid parameter

### DIFF
--- a/src/components/common/PeripheralsDialog.vue
+++ b/src/components/common/PeripheralsDialog.vue
@@ -368,7 +368,8 @@ export default class ManualProbeDialog extends Mixins(StateMixin) {
         type: 'can',
         count: this.canbusUuids
           ? Object.values(this.canbusUuids)
-            .reduce((a, b) => a + b.length, 0)
+            .filter(value => Array.isArray(value))
+            .reduce((a, b) => a + (b ? b.length : 0), 0)
           : undefined
       })
     }
@@ -414,9 +415,9 @@ export default class ManualProbeDialog extends Mixins(StateMixin) {
           break
 
         case 'can':
-          for (const canbusInterface in this.canbusInterfaces) {
+          this.canbusInterfaces.forEach((canbusInterface) => {
             SocketActions.machinePeripheralsCanbus(canbusInterface)
-          }
+          })
           break
       }
     }

--- a/src/components/common/PeripheralsDialog.vue
+++ b/src/components/common/PeripheralsDialog.vue
@@ -368,8 +368,7 @@ export default class ManualProbeDialog extends Mixins(StateMixin) {
         type: 'can',
         count: this.canbusUuids
           ? Object.values(this.canbusUuids)
-            .filter(value => Array.isArray(value))
-            .reduce((a, b) => a + (b ? b.length : 0), 0)
+            .reduce((a, b) => a + b.length, 0)
           : undefined
       })
     }
@@ -415,9 +414,9 @@ export default class ManualProbeDialog extends Mixins(StateMixin) {
           break
 
         case 'can':
-          this.canbusInterfaces.forEach((canbusInterface) => {
+          for (const canbusInterface of this.canbusInterfaces) {
             SocketActions.machinePeripheralsCanbus(canbusInterface)
-          })
+          }
           break
       }
     }

--- a/src/store/server/mutations.ts
+++ b/src/store/server/mutations.ts
@@ -37,10 +37,10 @@ export const mutations: MutationTree<ServerState> = {
     }
   },
 
-  setMachinePeripheralsCanbus (state, payload: { canbusInterface: string, canUuids: CanbusUuid[] }) {
+  setMachinePeripheralsCanbus (state, payload: { canbusInterface: string, can_uuids: CanbusUuid[] }) {
     state.can_uuids = {
       ...state.can_uuids,
-      [payload.canbusInterface]: payload.canUuids
+      [payload.canbusInterface]: payload.can_uuids
     }
   },
 


### PR DESCRIPTION
* The can interface sent to the backend should be "can0", "can1", not "0" or "1".

Signed-off-by: XiaoK <xiaok@zxkxz.cn>