### PR TITLE
fix: clear state on closing ScrewsTiltAdjustDialog

### DIFF
--- a/src/components/common/ScrewsTiltAdjustDialog.vue
+++ b/src/components/common/ScrewsTiltAdjustDialog.vue
@@ -95,13 +95,16 @@ export default class ScrewsTiltAdjustDialog extends Mixins(StateMixin, ToolheadM
     )
   }
 
+  @Watch('screwsTiltAdjustDialogOpen')
+  onScrewsTiltAdjustDialogOpen (value: boolean) {
+    if (!value) {
+      this.$store.commit('printer/setClearScrewsTiltAdjust')
+    }
+  }
+
   retry () {
     this.sendGcode('SCREWS_TILT_CALCULATE', this.$waits.onBedScrewsCalculate)
     this.screwsTiltAdjustDialogOpen = false
-  }
-
-  destroyed () {
-    this.$store.commit('printer/setClearScrewsTiltAdjust')
   }
 }
 </script>

--- a/src/store/printer/mutations.ts
+++ b/src/store/printer/mutations.ts
@@ -57,7 +57,7 @@ export const mutations: MutationTree<PrinterState> = {
     state.printer.screws_tilt_adjust = {
       ...state.printer.screws_tilt_adjust,
       error: false,
-      max_deviation: 0,
+      max_deviation: null,
       results: {}
     }
   },


### PR DESCRIPTION
Since d5926eecd04b40371754dfe2b8f8533f1548e43d, the `ScrewsTiltAdjustDialog` is mounted on the root and always available, so the `destroyed()` method is never called.

This fixes the issue by ensuring the state is cleared when the dialog is closed instead of unmounted/destroyed.

Fixes #1619 