### PR TITLE
fix: clipboard copy on non-secure context

### DIFF
--- a/src/components/ui/AppTextFieldWithCopy.vue
+++ b/src/components/ui/AppTextFieldWithCopy.vue
@@ -38,6 +38,8 @@
 
 <script lang="ts">
 import { Component, VModel, Vue } from 'vue-property-decorator'
+import clipboardCopy from '@/util/clipboard-copy'
+import sleep from '@/util/sleep'
 
 @Component({
   inheritAttrs: false
@@ -47,19 +49,23 @@ export default class AppTextFieldWithCopy extends Vue {
   inputValue!: unknown
 
   hasCopied = false
+  abortController: AbortController | null = null
 
-  handleCopy () {
-    if (
-      this.inputValue &&
-      navigator.clipboard
-    ) {
-      navigator.clipboard.writeText(this.inputValue.toString())
+  async handleCopy () {
+    if (this.inputValue) {
+      if (await clipboardCopy(this.inputValue.toString(), this.$el)) {
+        this.abortController?.abort()
 
-      this.hasCopied = true
+        this.hasCopied = true
 
-      setTimeout(() => {
-        this.hasCopied = false
-      }, 2000)
+        try {
+          const abortController = this.abortController = new AbortController()
+
+          await sleep(2000, abortController.signal)
+
+          this.hasCopied = false
+        } catch {}
+      }
     }
   }
 }

--- a/src/scss/misc.scss
+++ b/src/scss/misc.scss
@@ -79,3 +79,11 @@ input[type=number] {
 .v-application kbd {
   background: #4A4A4F !important;
 }
+
+textarea.clipboard-copy {
+  position: absolute;
+  top: -9999px;
+  left: -9999px;
+  z-index: 100000;
+  opacity: 0;
+}

--- a/src/util/clipboard-copy.ts
+++ b/src/util/clipboard-copy.ts
@@ -1,0 +1,40 @@
+import consola from 'consola'
+
+const clipboardCopy = async (text: string, parentElement?: Element): Promise<boolean> => {
+  if (navigator.clipboard) {
+    try {
+      await navigator.clipboard.writeText(text)
+
+      return true
+    } catch (e) {
+      consola.error('Error while copying text to clipboard', e)
+
+      return false
+    }
+  }
+
+  parentElement ??= document.body
+
+  const textarea = document.createElement('textarea')
+
+  textarea.value = text
+  textarea.classList.add('clipboard-copy')
+
+  parentElement.appendChild(textarea)
+
+  try {
+    textarea.focus()
+    textarea.select()
+    textarea.setSelectionRange(0, 99999)
+
+    return document.execCommand('copy')
+  } catch (e) {
+    consola.error('Error while copying text to clipboard', e)
+
+    return false
+  } finally {
+    parentElement.removeChild(textarea)
+  }
+}
+
+export default clipboardCopy


### PR DESCRIPTION
The existing clipboard copy method relies on having `navigator.clipboard` access, however this is only available on "secure" https context, and always `undefined` on "non-secure" http context.

The fix here is to use an old deprecated method that seems to still work in browsers and under "non-secure" http context.

Fix #1556