### PR TITLE
fix(Camera): full-screen link

### DIFF
--- a/src/components/widgets/camera/CameraItem.vue
+++ b/src/components/widgets/camera/CameraItem.vue
@@ -84,9 +84,16 @@
       v-if="!fullscreen && (fullscreenMode === 'embed' || !rawCameraUrl) && camera.service !== 'device'"
       class="camera-fullscreen"
     >
-      <a :href="`/#/camera/${encodeURIComponent(camera.uid)}`">
+      <router-link
+        :to="{
+          name: 'camera',
+          params: {
+            cameraId: camera.uid
+          }
+        }"
+      >
         <v-icon>$fullScreen</v-icon>
-      </a>
+      </router-link>
     </div>
     <div
       v-else-if="rawCameraUrl"


### PR DESCRIPTION
The changes in c7204460c3185d4003f4da98b72dfd9d7d064b71 replaced all internal links with named navigation, however it seems I missed one.

This fixes the problem by using a `router-link` with named navigation.

Fixed #1585 