### PR TITLE
fix(FileSystem): show default metadata columns

### DIFF
--- a/src/components/widgets/jobs/JobsCard.vue
+++ b/src/components/widgets/jobs/JobsCard.vue
@@ -20,14 +20,19 @@
     </template>
 
     <file-system
+      v-if="fullscreen"
+      roots="gcodes"
+      name="jobs"
+      bulk-actions
+      class="full-screen"
+    />
+
+    <file-system
+      v-else
       roots="gcodes"
       name="dashboard"
-      :dense="!fullscreen"
-      :bulk-actions="fullscreen"
-      :class="{
-        'full-screen': fullscreen,
-        'partial-screen': !fullscreen
-      }"
+      dense
+      class="partial-screen"
     />
   </collapsable-card>
 </template>


### PR DESCRIPTION
Bug was introduced by refactor done in a3ef5a22a43dc0caf495f4b6440b490781787e2a, where the file browser `name` property value was fixed to "dashboard" when in fact it should be "jobs" when on the Jobs page.

Fixes #1594 