### PR TITLE
fix(AppBtnToggle): specify v-model property

### DIFF
--- a/src/components/ui/AppBtnToggle.vue
+++ b/src/components/ui/AppBtnToggle.vue
@@ -1,5 +1,6 @@
 <template>
   <v-btn-toggle
+    v-model="inputValue"
     v-bind="$attrs"
     :class="{
       'elevation-2': !disabled
@@ -11,12 +12,15 @@
 </template>
 
 <script lang="ts">
-import { Component, Prop, Vue } from 'vue-property-decorator'
+import { Component, Prop, VModel, Vue } from 'vue-property-decorator'
 
 @Component({
   inheritAttrs: false
 })
-export default class AppBtn extends Vue {
+export default class AppBtnToggle extends Vue {
+  @VModel()
+  inputValue?: unknown
+
   @Prop({ type: Boolean })
   disabled?: boolean
 }


### PR DESCRIPTION
This bug was introduced with changes on 15f79fae0a8f2792d885e1caf0f0e817463972f7, where the new `AppBtnToggle` class was missing the required v-model declaration.

Fixes #1626 