### PR TITLE
fix: get directory for current printing file

### DIFF
--- a/src/components/widgets/filesystem/FileSystem.vue
+++ b/src/components/widgets/filesystem/FileSystem.vue
@@ -19,7 +19,7 @@
       :loading="filesLoading"
       :headers="configurableHeaders"
       @root-change="handleRootChange"
-      @refresh="refreshPath(currentPath)"
+      @refresh="handleRefresh"
       @add-file="handleAddFileDialog"
       @add-dir="handleAddDirDialog"
       @upload="handleUpload"
@@ -590,15 +590,20 @@ export default class FileSystem extends Mixins(StateMixin, FilesMixin, ServicesM
   loadFiles (path: string) {
     if (!this.disabled) {
       this.currentPath = path
-      if (this.files.length <= 0) {
-        this.refreshPath(path)
+
+      const directoryLoaded = path in this.$store.state.files.pathFiles
+
+      if (!directoryLoaded) {
+        this.handleRefresh()
       }
     }
   }
 
   // Refreshes a path by loading the directory.
-  refreshPath (path: string) {
-    if (path && !this.disabled) SocketActions.serverFilesGetDirectory(path)
+  handleRefresh () {
+    if (!this.disabled) {
+      SocketActions.serverFilesGetDirectory(this.currentPath)
+    }
   }
 
   // Handles a user filtering the data.

--- a/src/store/files/actions.ts
+++ b/src/store/files/actions.ts
@@ -125,16 +125,10 @@ export const actions: ActionTree<FilesState, RootState> = {
     }
   },
 
-  async notifyMoveFile ({ commit }, payload: FileChange) {
-    const { item, source_item } = payload
+  async notifyMoveFile ({ commit, dispatch }, payload: FileChange) {
+    const { source_item } = payload
 
-    const paths = getFilePaths(item.path, item.root)
-
-    if (!paths.filtered) {
-      const file = itemAsMoonrakerFile(payload.item, paths)
-
-      commit('setFileUpdate', { paths, file })
-    }
+    dispatch('notifyCreateFile', payload)
 
     if (source_item) {
       const sourcePaths = getFilePaths(source_item.path, source_item.root)


### PR DESCRIPTION
For a long time now, we force the load of the metadata for the current printing file, and that works fine.

However, the way that the files store works, we store files and folders information on an object with root path as key - and loading the metadata for a file whose folder does not exist on the object would just discard said data!

To fix this, we will now ensure we load the full file parent directory (which will include the metadata for all files) instead of just the metadata for this specific file.

Fixes #1603 and #1606