### PR TITLE
fix(FileSystem): filename on metadata response

### DIFF
--- a/src/store/files/actions.ts
+++ b/src/store/files/actions.ts
@@ -56,7 +56,13 @@ export const actions: ActionTree<FilesState, RootState> = {
     const paths = getFilePaths(payload.filename, 'gcodes')
 
     if (!paths.filtered) {
-      commit('setFileUpdate', { paths, file: payload })
+      // We need to update filename here as it can contain a relative path
+      const file: MoonrakerFileWithMeta = {
+        ...payload,
+        filename: paths.filename
+      }
+
+      commit('setFileUpdate', { paths, file })
     }
   },
 
@@ -80,13 +86,13 @@ export const actions: ActionTree<FilesState, RootState> = {
 
   async notifyModifyFile ({ dispatch }, payload: FileChange) { dispatch('notifyCreateFile', payload) },
 
-  async notifyCreateFile ({ commit, dispatch, rootState }, payload: FileChange) {
+  async notifyCreateFile ({ commit, getters, dispatch, rootState }, payload: FileChange) {
     const paths = getFilePaths(payload.item.path, payload.item.root)
 
     if (!paths.filtered) {
       if (
         paths.root === 'gcodes' &&
-        paths.extension === '.gcode'
+        getters.getRootProperties('gcodes').accepts.includes(paths.extension)
       ) {
         // If the file in the gcode preview is the same as the one being updated, then reset gcode preview
         const gcodePreviewFile = rootState.gcodePreview.file


### PR DESCRIPTION
When a new file is created/uploaded, we check if the root is "gcodes" and if the file is one of the gcode file types, and if so, we ask for the file metadata from Moonraker.

The problem is that the filename on the response is a path, not just a filename, so it can includes a folder tree!

This fixes the issue by overwriting the filename to make sure it is just a file name.

Fixes #1599