### PR TITLE
fix(FileSystem): extension parsing

### DIFF
--- a/src/util/get-file-paths.ts
+++ b/src/util/get-file-paths.ts
@@ -10,8 +10,8 @@ const getFilePaths = (pathFilename: string, root = ''): FilePaths => {
   const rootPath = root && path ? `${root}/${path}` : root || path
   const rootPathFilename = rootPath ? `${rootPath}/${filename}` : filename
 
-  const extensionIndex = filename.lastIndexOf('.') + 1
-  const extension = extensionIndex > 0 ? filename.substring(extensionIndex) : ''
+  const extensionIndex = filename.lastIndexOf('.')
+  const extension = extensionIndex >= 0 ? filename.substring(extensionIndex) : ''
 
   return {
     root,


### PR DESCRIPTION
This was caused by changes on 5984451912301d23f63ed6567ddefe7955e8445d, the extension should now be prefixed with "." and that is missing from the parser - this PR fixes that.

Fix #1589 