### PR TITLE
feat: show job queue totals

### DIFF
--- a/src/components/ui/AppDragIcon.vue
+++ b/src/components/ui/AppDragIcon.vue
@@ -1,17 +1,22 @@
 <template>
   <div class="handle-container">
-    <v-icon>
+    <v-icon :disabled="disabled">
       $drag
     </v-icon>
-    <div class="handle" />
+    <div
+      v-if="!disabled"
+      class="handle"
+    />
   </div>
 </template>
 
 <script lang="ts">
-import { Component, Vue } from 'vue-property-decorator'
+import { Component, Prop, Vue } from 'vue-property-decorator'
 
 @Component({})
 export default class AppDraggable extends Vue {
+  @Prop({ type: Boolean })
+  readonly disabled?: boolean
 }
 </script>
 

--- a/src/components/widgets/filesystem/FileSystem.vue
+++ b/src/components/widgets/filesystem/FileSystem.vue
@@ -136,7 +136,7 @@
 <script lang="ts">
 import { Component, Prop, Mixins, Watch } from 'vue-property-decorator'
 import { SocketActions } from '@/api/socketActions'
-import type { AppDirectory, AppFile, AppFileWithMeta, FileFilterType, FileBrowserEntry, RootProperties } from '@/store/files/types'
+import type { AppDirectory, AppFile, AppFileWithMeta, FileFilterType, FileBrowserEntry, RootProperties, MoonrakerPathContent } from '@/store/files/types'
 import StateMixin from '@/mixins/state'
 import FilesMixin from '@/mixins/files'
 import ServicesMixin from '@/mixins/services'
