### PR TITLE
fix(FileSystem): metadata types on getFile

### DIFF
--- a/src/store/files/getters.ts
+++ b/src/store/files/getters.ts
@@ -1,6 +1,6 @@
 import Vue from 'vue'
 import type { GetterTree } from 'vuex'
-import type { AppDirectory, AppFile, AppFileMeta, AppFileWithMeta, FileBrowserEntry, FilesState, MoonrakerFileMeta, RootProperties } from './types'
+import type { AppDirectory, AppFile, AppFileMeta, AppFileWithMeta, FileBrowserEntry, FilesState, RootProperties } from './types'
 import type { RootState } from '../types'
 import type { HistoryItem } from '../history/types'
 import { SupportedImageFormats, SupportedMarkdownFormats, SupportedVideoFormats } from '@/globals'
@@ -16,9 +16,9 @@ export const getters: GetterTree<FilesState, RootState> = {
       const items: FileBrowserEntry[] = []
 
       const [root, ...restOfPath] = path.split('/')
-      const pathNoRoot = restOfPath.join('/')
+      const pathFilename = restOfPath.join('/')
 
-      if (pathNoRoot !== '') {
+      if (pathFilename !== '') {
         const item: AppDirectory = {
           type: 'directory',
           name: '..',
@@ -91,7 +91,7 @@ export const getters: GetterTree<FilesState, RootState> = {
           type: 'file',
           name: file.filename,
           extension,
-          path: pathNoRoot,
+          path: pathFilename,
           modified: new Date(file.modified).getTime()
         }
 
@@ -192,7 +192,7 @@ export const getters: GetterTree<FilesState, RootState> = {
     const file = pathContent?.files.find(file => file.filename === filename)
 
     if (file) {
-      const metadata: Partial<MoonrakerFileMeta> & Pick<AppFileWithMeta, 'history'> = {}
+      const metadata: Partial<AppFileMeta> & Pick<AppFileWithMeta, 'history'> = {}
 
       if ('job_id' in file && file.job_id) {
         const history: HistoryItem | undefined = rootGetters['history/getHistoryById'](file.job_id)
@@ -200,8 +200,16 @@ export const getters: GetterTree<FilesState, RootState> = {
         metadata.history = history
       }
 
+      if ('filament_name' in file && file.filament_name) {
+        metadata.filament_name = Vue.$filters.getStringArray(file.filament_name)
+      }
+
+      if ('filament_type' in file && file.filament_type) {
+        metadata.filament_type = Vue.$filters.getStringArray(file.filament_type)
+      }
+
       const [, ...restOfPath] = path.split('/')
-      const pathNoRoot = restOfPath.join('/')
+      const pathFilename = restOfPath.join('/')
 
       const extensionIndex = filename.lastIndexOf('.')
       const extension = extensionIndex > -1 ? filename.substring(extensionIndex) : ''
@@ -212,7 +220,7 @@ export const getters: GetterTree<FilesState, RootState> = {
         type: 'file',
         name: file.filename,
         extension,
-        path: pathNoRoot,
+        path: pathFilename,
         modified: new Date(file.modified).getDate()
       }
 


### PR DESCRIPTION
The `filament_name` and `filament_type` metadata should now be converted to array from the string values we get from Moonraker; while we are doing this correctly for `files/getDirectory` and `history/getHistory`, it is missing on `files/getFile`.

Fixes #1622