### PR TITLE
fix: ensure Kalico is correctly detected

### DIFF
--- a/src/components/widgets/system/SystemOverviewCard.vue
+++ b/src/components/widgets/system/SystemOverviewCard.vue
@@ -43,7 +43,7 @@
       <v-col>
         <v-simple-table dense>
           <tbody>
-            <tr v-if="printerInfo.hostname">
+            <tr v-if="printerInfo?.hostname">
               <th>{{ $t('app.system_info.label.hostname') }}</th>
               <td>{{ printerInfo.hostname }}</td>
             </tr>
@@ -169,7 +169,7 @@ export default class PrinterStatsCard extends Vue {
       .join(', ')
   }
 
-  get printerInfo (): PrinterInfo {
+  get printerInfo (): PrinterInfo | null {
     return this.$store.state.printer.info
   }
 

--- a/src/store/printer/state.ts
+++ b/src/store/printer/state.ts
@@ -6,6 +6,7 @@ import type { PrinterState } from './types'
  */
 export const defaultState = (): PrinterState => {
   return {
+    info: null,
     endstops: {},
     manualProbeDialogOpen: false,
     bedScrewsAdjustDialogOpen: false,

--- a/src/store/printer/types.ts
+++ b/src/store/printer/types.ts
@@ -1,7 +1,7 @@
 import type { Globals } from '@/globals'
 
 export interface PrinterState {
-  info?: PrinterInfo;
+  info: PrinterInfo | null;
   endstops: Record<string, 'TRIGGERED' | 'open'>
   manualProbeDialogOpen: boolean;
   bedScrewsAdjustDialogOpen: boolean;


### PR DESCRIPTION
Another issue introduced by 785baa713c1ff4a3949f7e7a4b9a6e859516533f...

By allowing the `printer.ìnfo` property to start as `undefined`, the state object is not making this a reactive property... initializing the property as `null` fixes the problem.

Fixes #1592 