@@ -621,9 +621,9 @@ export default class FileSystem extends Mixins(StateMixin, FilesMixin, ServicesM
     if (!this.disabled) {
       this.currentPath = path
 
-      const directoryLoaded = path in this.$store.state.files.pathFiles
+      const pathContent: MoonrakerPathContent | undefined = this.$store.state.files.pathContent[path]
 
-      if (!directoryLoaded) {
+      if (pathContent == null || pathContent.partial === true) {
         this.handleRefresh()
       }
     }

--- a/src/components/widgets/filesystem/FileSystemBrowser.vue
+++ b/src/components/widgets/filesystem/FileSystemBrowser.vue
@@ -30,6 +30,7 @@
     >
       <template #item="{ headers, item, isSelected, select }">
         <app-data-table-row
+          :key="item.name"
           :headers="headers"
           :item="item"
           :is-selected="isSelected && item.name !== '..'"
@@ -62,7 +63,7 @@
               class="no-pointer-events"
             >
               <v-icon
-                v-if="!item.thumbnails || !item.thumbnails.length"
+                v-if="!item.thumbnails?.length"
                 :small="dense"
                 :color="(item.type === 'file') ? 'grey' : 'primary'"
               >

--- a/src/components/widgets/history/JobHistory.vue
+++ b/src/components/widgets/history/JobHistory.vue
@@ -42,6 +42,7 @@
     >
       <template #item="{ headers, item }">
         <app-data-table-row
+          :key="item.job_id"
           :headers="headers"
           :item="item"
           :class="{
@@ -54,7 +55,7 @@
             <v-icon
               v-if="!item.exists"
               class="mr-2"
-              color="secondary"
+              color="grey"
             >
               $fileCancel
             </v-icon>
@@ -63,7 +64,7 @@
             <v-icon
               v-else-if="!item.metadata.thumbnails?.length"
               class="mr-2"
-              color="secondary"
+              color="grey"
             >
               $file
             </v-icon>

--- a/src/components/widgets/job-queue/JobQueue.vue
+++ b/src/components/widgets/job-queue/JobQueue.vue
@@ -23,6 +23,7 @@
 
     <job-queue-browser
       v-model="selected"
+      :jobs="jobs"
       :headers="headers"
       :dense="dense"
       :bulk-actions="bulkActions"
@@ -57,7 +58,7 @@
 
 <script lang="ts">
 import { SocketActions } from '@/api/socketActions'
-import type { QueuedJob } from '@/store/jobQueue/types'
+import type { QueuedJobWithAppFile } from '@/store/jobQueue/types'
 import { Component, Prop, Vue } from 'vue-property-decorator'
 import JobQueueToolbar from './JobQueueToolbar.vue'
 import JobQueueBulkActions from './JobQueueBulkActions.vue'
@@ -90,7 +91,7 @@ export default class JobQueue extends Vue {
     job: null
   }
 
-  selected: QueuedJob[] = []
+  selected: QueuedJobWithAppFile[] = []
   overlay = false
 
   @Prop({ type: Boolean })
@@ -98,6 +99,12 @@ export default class JobQueue extends Vue {
 
   @Prop({ type: Boolean })
   readonly bulkActions?: boolean
+
+  get jobs (): QueuedJobWithAppFile[] {
+    this.selected = []
+
+    return this.$store.getters['jobQueue/getQueuedJobsWithFiles']
+  }
 
   get configurableHeaders (): AppDataTableHeader[] {
     const headers: AppDataTableHeader[] = [
@@ -130,6 +137,12 @@ export default class JobQueue extends Vue {
         width: '24px'
       },
       {
+        text: '',
+        value: 'data-table-icons',
+        sortable: false,
+        width: this.dense ? '28px' : '56px'
+      },
+      {
         text: this.$tc('app.general.table.header.name'),
         value: 'filename',
         sortable: false
@@ -139,7 +152,7 @@ export default class JobQueue extends Vue {
     ]
   }
 
-  handleRowClick (item: QueuedJob, event: MouseEvent) {
+  handleRowClick (item: QueuedJobWithAppFile, event: MouseEvent) {
     if (this.contextMenuState.open) {
       this.contextMenuState.open = false
 
@@ -181,7 +194,7 @@ export default class JobQueue extends Vue {
     SocketActions.serverJobQueueStatus()
   }
 
-  handleRemove (jobs: QueuedJob | QueuedJob[]) {
+  handleRemove (jobs: QueuedJobWithAppFile | QueuedJobWithAppFile[]) {
     const jobIds = Array.isArray(jobs)
       ? jobs.map(job => job.job_id)
       : [jobs.job_id]
@@ -189,14 +202,14 @@ export default class JobQueue extends Vue {
     SocketActions.serverJobQueueDeleteJobs(jobIds)
   }
 
-  handleMultiplyDialog (jobs: QueuedJob | QueuedJob[]) {
+  handleMultiplyDialog (jobs: QueuedJobWithAppFile | QueuedJobWithAppFile[]) {
     this.multiplyJobDialogState = {
       open: true,
       job: jobs
     }
   }
 
-  handleMultiply (jobs: QueuedJob | QueuedJob[], copies: number) {
+  handleMultiply (jobs: QueuedJobWithAppFile | QueuedJobWithAppFile[], copies: number) {
     const filenames = Array.isArray(jobs)
       ? jobs.map(job => job.filename)
       : [jobs.filename]

--- a/src/components/widgets/job-queue/JobQueueBrowser.vue
+++ b/src/components/widgets/job-queue/JobQueueBrowser.vue
@@ -45,7 +45,7 @@
             </template>
 
             <template #[`item.handle`]>
-              <app-drag-icon />
+              <app-drag-icon :disabled="jobTotals.withoutFile > 0" />
             </template>
 
             <template #[`item.data-table-icons`]>
@@ -93,10 +93,19 @@
         <template #footer>
           <div class="v-data-footer px-3 py-1">
             <v-chip
+              v-if="jobTotals.withoutFile > 0"
+              small
+              class="ma-1"
+              color="warning"
+            >
+              {{ $t('app.job_queue.label.unknown_jobs') }}: {{ jobTotals.withoutFile }}
+            </v-chip>
+
+            <v-chip
               small
               class="ma-1"
             >
-              {{ $t('app.job_queue.label.filament') }}: {{ $filters.getReadableLengthString(jobTotals.filament_length) }} / {{ $filters.getReadableWeightString(jobTotals.filament_weight) }}
+              {{ $t('app.job_queue.label.filament') }}: {{ $filters.getReadableLengthString(jobTotals.filamentLength) }} / {{ $filters.getReadableWeightString(jobTotals.filamentWeight) }}
             </v-chip>
             <v-chip
               small
@@ -128,9 +137,10 @@ import FilesMixin from '@/mixins/files'
 import getFilePaths from '@/util/get-file-paths'
 
 type JobTotals = {
-  filament_length: number,
-  filament_weight: number,
-  time: number
+  filamentLength: number,
+  filamentWeight: number,
+  time: number,
+  withoutFile: number
 }
 
 type QueueJobWithKey = QueuedJobWithAppFile & {
@@ -180,20 +190,22 @@ export default class JobQueueBrowser extends Mixins(StateMixin, FilesMixin) {
     return this.jobs.reduce<JobTotals>((totals, job) => {
       if (job.file) {
         if ('filament_total' in job.file) {
-          totals.filament_length += job.file.filament_total ?? 0
+          totals.filamentLength += job.file.filament_total ?? 0
         }
 
         if ('filament_weight_total' in job.file) {
-          totals.filament_weight += job.file.filament_weight_total ?? 0
+          totals.filamentWeight += job.file.filament_weight_total ?? 0
         }
 
         if ('estimated_time' in job.file) {
           totals.time += job.file.estimated_time ?? 0
         }
+      } else {
+        totals.withoutFile++
       }
 
       return totals
-    }, { filament_length: 0, filament_weight: 0, time: 0 })
+    }, { filamentLength: 0, filamentWeight: 0, time: 0, withoutFile: 0 })
   }
 
   getFilePaths (filename: string) {

--- a/src/components/widgets/job-queue/JobQueueBrowser.vue
+++ b/src/components/widgets/job-queue/JobQueueBrowser.vue
@@ -91,23 +91,23 @@
         </template>
 
         <template #footer>
-          <div class="v-data-footer py-2">
+          <div class="v-data-footer px-3 py-1">
             <v-chip
               small
-              class="mr-1"
+              class="ma-1"
             >
               {{ $t('app.job_queue.label.filament') }}: {{ $filters.getReadableLengthString(jobTotals.filament_length) }} / {{ $filters.getReadableWeightString(jobTotals.filament_weight) }}
             </v-chip>
             <v-chip
               small
-              class="mr-1"
+              class="ma-1"
             >
               {{ $t('app.job_queue.label.print_time') }}: {{ $filters.formatCounterSeconds(jobTotals.time) }}
             </v-chip>
 
             <v-chip
               small
-              class="mr-1"
+              class="ma-1"
             >
               {{ $t('app.job_queue.label.eta') }}: {{ $filters.formatDateTime(Date.now() + jobTotals.time * 1000) }}
             </v-chip>

--- a/src/components/widgets/job-queue/JobQueueBrowser.vue
+++ b/src/components/widgets/job-queue/JobQueueBrowser.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="file-system">
     <app-draggable
-      v-model="jobs"
+      v-model="jobsWithKey"
       :options="{
         group: 'jobQueue',
       }"
@@ -23,27 +23,95 @@
         disable-pagination
         disable-sort
         fixed-header
-        @click:row="handleRowClick"
-        @contextmenu:row.prevent="handleContextMenu"
       >
-        <template #[`item.data-table-select`]="{ isSelected, select }">
-          <v-simple-checkbox
-            :value="isSelected"
-            class="mt-1"
-            @click.stop="select(!isSelected)"
-          />
+        <template #item="{ headers, item, isSelected, select }">
+          <app-data-table-row
+            :key="item.key"
+            :headers="headers"
+            :item="item"
+            :is-selected="isSelected"
+            :class="{
+              'v-data-table__inactive': item.file == null
+            }"
+            @click.prevent="$emit('row-click', item, $event)"
+            @contextmenu.prevent="$emit('row-click', item, $event)"
+          >
+            <template #[`item.data-table-select`]>
+              <v-simple-checkbox
+                :value="isSelected"
+                class="mt-1"
+                @click.stop="select(!isSelected)"
+              />
+            </template>
+
+            <template #[`item.handle`]>
+              <app-drag-icon />
+            </template>
+
+            <template #[`item.data-table-icons`]>
+              <v-layout
+                justify-center
+                class="no-pointer-events"
+              >
+                <v-icon
+                  v-if="item.file == null"
+                  :small="dense"
+                  color="grey"
+                >
+                  $fileCancel
+                </v-icon>
+                <v-icon
+                  v-else-if="!item.file.thumbnails?.length"
+                  :small="dense"
+                  color="grey"
+                >
+                  $file
+                </v-icon>
+                <img
+                  v-else
+                  class="file-icon-thumb"
+                  :src="getThumbUrl(item.file, 'gcodes', getFilePaths(item.filename).path, dense != true, item.file.modified)"
+                  :width="dense ? 16 : 32"
+                >
+              </v-layout>
+            </template>
+
+            <template #[`item.filename`]="{ value }">
+              {{ value }}
+            </template>
+
+            <template #[`item.time_added`]="{ value }">
+              {{ $filters.formatAbsoluteDateTime(value * 1000) }}
+            </template>
+
+            <template #[`item.time_in_queue`]="{ value }">
+              {{ $filters.formatCounterSeconds(value) }}
+            </template>
+          </app-data-table-row>
         </template>
-        <template #[`item.handle`]>
-          <app-drag-icon />
-        </template>
-        <template #[`item.filename`]="{ value }">
-          {{ value }}
-        </template>
-        <template #[`item.time_added`]="{ value }">
-          {{ $filters.formatAbsoluteDateTime(value * 1000) }}
-        </template>
-        <template #[`item.time_in_queue`]="{ value }">
-          {{ $filters.formatCounterSeconds(value) }}
+
+        <template #footer>
+          <div class="v-data-footer py-2">
+            <v-chip
+              small
+              class="mr-1"
+            >
+              {{ $t('app.job_queue.label.filament') }}: {{ $filters.getReadableLengthString(jobTotals.filament_length) }} / {{ $filters.getReadableWeightString(jobTotals.filament_weight) }}
+            </v-chip>
+            <v-chip
+              small
+              class="mr-1"
+            >
+              {{ $t('app.job_queue.label.print_time') }}: {{ $filters.formatCounterSeconds(jobTotals.time) }}
+            </v-chip>
+
+            <v-chip
+              small
+              class="mr-1"
+            >
+              {{ $t('app.job_queue.label.eta') }}: {{ $filters.formatDateTime(Date.now() + jobTotals.time * 1000) }}
+            </v-chip>
+          </div>
         </template>
       </v-data-table>
     </app-draggable>
@@ -52,19 +120,30 @@
 
 <script lang="ts">
 import { Component, Mixins, Prop, VModel } from 'vue-property-decorator'
-import type { QueuedJob } from '@/store/jobQueue/types'
+import type { QueuedJobWithAppFile } from '@/store/jobQueue/types'
 import { SocketActions } from '@/api/socketActions'
 import StateMixin from '@/mixins/state'
-import type { DataTableHeader, DataTableItemProps } from 'vuetify'
+import type { DataTableHeader } from 'vuetify'
+import FilesMixin from '@/mixins/files'
+import getFilePaths from '@/util/get-file-paths'
 
-type QueueJobWithKey = QueuedJob & {
+type JobTotals = {
+  filament_length: number,
+  filament_weight: number,
+  time: number
+}
+
+type QueueJobWithKey = QueuedJobWithAppFile & {
   key: string
 }
 
 @Component({})
-export default class JobQueueBrowser extends Mixins(StateMixin) {
+export default class JobQueueBrowser extends Mixins(StateMixin, FilesMixin) {
   @VModel({ type: Array, default: () => [] })
-  selected!: QueuedJob[]
+  selected!: QueuedJobWithAppFile[]
+
+  @Prop({ type: Array, required: true })
+  readonly jobs!: QueuedJobWithAppFile[]
 
   @Prop({ type: Boolean })
   readonly dense?: boolean
@@ -74,24 +153,6 @@ export default class JobQueueBrowser extends Mixins(StateMixin) {
 
   @Prop({ type: Array, required: true })
   readonly headers!: DataTableHeader[]
-
-  get jobs (): QueuedJob[] {
-    this.selected = []
-
-    return this.$store.state.jobQueue.queued_jobs
-  }
-
-  set jobs (value: QueuedJob[]) {
-    const filenames = value
-      .map(job => job.filename)
-
-    if (this.$store.getters['server/getIsMinApiVersion']('1.1.0')) {
-      SocketActions.serverJobQueuePostJob(filenames, true)
-    } else {
-      SocketActions.serverJobQueueDeleteJobs(['all'])
-      SocketActions.serverJobQueuePostJob(filenames)
-    }
-  }
 
   get jobsWithKey (): QueueJobWithKey[] {
     const refresh = Date.now()
@@ -103,12 +164,40 @@ export default class JobQueueBrowser extends Mixins(StateMixin) {
       }))
   }
 
-  handleRowClick (_data: unknown, props: DataTableItemProps, event: MouseEvent) {
-    this.$emit('row-click', props.item, event)
+  set jobsWithKey (value: QueueJobWithKey[]) {
+    const filenames = value
+      .map(job => job.filename)
+
+    if (this.$store.getters['server/getIsMinApiVersion']('1.1.0')) {
+      SocketActions.serverJobQueuePostJob(filenames, true)
+    } else {
+      SocketActions.serverJobQueueDeleteJobs(['all'])
+      SocketActions.serverJobQueuePostJob(filenames)
+    }
   }
 
-  handleContextMenu (event: MouseEvent, props: DataTableItemProps) {
-    this.$emit('row-click', props.item, event)
+  get jobTotals (): JobTotals {
+    return this.jobs.reduce<JobTotals>((totals, job) => {
+      if (job.file) {
+        if ('filament_total' in job.file) {
+          totals.filament_length += job.file.filament_total ?? 0
+        }
+
+        if ('filament_weight_total' in job.file) {
+          totals.filament_weight += job.file.filament_weight_total ?? 0
+        }
+
+        if ('estimated_time' in job.file) {
+          totals.time += job.file.estimated_time ?? 0
+        }
+      }
+
+      return totals
+    }, { filament_length: 0, filament_weight: 0, time: 0 })
+  }
+
+  getFilePaths (filename: string) {
+    return getFilePaths(filename, 'gcodes')
   }
 }
 </script>

--- a/src/components/widgets/job-queue/JobQueueCard.vue
+++ b/src/components/widgets/job-queue/JobQueueCard.vue
@@ -10,7 +10,7 @@
     <template #menu>
       <app-btn-collapse-group :collapsed="menuCollapsed">
         <app-btn
-          v-if="['ready','loading','starting'].includes(queueStatus)"
+          v-if="['ready','loading','starting'].includes(queueState)"
           small
           class="me-1 my-1"
           @click="handlePause"
@@ -24,7 +24,7 @@
           <span>{{ $t('app.general.btn.pause') }}</span>
         </app-btn>
         <app-btn
-          v-else-if="queueStatus === 'paused'"
+          v-else-if="queueState === 'paused'"
           small
           class="my-1"
           :class="{
@@ -82,8 +82,8 @@ export default class JobQueueCard extends Vue {
   @Prop({ type: Boolean })
   readonly fullscreen?: boolean
 
-  get queueStatus (): QueueState {
-    return this.$store.state.jobQueue.queue_state
+  get queueState (): QueueState {
+    return this.$store.state.jobQueue.queueState
   }
 
   handlePause () {

--- a/src/components/widgets/spoolman/SpoolSelectionDialog.vue
+++ b/src/components/widgets/spoolman/SpoolSelectionDialog.vue
@@ -113,6 +113,7 @@
       >
         <template #item="{ headers, item }">
           <app-data-table-row
+            :key="item.id"
             :headers="headers"
             :item="item"
             :is-selected="item.id === selectedSpoolId"
@@ -242,15 +243,8 @@ export default class SpoolSelectionDialog extends Mixins(StateMixin, BrowserMixi
         this.selectedSpoolId = macro?.variables.spool_id ?? null
       }
 
-      if (this.currentFileName) {
-        const { rootPath } = getFilePaths(this.currentFileName, 'gcodes')
-
-        const directoryLoaded = rootPath in this.$store.state.files.pathFiles
-
-        // Load the containing the currently printing file if we haven't done that already
-        if (!directoryLoaded) {
-          SocketActions.serverFilesGetDirectory(rootPath)
-        }
+      if (this.currentFileName && this.currentFile == null) {
+        SocketActions.serverFilesMetadata(this.currentFileName)
       }
 
       if (this.hasDeviceCamera && this.preferDeviceCamera) {

--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -521,6 +521,7 @@ app:
       filament: Filament
       number_of_copies: Number of copies
       print_time: Print time
+      unknown_jobs: Unknown jobs
     title:
       multiply_job: Multiply Job | Multiply Jobs
     tooltip:

--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -517,7 +517,10 @@ app:
     msg:
       confirm: Are you sure? This will clear the entire printer queue
     label:
+      eta: ETA
+      filament: Filament
       number_of_copies: Number of copies
+      print_time: Print time
     title:
       multiply_job: Multiply Job | Multiply Jobs
     tooltip:

--- a/src/store/files/getters.ts
+++ b/src/store/files/getters.ts
@@ -30,9 +30,9 @@ export const getters: GetterTree<FilesState, RootState> = {
    * Returns a directory of files and sub-directories.
    */
   getDirectory: (state, getters, rootState, rootGetters) => (path: string) => {
-    const pathContent = state.pathFiles[path]
+    const pathContent = state.pathContent[path]
 
-    if (pathContent) {
+    if (pathContent && pathContent.partial !== true) {
       const items: FileBrowserEntry[] = []
 
       const [root, ...restOfPath] = path.split('/')
@@ -193,7 +193,7 @@ export const getters: GetterTree<FilesState, RootState> = {
    * Returns a specific file.
    */
   getFile: (state, getters, rootState, rootGetters) => (path: string, filename: string) => {
-    const pathContent = state.pathFiles[path]
+    const pathContent = state.pathContent[path]
 
     const file = pathContent?.files.find(file => file.filename === filename)
 

--- a/src/store/files/mutations.ts
+++ b/src/store/files/mutations.ts
@@ -13,11 +13,11 @@ export const mutations: MutationTree<FilesState> = {
   },
 
   setResetRoot (state, root) {
-    const keysToDelete = Object.keys(state.pathFiles)
+    const keysToDelete = Object.keys(state.pathContent)
       .filter(key => key === root || key.startsWith(`${root}/`))
 
     for (const key of keysToDelete) {
-      Vue.delete(state.pathFiles, key)
+      Vue.delete(state.pathContent, key)
     }
 
     if (state.currentPaths[root]) {
@@ -28,7 +28,7 @@ export const mutations: MutationTree<FilesState> = {
   setServerFilesGetDirectory (state, payload: { path: string, content: MoonrakerPathContent }) {
     const { path, content } = payload
 
-    Vue.set(state.pathFiles, path, content)
+    Vue.set(state.pathContent, path, content)
   },
 
   setServerFilesListRoot (state, payload: { root: string, files: MoonrakerRootFile[] }) {
@@ -47,7 +47,7 @@ export const mutations: MutationTree<FilesState> = {
 
     if (!isFiltered) {
       // Find relevant directory.
-      const directory = state.pathFiles[paths.rootPath]
+      const directory = state.pathContent[paths.rootPath]
 
       if (directory) {
         const fileIndex = directory.files.findIndex(file => file.filename === paths.filename)
@@ -57,6 +57,14 @@ export const mutations: MutationTree<FilesState> = {
         } else {
           directory.files.push(file)
         }
+      } else {
+        const directory: MoonrakerPathContent = {
+          partial: true,
+          files: [file],
+          dirs: []
+        }
+
+        Vue.set(state.pathContent, paths.rootPath, directory)
       }
     }
   },
@@ -71,7 +79,7 @@ export const mutations: MutationTree<FilesState> = {
 
     if (!isFiltered) {
       // Find relevant directory.
-      const directory = state.pathFiles[paths.rootPath]
+      const directory = state.pathContent[paths.rootPath]
 
       if (directory) {
         const dirIndex = directory.dirs.findIndex(dir => dir.dirname === paths.filename)
@@ -87,7 +95,7 @@ export const mutations: MutationTree<FilesState> = {
 
   setFileDelete (state, payload: FilePaths) {
     // Find relevant directory.
-    const directory = state.pathFiles[payload.rootPath]
+    const directory = state.pathContent[payload.rootPath]
 
     if (directory) {
       const fileIndex = directory.files.findIndex(file => file.filename === payload.filename)
@@ -100,7 +108,7 @@ export const mutations: MutationTree<FilesState> = {
 
   setDirDelete (state, payload: FilePaths) {
     // Find relevant directory.
-    const directory = state.pathFiles[payload.rootPath]
+    const directory = state.pathContent[payload.rootPath]
 
     if (directory) {
       const dirIndex = directory.dirs.findIndex(dir => dir.dirname === payload.filename)
@@ -113,11 +121,11 @@ export const mutations: MutationTree<FilesState> = {
 
   setPathDelete (state, payload: string) {
     // Find relevant directories.
-    const keysToDelete = Object.keys(state.pathFiles)
+    const keysToDelete = Object.keys(state.pathContent)
       .filter(key => key === payload || key.startsWith(`${payload}/`))
 
     for (const key of keysToDelete) {
-      Vue.delete(state.pathFiles, key)
+      Vue.delete(state.pathContent, key)
     }
   },
 

--- a/src/store/files/state.ts
+++ b/src/store/files/state.ts
@@ -7,7 +7,7 @@ export const defaultState = (): FilesState => {
     currentPaths: {},
     disk_usage: null,
     rootFiles: {},
-    pathFiles: {}
+    pathContent: {}
   }
 }
 

--- a/src/store/files/types.ts
+++ b/src/store/files/types.ts
@@ -9,7 +9,7 @@ export interface FilesState {
   currentPaths: Record<string, string>;
   disk_usage: DiskUsage | null;
   rootFiles: Record<string, MoonrakerRootFile[] | undefined>;
-  pathFiles: Record<string, MoonrakerPathContent | undefined>;
+  pathContent: Record<string, MoonrakerPathContent | undefined>;
 }
 
 export interface DiskUsage {
@@ -26,8 +26,9 @@ export interface MoonrakerRootFile {
 }
 
 export interface MoonrakerPathContent {
-  files: (MoonrakerFile | MoonrakerFileWithMeta) []
-  dirs: MoonrakerDir[]
+  partial?: boolean;
+  files: (MoonrakerFile | MoonrakerFileWithMeta)[];
+  dirs: MoonrakerDir[];
 }
 
 type MoonrakerFilePermissions = '' | 'r' | 'rw'

--- a/src/store/helpers.ts
+++ b/src/store/helpers.ts
@@ -71,13 +71,13 @@ export const handleCurrentFileChange = (payload: KlipperPrinterState, state: Roo
     payload.print_stats?.filename &&
     payload.print_stats.filename !== state.printer.printer.print_stats?.filename
   ) {
-    const { rootPath } = getFilePaths(payload.print_stats.filename, 'gcodes')
+    const { rootPath, filename } = getFilePaths(payload.print_stats.filename, 'gcodes')
 
-    const directoryLoaded = rootPath in state.files.pathFiles
+    const pathContent = state.files.pathContent[rootPath]
 
-    // Load the folder containing the currently printing file if we haven't done that already
-    if (!directoryLoaded) {
-      SocketActions.serverFilesGetDirectory(rootPath)
+    // If the file is not known, then update the file metadata
+    if (pathContent == null || !pathContent.files.some(file => file.filename === filename)) {
+      SocketActions.serverFilesMetadata(payload.print_stats.filename)
     }
   }
 }

--- a/src/store/history/actions.ts
+++ b/src/store/history/actions.ts
@@ -65,12 +65,12 @@ export const actions: ActionTree<HistoryState, RootState> = {
         case 'added': {
           commit('setAddHistory', payload.job)
 
-          const { rootPath } = getFilePaths(payload.job.filename, 'gcodes')
+          const { rootPath, filename } = getFilePaths(payload.job.filename, 'gcodes')
 
-          const directoryLoaded = rootPath in rootState.files.pathFiles
+          const pathContent = rootState.files.pathContent[rootPath]
 
-          // If the folder containing the file has been loaded, update the file metadata
-          if (directoryLoaded) {
+          // If the file is known, then update the file metadata
+          if (pathContent != null && pathContent.files.some(file => file.filename === filename)) {
             SocketActions.serverFilesMetadata(payload.job.filename)
           }
 

--- a/src/store/jobQueue/actions.ts
+++ b/src/store/jobQueue/actions.ts
@@ -15,7 +15,7 @@ export const actions: ActionTree<JobQueueState, RootState> = {
 
   async updateJobsMetadata ({ state, rootState }) {
     const pathFilenames = new Set(
-      state.queued_jobs
+      state.queuedJobs
         .map(job => job.filename)
     )
 

--- a/src/store/jobQueue/actions.ts
+++ b/src/store/jobQueue/actions.ts
@@ -2,6 +2,7 @@ import type { ActionTree } from 'vuex'
 import type { JobQueueState, QueuedJob, QueueState } from './types'
 import type { RootState } from '../types'
 import { SocketActions } from '@/api/socketActions'
+import getFilePaths from '@/util/get-file-paths'
 
 export const actions: ActionTree<JobQueueState, RootState> = {
   async reset ({ commit }) {
@@ -12,14 +13,33 @@ export const actions: ActionTree<JobQueueState, RootState> = {
     SocketActions.serverJobQueueStatus()
   },
 
-  async onJobQueueStatus ({ commit }, payload : { queue_state: QueueState, queued_jobs: QueuedJob[] }) {
-    if (payload) {
-      commit('setQueueState', payload.queue_state)
-      commit('setQueuedJobs', payload.queued_jobs)
+  async updateJobsMetadata ({ state, rootState }) {
+    const pathFilenames = new Set(
+      state.queued_jobs
+        .map(job => job.filename)
+    )
+
+    for (const pathFilename of pathFilenames) {
+      const { rootPath, filename } = getFilePaths(pathFilename, 'gcodes')
+
+      const pathContent = rootState.files.pathContent[rootPath]
+
+      if (pathContent == null || !pathContent.files.some(file => file.filename === filename)) {
+        SocketActions.serverFilesMetadata(pathFilename)
+      }
     }
   },
 
-  async onJobQueueChanged ({ commit }, payload : { action: string, queue_state?: QueueState, updated_queue?: QueuedJob[] | null }) {
+  async onJobQueueStatus ({ commit, dispatch }, payload : { queue_state: QueueState, queued_jobs: QueuedJob[] }) {
+    if (payload) {
+      commit('setQueueState', payload.queue_state)
+      commit('setQueuedJobs', payload.queued_jobs)
+
+      dispatch('updateJobsMetadata')
+    }
+  },
+
+  async onJobQueueChanged ({ commit, dispatch }, payload : { action: string, queue_state?: QueueState, updated_queue?: QueuedJob[] | null }) {
     if (payload) {
       const { queue_state, updated_queue } = payload
 
@@ -27,8 +47,10 @@ export const actions: ActionTree<JobQueueState, RootState> = {
         commit('setQueueState', queue_state)
       }
 
-      if (updated_queue !== undefined && updated_queue !== null) {
+      if (updated_queue != null) {
         commit('setQueuedJobs', updated_queue)
+
+        dispatch('updateJobsMetadata')
       }
     }
   }

--- a/src/store/jobQueue/getters.ts
+++ b/src/store/jobQueue/getters.ts
@@ -1,8 +1,20 @@
 import type { GetterTree } from 'vuex'
-import type { JobQueueState } from './types'
+import type { JobQueueState, QueuedJobWithAppFile } from './types'
 import type { RootState } from '../types'
+import getFilePaths from '@/util/get-file-paths'
 
 export const getters: GetterTree<JobQueueState, RootState> = {
+  getQueuedJobsWithFiles: (state, getters, rootState, rootGetters) => {
+    return state.queued_jobs.map((job): QueuedJobWithAppFile => {
+      const { rootPath, filename } = getFilePaths(job.filename, 'gcodes')
+
+      return {
+        ...job,
+        file: rootGetters['files/getFile'](rootPath, filename)
+      }
+    })
+  },
+
   getQueuedJob: (state) => (jobId: string) => {
     return state.queued_jobs.findIndex(job => job.job_id === jobId)
   }

--- a/src/store/jobQueue/getters.ts
+++ b/src/store/jobQueue/getters.ts
@@ -5,7 +5,7 @@ import getFilePaths from '@/util/get-file-paths'
 
 export const getters: GetterTree<JobQueueState, RootState> = {
   getQueuedJobsWithFiles: (state, getters, rootState, rootGetters) => {
-    return state.queued_jobs.map((job): QueuedJobWithAppFile => {
+    return state.queuedJobs.map((job): QueuedJobWithAppFile => {
       const { rootPath, filename } = getFilePaths(job.filename, 'gcodes')
 
       return {
@@ -14,8 +14,4 @@ export const getters: GetterTree<JobQueueState, RootState> = {
       }
     })
   },
-
-  getQueuedJob: (state) => (jobId: string) => {
-    return state.queued_jobs.findIndex(job => job.job_id === jobId)
-  }
 }

--- a/src/store/jobQueue/mutations.ts
+++ b/src/store/jobQueue/mutations.ts
@@ -8,10 +8,10 @@ export const mutations: MutationTree<JobQueueState> = {
   },
 
   setQueueState (state, payload: QueueState) {
-    state.queue_state = payload
+    state.queueState = payload
   },
 
   setQueuedJobs (state, payload: QueuedJob[]) {
-    state.queued_jobs = payload || []
+    state.queuedJobs = payload || []
   }
 }

--- a/src/store/jobQueue/state.ts
+++ b/src/store/jobQueue/state.ts
@@ -2,8 +2,8 @@ import type { JobQueueState } from './types'
 
 export const defaultState = (): JobQueueState => {
   return {
-    queue_state: 'paused',
-    queued_jobs: []
+    queueState: 'paused',
+    queuedJobs: []
   }
 }
 

--- a/src/store/jobQueue/types.ts
+++ b/src/store/jobQueue/types.ts
@@ -1,8 +1,8 @@
 import type { AppFile, AppFileWithMeta } from '@/store/files/types'
 
 export interface JobQueueState {
-  queue_state: QueueState;
-  queued_jobs: QueuedJob[];
+  queueState: QueueState;
+  queuedJobs: QueuedJob[];
 }
 
 export interface QueuedJob {

--- a/src/store/jobQueue/types.ts
+++ b/src/store/jobQueue/types.ts
@@ -1,3 +1,5 @@
+import type { AppFile, AppFileWithMeta } from '@/store/files/types'
+
 export interface JobQueueState {
   queue_state: QueueState;
   queued_jobs: QueuedJob[];
@@ -8,6 +10,10 @@ export interface QueuedJob {
   job_id: string;
   time_added: number;
   time_in_queue: number;
+}
+
+export interface QueuedJobWithAppFile extends QueuedJob {
+  file?: AppFile | AppFileWithMeta;
 }
 
 export type QueueState = 'ready' | 'loading' | 'starting' | 'paused'

--- a/src/views/Jobs.vue
+++ b/src/views/Jobs.vue
@@ -34,7 +34,7 @@ export default class Configuration extends Mixins(StateMixin) {
   }
 
   get hasQueuedJobs () {
-    return this.supportsJobQueue && this.$store.state.jobQueue.queued_jobs.length > 0
+    return this.supportsJobQueue && this.$store.state.jobQueue.queuedJobs.length > 0
   }
 }
 </script>


### PR DESCRIPTION
Shows the job queue totals (filament length and weight, total estimated print time, and estimated finishing time) as a footer of the Job Queue card.

Part of the code changes on this PR is to allow partial file metadata load (thus marking the cache as `partial: true` to ensure that the file browser will force a directory refresh if needed) and so we now have the full metadata available on each queued job - which allows to show the thumbnail (implemented) and any other data column that we wish for (not done as of this PR)

Queued jobs that we can't find the file for will be shown in grey (just like the Job History when associated files are missing) and show the "missing file" icon.

When there are missing files, we show a warning label on the bottom with the count and disable drag & drop reordering as that does not work in this invalid state.

# Job Queue in valid state

![image](https://github.com/user-attachments/assets/f220be03-3a91-4851-8c85-da1779cde765)

# Job Queue with unknown files

![image](https://github.com/user-attachments/assets/208b6bb4-f70f-4872-902c-604834137193)

Resolves #1102
Resolves #1544