### PR TITLE
fix: lower case variable name for SAVE_VARIABLE

### DIFF
--- a/src/components/widgets/spoolman/SpoolSelectionDialog.vue
+++ b/src/components/widgets/spoolman/SpoolSelectionDialog.vue
@@ -432,7 +432,7 @@ export default class SpoolSelectionDialog extends Mixins(StateMixin, BrowserMixi
       const supportsSaveVariables = this.$store.getters['printer/getPrinterConfig']('save_variables')
       if (supportsSaveVariables) {
         // persist selected spool across restarts
-        commands.push(`SAVE_VARIABLE VARIABLE=${this.targetMacro.toUpperCase()}__SPOOL_ID VALUE=${this.selectedSpool ?? 'None'}`)
+        commands.push(`SAVE_VARIABLE VARIABLE=${this.targetMacro.toLowerCase()}__spool_id VALUE=${this.selectedSpool ?? 'None'}`)
       }
 
       await SocketActions.printerGcodeScript(commands.join('\n'))


### PR DESCRIPTION
Change the call to `SAVE_VARIABLE` in Spoolman integration to ensure we only use lower-case variable names.

Fixes: #1562 