### PR TITLE
fix(spoolman): QR code detection with MJPEG-adaptive camera sources

### DIFF
--- a/src/components/widgets/camera/services/MjpegstreamerAdaptiveCamera.vue
+++ b/src/components/widgets/camera/services/MjpegstreamerAdaptiveCamera.vue
@@ -31,6 +31,7 @@ export default class MjpegstreamerAdaptiveCamera extends Mixins(CameraMixin) {
 
   handleImageLoad () {
     this.updateStatus('connected')
+    this.$emit('frame')
 
     const fpsTarget = (!document.hasFocus() && this.camera.target_fps_idle) || this.camera.target_fps || 10
     const endTime = performance.now()


### PR DESCRIPTION
Fixes a regression introduced by https://github.com/fluidd-core/fluidd/commit/552a4f625a5dc2c48ca82d2a62b2e637249e6611 where MJPEG-adaptive camera sources can't detect QR codes
