### PR TITLE
refactor: introduces typed store accessors

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -425,11 +425,11 @@ export default class App extends Mixins(StateMixin, FilesMixin, BrowserMixin) {
 
           const wait = `${this.$waits.onFileSystem}/${pathWithRoot}/`
 
-          this.$store.dispatch('wait/addWait', wait)
+          this.$typedDispatch('wait/addWait', wait)
 
           await this.uploadFiles(files, path, root, false)
 
-          this.$store.dispatch('wait/removeWait', wait)
+          this.$typedDispatch('wait/removeWait', wait)
         }
       }
     }

--- a/src/components/common/CollapsableCard.vue
+++ b/src/components/common/CollapsableCard.vue
@@ -320,7 +320,7 @@ export default class CollapsableCard extends Vue {
     const value = this.layout
     if (value && this._layoutPath) {
       value.collapsed = collapsed
-      this.$store.dispatch('layout/onUpdateConfig', { name: this._layoutPath.name, value })
+      this.$typedDispatch('layout/onUpdateConfig', { name: this._layoutPath.name, value })
     }
   }
 
@@ -343,7 +343,7 @@ export default class CollapsableCard extends Vue {
     const value = this.layout
     if (value && this._layoutPath) {
       value.enabled = enabled
-      this.$store.dispatch('layout/onUpdateConfig', { name: this._layoutPath.name, value })
+      this.$typedDispatch('layout/onUpdateConfig', { name: this._layoutPath.name, value })
     }
   }
 

--- a/src/components/common/ScrewsTiltAdjustDialog.vue
+++ b/src/components/common/ScrewsTiltAdjustDialog.vue
@@ -98,7 +98,7 @@ export default class ScrewsTiltAdjustDialog extends Mixins(StateMixin, ToolheadM
   @Watch('screwsTiltAdjustDialogOpen')
   onScrewsTiltAdjustDialogOpen (value: boolean) {
     if (!value) {
-      this.$store.commit('printer/setClearScrewsTiltAdjust')
+      this.$typedCommit('printer/setClearScrewsTiltAdjust')
     }
   }
 

--- a/src/components/common/SystemLayout.vue
+++ b/src/components/common/SystemLayout.vue
@@ -34,7 +34,7 @@ export default class SystemLayout extends Mixins(StateMixin) {
   }
 
   set layoutMode (val: boolean) {
-    this.$store.commit('config/setLayoutMode', val)
+    this.$typedCommit('config/setLayoutMode', val)
     this.close()
   }
 

--- a/src/components/common/SystemPrinters.vue
+++ b/src/components/common/SystemPrinters.vue
@@ -83,7 +83,7 @@ export default class SystemPrinters extends Mixins(StateMixin) {
     )
 
     if (result) {
-      this.$store.dispatch('config/removeInstance', instance)
+      this.$typedDispatch('config/removeInstance', instance)
     }
   }
 

--- a/src/components/common/UpdatingDialog.vue
+++ b/src/components/common/UpdatingDialog.vue
@@ -59,7 +59,7 @@ export default class UpdatingDialog extends Mixins(StateMixin, BrowserMixin) {
   set open (value: boolean) {
     if (!value) {
       this.invokedDialog = false
-      this.$store.commit('version/setClearUpdateResponse')
+      this.$typedCommit('version/setClearUpdateResponse')
     }
   }
 

--- a/src/components/layout/AppBar.vue
+++ b/src/components/layout/AppBar.vue
@@ -391,7 +391,7 @@ export default class AppBar extends Mixins(StateMixin, ServicesMixin, FilesMixin
   }
 
   handleExitLayout () {
-    this.$store.commit('config/setLayoutMode', false)
+    this.$typedCommit('config/setLayoutMode', false)
   }
 
   get isDashboard () {
@@ -408,11 +408,11 @@ export default class AppBar extends Mixins(StateMixin, ServicesMixin, FilesMixin
       : undefined
     const layoutDefaultState = pathLayout
       ? defaultState().layouts[pathLayout]
-      : this.$typedGetters['layout/getLayout']('dashboard')
+      : this.$typedGetters['layout/getLayout']('dashboard')!
 
     const toReset = pathLayout ?? this.$typedGetters['layout/getSpecificLayoutName']
 
-    this.$store.dispatch('layout/onLayoutChange', {
+    this.$typedDispatch('layout/onLayoutChange', {
       name: toReset,
       value: layoutDefaultState
     })
@@ -431,14 +431,14 @@ export default class AppBar extends Mixins(StateMixin, ServicesMixin, FilesMixin
   }
 
   handleSetDefaultLayout () {
-    this.$store.dispatch('layout/onLayoutChange', {
+    this.$typedDispatch('layout/onLayoutChange', {
       name: 'dashboard',
-      value: this.$typedGetters['layout/getLayout'](this.currentLayoutName)
+      value: this.$typedGetters['layout/getLayout'](this.currentLayoutName)!
     })
   }
 
   handleResetDefaultLayout () {
-    this.$store.dispatch('layout/onLayoutChange', {
+    this.$typedDispatch('layout/onLayoutChange', {
       name: 'dashboard',
       value: defaultState().layouts.dashboard
     })

--- a/src/components/layout/AppNavDrawer.vue
+++ b/src/components/layout/AppNavDrawer.vue
@@ -186,7 +186,7 @@ export default class AppNavDrawer extends Mixins(StateMixin, BrowserMixin) {
   }
 
   set layoutMode (val: boolean) {
-    this.$store.commit('config/setLayoutMode', val)
+    this.$typedCommit('config/setLayoutMode', val)
   }
 }
 </script>

--- a/src/components/layout/AppNotificationMenu.vue
+++ b/src/components/layout/AppNotificationMenu.vue
@@ -228,16 +228,16 @@ export default class AppNotificationMenu extends Mixins(BrowserMixin) {
   }
 
   handleClear (n: AppNotification) {
-    this.$store.dispatch('notifications/clearNotification', n)
+    this.$typedDispatch('notifications/clearNotification', n)
   }
 
   handleClearAll () {
-    this.$store.dispatch('notifications/clearAll')
+    this.$typedDispatch('notifications/clearAll')
   }
 
   handleAnnouncementDismiss (n: AppNotification, wake_time: number) {
     if (n && wake_time) {
-      this.$store.dispatch('announcements/dismiss', {
+      this.$typedDispatch('announcements/dismiss', {
         entry_id: n.id,
         wake_time
       })

--- a/src/components/layout/AppUserMenu.vue
+++ b/src/components/layout/AppUserMenu.vue
@@ -115,7 +115,7 @@ export default class AppNotificationMenu extends Vue {
   }
 
   async handleLogout () {
-    await this.$store.dispatch('auth/checkTrust')
+    await this.$typedDispatch('auth/checkTrust')
   }
 }
 </script>

--- a/src/components/settings/FileBrowserSettings.vue
+++ b/src/components/settings/FileBrowserSettings.vue
@@ -44,7 +44,7 @@ export default class FileEditorSettings extends Vue {
   }
 
   set textSortOrder (value: TextSortOrder) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.general.textSortOrder',
       value,
       server: true
@@ -73,7 +73,7 @@ export default class FileEditorSettings extends Vue {
   }
 
   set filesAndFoldersDragAndDrop (value: boolean) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.general.filesAndFoldersDragAndDrop',
       value,
       server: true

--- a/src/components/settings/FileEditorSettings.vue
+++ b/src/components/settings/FileEditorSettings.vue
@@ -91,7 +91,7 @@ export default class FileEditorSettings extends Mixins(StateMixin) {
   }
 
   set confirmDirtyEditorClose (value: boolean) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.editor.confirmDirtyEditorClose',
       value,
       server: true
@@ -103,7 +103,7 @@ export default class FileEditorSettings extends Mixins(StateMixin) {
   }
 
   set autoEditExtensions (value: string[]) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.editor.autoEditExtensions',
       value: [
         ...new Set(value.map(ext => ext.startsWith('.') ? ext : `.${ext}`))
@@ -117,7 +117,7 @@ export default class FileEditorSettings extends Mixins(StateMixin) {
   }
 
   set restoreViewState (value: RestoreViewState) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.editor.restoreViewState',
       value,
       server: true
@@ -146,7 +146,7 @@ export default class FileEditorSettings extends Mixins(StateMixin) {
   }
 
   set codeLens (value: boolean) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.editor.codeLens',
       value,
       server: true
@@ -154,7 +154,7 @@ export default class FileEditorSettings extends Mixins(StateMixin) {
   }
 
   handleReset () {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.editor',
       value: defaultState().uiSettings.editor,
       server: true

--- a/src/components/settings/GcodePreviewSettings.vue
+++ b/src/components/settings/GcodePreviewSettings.vue
@@ -203,7 +203,7 @@ export default class GcodePreviewSettings extends Vue {
   }
 
   setExtrusionLineWidth (value: number) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.gcodePreview.extrusionLineWidth',
       value: +value,
       server: true
@@ -215,7 +215,7 @@ export default class GcodePreviewSettings extends Vue {
   }
 
   setMoveLineWidth (value: number) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.gcodePreview.moveLineWidth',
       value: +value,
       server: true
@@ -227,7 +227,7 @@ export default class GcodePreviewSettings extends Vue {
   }
 
   setRetractionIconSize (value: number) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.gcodePreview.retractionIconSize',
       value: +value,
       server: true
@@ -239,7 +239,7 @@ export default class GcodePreviewSettings extends Vue {
   }
 
   set flipHorizontal (value: boolean) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.gcodePreview.flip.horizontal',
       value,
       server: true
@@ -251,7 +251,7 @@ export default class GcodePreviewSettings extends Vue {
   }
 
   set flipVertical (value: boolean) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.gcodePreview.flip.vertical',
       value,
       server: true
@@ -263,7 +263,7 @@ export default class GcodePreviewSettings extends Vue {
   }
 
   set drawOrigin (value: boolean) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.gcodePreview.drawOrigin',
       value,
       server: true
@@ -275,7 +275,7 @@ export default class GcodePreviewSettings extends Vue {
   }
 
   set drawBackground (value: boolean) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.gcodePreview.drawBackground',
       value,
       server: true
@@ -287,7 +287,7 @@ export default class GcodePreviewSettings extends Vue {
   }
 
   set showAnimations (value: boolean) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.gcodePreview.showAnimations',
       value,
       server: true
@@ -299,7 +299,7 @@ export default class GcodePreviewSettings extends Vue {
   }
 
   setMinLayerHeight (value: number) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.gcodePreview.minLayerHeight',
       value: +value,
       server: true
@@ -311,7 +311,7 @@ export default class GcodePreviewSettings extends Vue {
   }
 
   set autoLoadOnPrintStart (value: boolean) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.gcodePreview.autoLoadOnPrintStart',
       value,
       server: true
@@ -327,7 +327,7 @@ export default class GcodePreviewSettings extends Vue {
   }
 
   set autoLoadMobileOnPrintStart (value: boolean) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.gcodePreview.autoLoadMobileOnPrintStart',
       value,
       server: true
@@ -339,7 +339,7 @@ export default class GcodePreviewSettings extends Vue {
   }
 
   set autoFollowOnFileLoad (value: boolean) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.gcodePreview.autoFollowOnFileLoad',
       value,
       server: true
@@ -351,7 +351,7 @@ export default class GcodePreviewSettings extends Vue {
   }
 
   set hideSinglePartBoundingBox (value: boolean) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.gcodePreview.hideSinglePartBoundingBox',
       value,
       server: true
@@ -359,7 +359,7 @@ export default class GcodePreviewSettings extends Vue {
   }
 
   handleReset () {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.gcodePreview',
       value: defaultState().uiSettings.gcodePreview,
       server: true

--- a/src/components/settings/GeneralSettings.vue
+++ b/src/components/settings/GeneralSettings.vue
@@ -301,7 +301,7 @@ export default class GeneralSettings extends Mixins(StateMixin) {
   }
 
   setInstanceName (value: string) {
-    if (this.instanceNameElement.valid) this.$store.dispatch('config/updateInstance', value)
+    if (this.instanceNameElement.valid) this.$typedDispatch('config/updateInstance', value)
   }
 
   get locale (): string {
@@ -316,7 +316,7 @@ export default class GeneralSettings extends Mixins(StateMixin) {
   }
 
   setLocale (value: string) {
-    this.$store.dispatch('config/onLocaleChange', value)
+    this.$typedDispatch('config/onLocaleChange', value)
   }
 
   get dateFormat (): string {
@@ -324,7 +324,7 @@ export default class GeneralSettings extends Mixins(StateMixin) {
   }
 
   set dateFormat (value: string) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.general.dateFormat',
       value,
       server: true
@@ -346,7 +346,7 @@ export default class GeneralSettings extends Mixins(StateMixin) {
   }
 
   set timeFormat (value: string) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.general.timeFormat',
       value,
       server: true
@@ -368,7 +368,7 @@ export default class GeneralSettings extends Mixins(StateMixin) {
   }
 
   set enableKeyboardShortcuts (value: boolean) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.general.enableKeyboardShortcuts',
       value,
       server: true
@@ -380,7 +380,7 @@ export default class GeneralSettings extends Mixins(StateMixin) {
   }
 
   set confirmOnEstop (value: boolean) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.general.confirmOnEstop',
       value,
       server: true
@@ -392,7 +392,7 @@ export default class GeneralSettings extends Mixins(StateMixin) {
   }
 
   set printerPowerDevice (value: string | null) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.general.printerPowerDevice',
       value,
       server: true
@@ -425,7 +425,7 @@ export default class GeneralSettings extends Mixins(StateMixin) {
   }
 
   set topNavPowerToggle (value: string | null) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.general.topNavPowerToggle',
       value,
       server: true
@@ -470,7 +470,7 @@ export default class GeneralSettings extends Mixins(StateMixin) {
   }
 
   set confirmOnPowerDeviceChange (value: boolean) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.general.confirmOnPowerDeviceChange',
       value,
       server: true
@@ -482,7 +482,7 @@ export default class GeneralSettings extends Mixins(StateMixin) {
   }
 
   set showSaveConfigAndRestart (value: boolean) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.general.showSaveConfigAndRestart',
       value,
       server: true
@@ -494,7 +494,7 @@ export default class GeneralSettings extends Mixins(StateMixin) {
   }
 
   set showUploadAndPrint (value: boolean) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.general.showUploadAndPrint',
       value,
       server: true
@@ -506,7 +506,7 @@ export default class GeneralSettings extends Mixins(StateMixin) {
   }
 
   set confirmOnSaveConfigAndRestart (value: boolean) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.general.confirmOnSaveConfigAndRestart',
       value,
       server: true
@@ -518,7 +518,7 @@ export default class GeneralSettings extends Mixins(StateMixin) {
   }
 
   set sectionsToIgnorePendingConfigurationChanges (value: string[]) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.general.sectionsToIgnorePendingConfigurationChanges',
       value: [...new Set(value)].sort((a, b) => a.localeCompare(b)),
       server: true
@@ -530,7 +530,7 @@ export default class GeneralSettings extends Mixins(StateMixin) {
   }
 
   set printInProgressLayout (value: PrintInProgressLayout) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.general.printInProgressLayout',
       value,
       server: true
@@ -576,7 +576,7 @@ export default class GeneralSettings extends Mixins(StateMixin) {
   }
 
   set printProgressCalculation (value: PrintProgressCalculation[]) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.general.printProgressCalculation',
       value,
       server: true
@@ -601,7 +601,7 @@ export default class GeneralSettings extends Mixins(StateMixin) {
   }
 
   set printEtaCalculation (value: PrintEtaCalculation[]) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.general.printEtaCalculation',
       value,
       server: true
@@ -613,7 +613,7 @@ export default class GeneralSettings extends Mixins(StateMixin) {
   }
 
   set enableDiagnostics (value: boolean) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.general.enableDiagnostics',
       value,
       server: true

--- a/src/components/settings/SpoolmanSettings.vue
+++ b/src/components/settings/SpoolmanSettings.vue
@@ -141,7 +141,7 @@ export default class SpoolmanSettings extends Mixins(StateMixin) {
   }
 
   set autoSpoolSelectionDialog (value: boolean) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.spoolman.autoSpoolSelectionDialog',
       value,
       server: true
@@ -172,7 +172,7 @@ export default class SpoolmanSettings extends Mixins(StateMixin) {
   }
 
   set autoOpenQRDetectionCameraId (value: string) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.spoolman.autoOpenQRDetectionCamera',
       value,
       server: true
@@ -184,7 +184,7 @@ export default class SpoolmanSettings extends Mixins(StateMixin) {
   }
 
   set preferDeviceCamera (value: boolean) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.spoolman.preferDeviceCamera',
       value,
       server: true
@@ -196,7 +196,7 @@ export default class SpoolmanSettings extends Mixins(StateMixin) {
   }
 
   set autoSelectSpoolOnMatch (value: boolean) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.spoolman.autoSelectSpoolOnMatch',
       value,
       server: true
@@ -208,7 +208,7 @@ export default class SpoolmanSettings extends Mixins(StateMixin) {
   }
 
   set warnOnNotEnoughFilament (value: boolean) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.spoolman.warnOnNotEnoughFilament',
       value,
       server: true
@@ -220,7 +220,7 @@ export default class SpoolmanSettings extends Mixins(StateMixin) {
   }
 
   set warnOnFilamentTypeMismatch (value: boolean) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.spoolman.warnOnFilamentTypeMismatch',
       value,
       server: true
@@ -232,7 +232,7 @@ export default class SpoolmanSettings extends Mixins(StateMixin) {
   }
 
   set remainingFilamentUnit (value: SpoolmanRemainingFilamentUnit) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.spoolman.remainingFilamentUnit',
       value,
       server: true
@@ -268,7 +268,7 @@ export default class SpoolmanSettings extends Mixins(StateMixin) {
   }
 
   set fieldsToShowInSpoolmanCard (value: string[]) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.spoolman.selectedCardFields',
       value,
       server: true
@@ -276,7 +276,7 @@ export default class SpoolmanSettings extends Mixins(StateMixin) {
   }
 
   handleReset () {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.spoolman',
       value: defaultState().uiSettings.spoolman,
       server: true

--- a/src/components/settings/ThemeSettings.vue
+++ b/src/components/settings/ThemeSettings.vue
@@ -141,7 +141,7 @@ export default class ThemeSettings extends Mixins(StateMixin) {
   }
 
   updateTheme (updatedTheme: Partial<ThemeConfig>) {
-    this.$store.dispatch('config/updateTheme', updatedTheme)
+    this.$typedDispatch('config/updateTheme', updatedTheme)
   }
 
   handleReset () {

--- a/src/components/settings/ToolheadSettings.vue
+++ b/src/components/settings/ToolheadSettings.vue
@@ -415,7 +415,7 @@ export default class ToolHeadSettings extends Mixins(ToolheadMixin) {
   }
 
   setDefaultExtrudeSpeed (value: string) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.general.defaultExtrudeSpeed',
       value: +value,
       server: true
@@ -427,7 +427,7 @@ export default class ToolHeadSettings extends Mixins(ToolheadMixin) {
   }
 
   setDefaultExtrudeLength (value: number) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.general.defaultExtrudeLength',
       value: +value,
       server: true
@@ -439,7 +439,7 @@ export default class ToolHeadSettings extends Mixins(ToolheadMixin) {
   }
 
   setDefaultToolheadMoveLength (value: number) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.general.defaultToolheadMoveLength',
       value: +value,
       server: true
@@ -451,7 +451,7 @@ export default class ToolHeadSettings extends Mixins(ToolheadMixin) {
   }
 
   setDefaultToolheadYXSpeed (value: number) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.general.defaultToolheadXYSpeed',
       value: +value,
       server: true
@@ -463,7 +463,7 @@ export default class ToolHeadSettings extends Mixins(ToolheadMixin) {
   }
 
   setDefaultToolheadZSpeed (value: number) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.general.defaultToolheadZSpeed',
       value: +value,
       server: true
@@ -479,7 +479,7 @@ export default class ToolHeadSettings extends Mixins(ToolheadMixin) {
       return
     }
 
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.general.zAdjustDistances',
       value: [...new Set(value.map(Number))].sort((a, b) => a - b),
       server: true
@@ -491,7 +491,7 @@ export default class ToolHeadSettings extends Mixins(ToolheadMixin) {
   }
 
   set toolheadCircleXYHomingEnabled (value: boolean) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.general.toolheadCircleXYHomingEnabled',
       value,
       server: true
@@ -503,7 +503,7 @@ export default class ToolHeadSettings extends Mixins(ToolheadMixin) {
   }
 
   set toolheadControlStyle (value: ToolheadControlStyle) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.general.toolheadControlStyle',
       value,
       server: true
@@ -539,7 +539,7 @@ export default class ToolHeadSettings extends Mixins(ToolheadMixin) {
     const toolheadMoveDistances = [...new Set(value.map(Number))]
       .sort((a, b) => a - b)
 
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.general.toolheadMoveDistances',
       value: toolheadMoveDistances,
       server: true
@@ -559,7 +559,7 @@ export default class ToolHeadSettings extends Mixins(ToolheadMixin) {
       return
     }
 
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.general.toolheadXYMoveDistances',
       value: [...new Set(value.map(Number))].sort((a, b) => a - b),
       server: true
@@ -575,7 +575,7 @@ export default class ToolHeadSettings extends Mixins(ToolheadMixin) {
       return
     }
 
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.general.toolheadCircleXYMoveDistances',
       value: [...new Set(value.map(Number))].sort((a, b) => a - b),
       server: true
@@ -591,7 +591,7 @@ export default class ToolHeadSettings extends Mixins(ToolheadMixin) {
       return
     }
 
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.general.toolheadZMoveDistances',
       value: [...new Set(value.map(Number))].sort((a, b) => a - b),
       server: true
@@ -607,7 +607,7 @@ export default class ToolHeadSettings extends Mixins(ToolheadMixin) {
       return
     }
 
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.general.toolheadCircleZMoveDistances',
       value: [...new Set(value.map(Number))].sort((a, b) => a - b),
       server: true
@@ -619,7 +619,7 @@ export default class ToolHeadSettings extends Mixins(ToolheadMixin) {
   }
 
   set useGcodeCoords (value: boolean) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.general.useGcodeCoords',
       value,
       server: true
@@ -631,7 +631,7 @@ export default class ToolHeadSettings extends Mixins(ToolheadMixin) {
   }
 
   set invertX (value: boolean) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.general.axis.x.inverted',
       value,
       server: true
@@ -643,7 +643,7 @@ export default class ToolHeadSettings extends Mixins(ToolheadMixin) {
   }
 
   set invertY (value: boolean) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.general.axis.y.inverted',
       value,
       server: true
@@ -655,7 +655,7 @@ export default class ToolHeadSettings extends Mixins(ToolheadMixin) {
   }
 
   set invertZ (value: boolean) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.general.axis.z.inverted',
       value,
       server: true
@@ -673,7 +673,7 @@ export default class ToolHeadSettings extends Mixins(ToolheadMixin) {
   }
 
   set showManualProbeDialogAutomatically (value: boolean) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.general.showManualProbeDialogAutomatically',
       value,
       server: true
@@ -685,7 +685,7 @@ export default class ToolHeadSettings extends Mixins(ToolheadMixin) {
   }
 
   set showBedScrewsAdjustDialogAutomatically (value: boolean) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.general.showBedScrewsAdjustDialogAutomatically',
       value,
       server: true
@@ -697,7 +697,7 @@ export default class ToolHeadSettings extends Mixins(ToolheadMixin) {
   }
 
   set showScrewsTiltAdjustDialogAutomatically (value: boolean) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.general.showScrewsTiltAdjustDialogAutomatically',
       value,
       server: true
@@ -709,7 +709,7 @@ export default class ToolHeadSettings extends Mixins(ToolheadMixin) {
   }
 
   set forceMoveToggleWarning (value: boolean) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.general.forceMoveToggleWarning',
       value,
       server: true
@@ -726,7 +726,7 @@ export default class ToolHeadSettings extends Mixins(ToolheadMixin) {
       hideTempWaits
     }
 
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.general',
       value,
       server: true

--- a/src/components/settings/VersionSettings.vue
+++ b/src/components/settings/VersionSettings.vue
@@ -215,7 +215,7 @@ export default class VersionSettings extends Mixins(StateMixin) {
   }
 
   set enableNotifications (value: boolean) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.general.enableVersionNotifications',
       value,
       server: true
@@ -242,7 +242,7 @@ export default class VersionSettings extends Mixins(StateMixin) {
 
   // Will attempt to update the requirec component based on its type.
   handleUpdateComponent (key: string) {
-    this.$store.dispatch('version/onUpdateStatus', { busy: true })
+    this.$typedDispatch('version/onUpdateStatus', { busy: true })
     switch (key) {
       case 'klipper':
         SocketActions.machineUpdateKlipper()
@@ -266,7 +266,7 @@ export default class VersionSettings extends Mixins(StateMixin) {
 
   // Will attempt to recover a component based on its type and current status.
   handleRecoverComponent (component: UpdatePackage) {
-    this.$store.dispatch('version/onUpdateStatus', { busy: true })
+    this.$typedDispatch('version/onUpdateStatus', { busy: true })
     const dirty = ('is_dirty' in component) ? component.is_dirty : false
     const valid = ('is_valid' in component) ? component.is_valid : true
     if (dirty) {

--- a/src/components/settings/auth/ApiKeyDialog.vue
+++ b/src/components/settings/auth/ApiKeyDialog.vue
@@ -54,7 +54,7 @@ export default class ApiKeyDialog extends Vue {
   }
 
   handleRefreshApiKey () {
-    this.$store.dispatch('auth/refreshApiKey')
+    this.$typedDispatch('auth/refreshApiKey')
   }
 }
 </script>

--- a/src/components/settings/auth/AuthSettings.vue
+++ b/src/components/settings/auth/AuthSettings.vue
@@ -154,15 +154,15 @@ export default class AuthSettings extends Vue {
     )
 
     if (result) {
-      this.$store.dispatch('auth/removeUser', user)
+      this.$typedDispatch('auth/removeUser', user)
     }
   }
 
   async handleSaveUser (user: AppUser) {
-    await this.$store.dispatch('auth/addUser', user)
+    await this.$typedDispatch('auth/addUser', user)
 
     // We only want to check trust if this is the first user being added.
-    if (this.users.length === 0) this.$store.dispatch('auth/checkTrust')
+    if (this.users.length === 0) this.$typedDispatch('auth/checkTrust')
   }
 }
 </script>

--- a/src/components/settings/cameras/CameraSettings.vue
+++ b/src/components/settings/cameras/CameraSettings.vue
@@ -144,7 +144,7 @@ export default class CameraSettings extends Vue {
   }
 
   handleSaveCamera (camera: WebcamConfig) {
-    this.$store.dispatch('webcams/updateWebcam', camera)
+    this.$typedDispatch('webcams/updateWebcam', camera)
   }
 
   async handleRemoveCamera (camera: WebcamConfig) {
@@ -154,7 +154,7 @@ export default class CameraSettings extends Vue {
     )
 
     if (result) {
-      this.$store.dispatch('webcams/removeWebcam', camera.uid)
+      this.$typedDispatch('webcams/removeWebcam', camera.uid)
     }
   }
 
@@ -163,7 +163,7 @@ export default class CameraSettings extends Vue {
   }
 
   set defaultFullscreenAction (value: string) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.general.cameraFullscreenAction',
       value,
       server: true

--- a/src/components/settings/console/ConsoleSettings.vue
+++ b/src/components/settings/console/ConsoleSettings.vue
@@ -111,12 +111,12 @@ export default class ConsoleSettings extends Mixins(StateMixin) {
     )
 
     if (result) {
-      this.$store.dispatch('console/onRemoveFilter', filter)
+      this.$typedDispatch('console/onRemoveFilter', filter)
     }
   }
 
   handleSaveFilter (filter: ConsoleFilter) {
-    this.$store.dispatch('console/onSaveFilter', filter)
+    this.$typedDispatch('console/onSaveFilter', filter)
   }
 }
 </script>

--- a/src/components/settings/macros/MacroCategorySettings.vue
+++ b/src/components/settings/macros/MacroCategorySettings.vue
@@ -149,7 +149,7 @@ export default class MacroCategorySettings extends Vue {
   }
 
   set macros (macros: Macro[]) {
-    this.$store.dispatch('macros/saveAllOrder', macros)
+    this.$typedDispatch('macros/saveAllOrder', macros)
   }
 
   get categories (): MacroCategory[] {
@@ -189,18 +189,18 @@ export default class MacroCategorySettings extends Vue {
   }
 
   handleAllOn () {
-    this.$store.dispatch('macros/saveAllOn', this.macros)
+    this.$typedDispatch('macros/saveAllOn', this.macros)
   }
 
   handleAllOff () {
-    this.$store.dispatch('macros/saveAllOff', this.macros)
+    this.$typedDispatch('macros/saveAllOff', this.macros)
   }
 
   handleMacroVisible (macro: Macro, value: boolean) {
     const newMacro = {
       ...macro, visible: value
     }
-    this.$store.dispatch('macros/saveMacro', newMacro)
+    this.$typedDispatch('macros/saveMacro', newMacro)
   }
 }
 </script>

--- a/src/components/settings/macros/MacroSettings.vue
+++ b/src/components/settings/macros/MacroSettings.vue
@@ -144,7 +144,7 @@ export default class MacroSettings extends Mixins(StateMixin) {
         name
       }))
 
-    this.$store.dispatch('macros/updateCategories', categories)
+    this.$typedDispatch('macros/updateCategories', categories)
   }
 
   get uncategorizedMacros () {
@@ -186,12 +186,12 @@ export default class MacroSettings extends Mixins(StateMixin) {
     )
 
     if (result) {
-      this.$store.dispatch('macros/removeCategory', category)
+      this.$typedDispatch('macros/removeCategory', category)
     }
   }
 
   handleAddCategory (category: string) {
-    this.$store.dispatch('macros/addCategory', category)
+    this.$typedDispatch('macros/addCategory', category)
   }
 
   handleEditCategory (name: string) {
@@ -199,7 +199,7 @@ export default class MacroSettings extends Mixins(StateMixin) {
       ...this.categoryDialogState.category,
       name
     }
-    this.$store.dispatch('macros/editCategory', category)
+    this.$typedDispatch('macros/editCategory', category)
   }
 
   handleCategoryClick (category?: MacroCategory) {

--- a/src/components/settings/macros/MacroSettingsDialog.vue
+++ b/src/components/settings/macros/MacroSettingsDialog.vue
@@ -107,7 +107,7 @@ export default class MacroMoveDialog extends Vue {
   }
 
   handleSave () {
-    this.$store.dispatch('macros/saveMacro', this.macro)
+    this.$typedDispatch('macros/saveMacro', this.macro)
     this.open = false
   }
 }

--- a/src/components/settings/presets/PresetSettings.vue
+++ b/src/components/settings/presets/PresetSettings.vue
@@ -135,7 +135,7 @@ export default class TemperaturePresetSettings extends Mixins(StateMixin) {
   }
 
   handleSavePreset (preset: TemperaturePreset) {
-    this.$store.dispatch('config/updatePreset', preset)
+    this.$typedDispatch('config/updatePreset', preset)
   }
 
   async handleRemovePreset (preset: TemperaturePreset) {
@@ -145,7 +145,7 @@ export default class TemperaturePresetSettings extends Mixins(StateMixin) {
     )
 
     if (result) {
-      this.$store.dispatch('config/removePreset', preset)
+      this.$typedDispatch('config/removePreset', preset)
     }
   }
 }

--- a/src/components/ui/AppColorPicker.vue
+++ b/src/components/ui/AppColorPicker.vue
@@ -304,7 +304,7 @@ export default class AppColorPicker extends Vue {
   }
 
   set valueRange (value: ColorPickerValueRange) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.general.colorPickerValueRange',
       value,
       server: true

--- a/src/components/ui/AppColumnPicker.vue
+++ b/src/components/ui/AppColumnPicker.vue
@@ -80,7 +80,7 @@ export default class AppColumnPicker extends Vue {
         visible
       }))
 
-    this.$store.dispatch('config/updateHeaders', { name: this.keyName, headers })
+    this.$typedDispatch('config/updateHeaders', { name: this.keyName, headers })
   }
 
   handleToggleHeader (value: AppDataTableHeader) {
@@ -89,7 +89,7 @@ export default class AppColumnPicker extends Vue {
       visible: !(value.visible !== false)
     }
 
-    this.$store.dispatch('config/updateHeader', { name: this.keyName, header })
+    this.$typedDispatch('config/updateHeader', { name: this.keyName, header })
   }
 }
 </script>

--- a/src/components/widgets/bedmesh/BedMeshControls.vue
+++ b/src/components/widgets/bedmesh/BedMeshControls.vue
@@ -300,7 +300,7 @@ export default class BedMesh extends Mixins(StateMixin, ToolheadMixin) {
   }
 
   set matrix (val: MatrixType) {
-    this.$store.dispatch('mesh/onMatrix', val)
+    this.$typedDispatch('mesh/onMatrix', val)
   }
 
   get mapScale () {
@@ -308,7 +308,7 @@ export default class BedMesh extends Mixins(StateMixin, ToolheadMixin) {
   }
 
   set mapScale (val: number) {
-    this.$store.dispatch('mesh/onScale', val)
+    this.$typedDispatch('mesh/onScale', val)
   }
 
   get boxScale () {
@@ -316,7 +316,7 @@ export default class BedMesh extends Mixins(StateMixin, ToolheadMixin) {
   }
 
   set boxScale (val: number) {
-    this.$store.dispatch('mesh/onBoxScale', val)
+    this.$typedDispatch('mesh/onBoxScale', val)
   }
 
   get wireframe () {
@@ -324,7 +324,7 @@ export default class BedMesh extends Mixins(StateMixin, ToolheadMixin) {
   }
 
   set wireframe (val: boolean) {
-    this.$store.dispatch('mesh/onWireframe', val)
+    this.$typedDispatch('mesh/onWireframe', val)
   }
 
   get flatSurface () {
@@ -332,7 +332,7 @@ export default class BedMesh extends Mixins(StateMixin, ToolheadMixin) {
   }
 
   set flatSurface (val: boolean) {
-    this.$store.dispatch('mesh/onFlatSurface', val)
+    this.$typedDispatch('mesh/onFlatSurface', val)
   }
 
   get mesh (): MeshState {

--- a/src/components/widgets/camera/CameraCard.vue
+++ b/src/components/widgets/camera/CameraCard.vue
@@ -66,7 +66,7 @@ export default class CameraCard extends Mixins(StateMixin) {
   }
 
   handleCameraSelect (id: string) {
-    this.$store.dispatch('webcams/updateActiveWebcam', id)
+    this.$typedDispatch('webcams/updateActiveWebcam', id)
   }
 }
 </script>

--- a/src/components/widgets/console/Console.vue
+++ b/src/components/widgets/console/Console.vue
@@ -92,7 +92,7 @@ export default class Console extends Mixins(StateMixin) {
   }
 
   set currentCommand (val: string) {
-    this.$store.commit('console/setConsoleCommand', val)
+    this.$typedCommit('console/setConsoleCommand', val)
   }
 
   get flipLayout (): boolean {

--- a/src/components/widgets/console/ConsoleCard.vue
+++ b/src/components/widgets/console/ConsoleCard.vue
@@ -154,7 +154,7 @@ export default class ConsoleCard extends Vue {
   }
 
   set hideTempWaits (value: boolean) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.general.hideTempWaits',
       value,
       server: true
@@ -166,7 +166,7 @@ export default class ConsoleCard extends Vue {
   }
 
   set flipLayout (value: boolean) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.general.flipConsoleLayout',
       value,
       server: true
@@ -188,7 +188,7 @@ export default class ConsoleCard extends Vue {
   }
 
   set autoScroll (value: boolean) {
-    this.$store.dispatch('console/onUpdateAutoScroll', value)
+    this.$typedDispatch('console/onUpdateAutoScroll', value)
     if (value) {
       this.consoleElement.scrollToLatest(true)
     }
@@ -208,11 +208,11 @@ export default class ConsoleCard extends Vue {
   }
 
   handleClear () {
-    this.$store.dispatch('console/onClear')
+    this.$typedDispatch('console/onClear')
   }
 
   handleToggleFilter (filter: ConsoleFilter) {
-    this.$store.dispatch('console/onSaveFilter', {
+    this.$typedDispatch('console/onSaveFilter', {
       ...filter,
       enabled: !filter.enabled
     })

--- a/src/components/widgets/console/ConsoleCommand.vue
+++ b/src/components/widgets/console/ConsoleCommand.vue
@@ -89,7 +89,7 @@ export default class ConsoleCommand extends Vue {
         this.originalHistory.pop()
       }
       this.originalHistory.unshift(val)
-      this.$store.dispatch('console/onUpdateCommandHistory', [...this.originalHistory])
+      this.$typedDispatch('console/onUpdateCommandHistory', [...this.originalHistory])
       this.history = [...this.originalHistory]
       this.isFirst = true
       this.$emit('send', val)
@@ -135,7 +135,7 @@ export default class ConsoleCommand extends Vue {
         const message = commands
           .map(command => `// ${command}: ${availableCommands[command].help ?? ''}`)
           .join('\n')
-        this.$store.dispatch('console/onAddConsoleEntry', { message, type: 'response' })
+        this.$typedDispatch('console/onAddConsoleEntry', { message, type: 'response' })
       }
     }
   }

--- a/src/components/widgets/endstops/EndStopsCard.vue
+++ b/src/components/widgets/endstops/EndStopsCard.vue
@@ -103,7 +103,7 @@ export default class EndStopsCard extends Mixins(StateMixin) {
   }
 
   destroyed () {
-    this.$store.commit('printer/setClearEndStops')
+    this.$typedCommit('printer/setClearEndStops')
   }
 }
 </script>

--- a/src/components/widgets/filesystem/FileSystem.vue
+++ b/src/components/widgets/filesystem/FileSystem.vue
@@ -200,7 +200,7 @@ export default class FileSystem extends Mixins(StateMixin, FilesMixin, ServicesM
   }
 
   set filters (value: FileFilterType[]) {
-    this.$store.dispatch('config/updateFileSystemActiveFilters', { root: this.currentRoot, value })
+    this.$typedDispatch('config/updateFileSystemActiveFilters', { root: this.currentRoot, value })
   }
 
   // Maintains content menu state.
@@ -506,7 +506,7 @@ export default class FileSystem extends Mixins(StateMixin, FilesMixin, ServicesM
   }
 
   set currentPath (path: string) {
-    this.$store.dispatch('files/updateCurrentPathByRoot', { root: this.currentRoot, path })
+    this.$typedDispatch('files/updateCurrentPathByRoot', { root: this.currentRoot, path })
   }
 
   // Returns the current path with no root.
@@ -832,7 +832,7 @@ export default class FileSystem extends Mixins(StateMixin, FilesMixin, ServicesM
         this.$router.push({ name: 'gcode_preview' })
       }
 
-      this.$store.dispatch('gcodePreview/loadGcode', {
+      this.$typedDispatch('gcodePreview/loadGcode', {
         file,
         gcode
       })
@@ -896,7 +896,7 @@ export default class FileSystem extends Mixins(StateMixin, FilesMixin, ServicesM
     const spoolmanSupported: boolean = this.$typedGetters['spoolman/getAvailable']
     const autoSpoolSelectionDialog: boolean = this.$typedState.config.uiSettings.spoolman.autoSpoolSelectionDialog
     if (spoolmanSupported && autoSpoolSelectionDialog) {
-      this.$store.commit('spoolman/setDialogState', {
+      this.$typedCommit('spoolman/setDialogState', {
         show: true,
         filename
       })
@@ -1027,11 +1027,11 @@ export default class FileSystem extends Mixins(StateMixin, FilesMixin, ServicesM
   async handleUpload (files: FileList | File[] | FileWithPath[], print: boolean) {
     const wait = `${this.$waits.onFileSystem}/${this.currentPath}/`
 
-    this.$store.dispatch('wait/addWait', wait)
+    this.$typedDispatch('wait/addWait', wait)
 
     await this.uploadFiles(files, this.visiblePath, this.currentRoot, print)
 
-    this.$store.dispatch('wait/removeWait', wait)
+    this.$typedDispatch('wait/removeWait', wait)
   }
 
   handleAddDir (name: string) {

--- a/src/components/widgets/filesystem/FileSystemBrowser.vue
+++ b/src/components/widgets/filesystem/FileSystemBrowser.vue
@@ -215,7 +215,7 @@ export default class FileSystemBrowser extends Mixins(FilesMixin) {
   }
 
   set sortBy (value: string | null | undefined) {
-    this.$store.dispatch('config/updateFileSystemSortBy', { root: this.root, value: value ?? null })
+    this.$typedDispatch('config/updateFileSystemSortBy', { root: this.root, value: value ?? null })
   }
 
   get sortDesc (): boolean {
@@ -225,7 +225,7 @@ export default class FileSystemBrowser extends Mixins(FilesMixin) {
   }
 
   set sortDesc (value: boolean | null | undefined) {
-    this.$store.dispatch('config/updateFileSystemSortDesc', { root: this.root, value: value ?? null })
+    this.$typedDispatch('config/updateFileSystemSortDesc', { root: this.root, value: value ?? null })
   }
 
   customSort (items: FileBrowserEntry[], sortBy: string[], sortDesc: boolean[], locale: string) {

--- a/src/components/widgets/filesystem/FileSystemToolbar.vue
+++ b/src/components/widgets/filesystem/FileSystemToolbar.vue
@@ -223,7 +223,7 @@ export default class FileSystemToolbar extends Mixins(StatesMixin) {
   }
 
   set thumbnailSize (value: number) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.general.thumbnailSize',
       value,
       server: true

--- a/src/components/widgets/filesystem/FileSystemUploadDialog.vue
+++ b/src/components/widgets/filesystem/FileSystemUploadDialog.vue
@@ -89,7 +89,7 @@ export default class FileSystemUploadDialog extends Mixins(StateMixin) {
     if (!file.complete) {
       // Hasn't started uploading...
       if (file.loaded === 0) {
-        this.$store.dispatch('files/updateFileUpload', {
+        this.$typedDispatch('files/updateFileUpload', {
           uid: file.uid,
           cancelled: true
         })

--- a/src/components/widgets/gcode-preview/GcodePreview.vue
+++ b/src/components/widgets/gcode-preview/GcodePreview.vue
@@ -394,7 +394,7 @@ export default class GcodePreview extends Mixins(StateMixin, BrowserMixin) {
   }
 
   set autoZoom (value: boolean) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.gcodePreview.autoZoom',
       value,
       server: true
@@ -408,7 +408,7 @@ export default class GcodePreview extends Mixins(StateMixin, BrowserMixin) {
   }
 
   set followProgress (value: boolean) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.gcodePreview.followProgress',
       value,
       server: true
@@ -420,7 +420,7 @@ export default class GcodePreview extends Mixins(StateMixin, BrowserMixin) {
   }
 
   set showPreviousLayer (value: boolean) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.gcodePreview.showPreviousLayer',
       value,
       server: true
@@ -432,7 +432,7 @@ export default class GcodePreview extends Mixins(StateMixin, BrowserMixin) {
   }
 
   set showCurrentLayer (value: boolean) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.gcodePreview.showCurrentLayer',
       value,
       server: true
@@ -444,7 +444,7 @@ export default class GcodePreview extends Mixins(StateMixin, BrowserMixin) {
   }
 
   set showNextLayer (value: boolean) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.gcodePreview.showNextLayer',
       value,
       server: true
@@ -456,7 +456,7 @@ export default class GcodePreview extends Mixins(StateMixin, BrowserMixin) {
   }
 
   set showMoves (value: boolean) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.gcodePreview.showMoves',
       value,
       server: true
@@ -468,7 +468,7 @@ export default class GcodePreview extends Mixins(StateMixin, BrowserMixin) {
   }
 
   set showExtrusions (value: boolean) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.gcodePreview.showExtrusions',
       value,
       server: true
@@ -480,7 +480,7 @@ export default class GcodePreview extends Mixins(StateMixin, BrowserMixin) {
   }
 
   set showRetractions (value: boolean) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.gcodePreview.showRetractions',
       value,
       server: true
@@ -492,7 +492,7 @@ export default class GcodePreview extends Mixins(StateMixin, BrowserMixin) {
   }
 
   set showParts (value: boolean) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.gcodePreview.showParts',
       value,
       server: true

--- a/src/components/widgets/gcode-preview/GcodePreviewCard.vue
+++ b/src/components/widgets/gcode-preview/GcodePreviewCard.vue
@@ -302,7 +302,7 @@ export default class GcodePreviewCard extends Mixins(StateMixin, FilesMixin, Bro
   }
 
   set followProgress (value: boolean) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.gcodePreview.followProgress',
       value,
       server: true
@@ -340,11 +340,11 @@ export default class GcodePreviewCard extends Mixins(StateMixin, FilesMixin, Bro
   }
 
   abortParser () {
-    this.$store.dispatch('gcodePreview/terminateParserWorker')
+    this.$typedDispatch('gcodePreview/terminateParserWorker')
   }
 
   resetFile () {
-    this.$store.dispatch('gcodePreview/reset')
+    this.$typedDispatch('gcodePreview/reset')
   }
 
   async loadCurrent () {
@@ -363,7 +363,7 @@ export default class GcodePreviewCard extends Mixins(StateMixin, FilesMixin, Bro
 
       if (!gcode) return
 
-      this.$store.dispatch('gcodePreview/loadGcode', {
+      this.$typedDispatch('gcodePreview/loadGcode', {
         file,
         gcode
       })

--- a/src/components/widgets/history/JobHistory.vue
+++ b/src/components/widgets/history/JobHistory.vue
@@ -410,7 +410,7 @@ export default class JobHistory extends Mixins(FilesMixin) {
   }
 
   handleJobThumbnailError (job: HistoryItem) {
-    this.$store.dispatch('history/clearHistoryThumbnails', job.job_id)
+    this.$typedDispatch('history/clearHistoryThumbnails', job.job_id)
   }
 
   getItemValue (item: HistoryItem, header: DataTableHeader, defaultGetter: DefaultGetterFunction) {

--- a/src/components/widgets/macros/Macros.vue
+++ b/src/components/widgets/macros/Macros.vue
@@ -88,7 +88,7 @@ export default class Macros extends Mixins(StateMixin) {
   }
 
   set expanded (val: number[]) {
-    this.$store.dispatch('macros/saveExpanded', val)
+    this.$typedDispatch('macros/saveExpanded', val)
   }
 
   handleEditCategory (categoryId: string) {

--- a/src/components/widgets/spoolman/SpoolSelectionDialog.vue
+++ b/src/components/widgets/spoolman/SpoolSelectionDialog.vue
@@ -296,7 +296,7 @@ export default class SpoolSelectionDialog extends Mixins(StateMixin, BrowserMixi
   }
 
   set open (val: boolean) {
-    this.$store.commit('spoolman/setDialogState', {
+    this.$typedCommit('spoolman/setDialogState', {
       ...this.$typedState.spoolman.dialog,
       show: val
     })
@@ -618,7 +618,7 @@ export default class SpoolSelectionDialog extends Mixins(StateMixin, BrowserMixi
   }
 
   handleSortOrderKeyChange (value?: string) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.spoolman.selectionDialogSortOrder.key',
       value: value ?? null,
       server: true
@@ -626,7 +626,7 @@ export default class SpoolSelectionDialog extends Mixins(StateMixin, BrowserMixi
   }
 
   handleSortOrderDescChange (value?: boolean) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.spoolman.selectionDialogSortOrder.desc',
       value: value ?? null,
       server: true

--- a/src/components/widgets/spoolman/SpoolmanCard.vue
+++ b/src/components/widgets/spoolman/SpoolmanCard.vue
@@ -203,7 +203,7 @@ export default class SpoolmanCard extends Mixins(StateMixin) {
   labelWidth = '86px'
 
   handleSelectSpool (targetMacro?: Macro) {
-    this.$store.commit('spoolman/setDialogState', {
+    this.$typedCommit('spoolman/setDialogState', {
       show: true,
       targetMacro: targetMacro?.name
     })

--- a/src/components/widgets/status/PrinterStatusCard.vue
+++ b/src/components/widgets/status/PrinterStatusCard.vue
@@ -131,7 +131,7 @@ export default class PrinterStatusCard extends Mixins(StateMixin) {
     const autoSpoolSelectionDialog: boolean = this.$typedState.config.uiSettings.spoolman.autoSpoolSelectionDialog
 
     if (spoolmanSupported && autoSpoolSelectionDialog) {
-      this.$store.commit('spoolman/setDialogState', {
+      this.$typedCommit('spoolman/setDialogState', {
         show: true,
         filename
       })

--- a/src/components/widgets/status/ReprintTab.vue
+++ b/src/components/widgets/status/ReprintTab.vue
@@ -122,7 +122,7 @@ export default class ReprintTab extends Mixins(StateMixin, FilesMixin) {
   }
 
   handleJobThumbnailError (job: HistoryItem) {
-    this.$store.dispatch('history/clearHistoryThumbnails', job.job_id)
+    this.$typedDispatch('history/clearHistoryThumbnails', job.job_id)
   }
 }
 </script>

--- a/src/components/widgets/thermals/TemperatureCard.vue
+++ b/src/components/widgets/thermals/TemperatureCard.vue
@@ -154,7 +154,7 @@ export default class TemperatureCard extends Mixins(StateMixin, BrowserMixin) {
   }
 
   set chartVisible (value: boolean) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.general.chartVisible',
       value,
       server: true
@@ -166,7 +166,7 @@ export default class TemperatureCard extends Mixins(StateMixin, BrowserMixin) {
   }
 
   set showRateOfChange (value: boolean) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.general.showRateOfChange',
       value,
       server: true
@@ -178,7 +178,7 @@ export default class TemperatureCard extends Mixins(StateMixin, BrowserMixin) {
   }
 
   set showRelativeHumidity (value: boolean) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.general.showRelativeHumidity',
       value,
       server: true
@@ -190,7 +190,7 @@ export default class TemperatureCard extends Mixins(StateMixin, BrowserMixin) {
   }
 
   set showBarometricPressure (value: boolean) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.general.showBarometricPressure',
       value,
       server: true
@@ -202,7 +202,7 @@ export default class TemperatureCard extends Mixins(StateMixin, BrowserMixin) {
   }
 
   set showGasResistance (value: boolean) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.general.showGasResistance',
       value,
       server: true

--- a/src/components/widgets/thermals/ThermalChart.vue
+++ b/src/components/widgets/thermals/ThermalChart.vue
@@ -37,7 +37,7 @@ export default class ThermalChart extends Mixins(BrowserMixin) {
   initialSelected: Record<string, boolean> = {}
 
   handleLegendSelectChanged (event: { selected: Record<string, boolean> }) {
-    this.$store.dispatch('charts/saveSelectedLegends', event.selected)
+    this.$typedDispatch('charts/saveSelectedLegends', event.selected)
 
     let right = (this.isMobileViewport) ? 15 : 20
     if (this.showPowerAxis(event.selected)) {

--- a/src/components/widgets/toolhead/ExtruderMoves.vue
+++ b/src/components/widgets/toolhead/ExtruderMoves.vue
@@ -102,7 +102,7 @@ export default class ExtruderMoves extends Mixins(StateMixin, ToolheadMixin) {
   }
 
   set extrudeSpeed (value: number) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.toolhead.extrudeSpeed',
       value,
       server: false
@@ -118,7 +118,7 @@ export default class ExtruderMoves extends Mixins(StateMixin, ToolheadMixin) {
   }
 
   set extrudeLength (value: number) {
-    this.$store.dispatch('config/saveByPath', {
+    this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.toolhead.extrudeLength',
       value,
       server: false

--- a/src/components/widgets/toolhead/ToolheadCard.vue
+++ b/src/components/widgets/toolhead/ToolheadCard.vue
@@ -389,7 +389,7 @@ export default class ToolheadCard extends Mixins(StateMixin, ToolheadMixin) {
     )
 
     if (result) {
-      this.$store.dispatch('printer/forceMoveEnabled', !this.forceMoveEnabled)
+      this.$typedDispatch('printer/forceMoveEnabled', !this.forceMoveEnabled)
     }
   }
 }

--- a/src/mixins/files.ts
+++ b/src/mixins/files.ts
@@ -80,7 +80,7 @@ export default class FilesMixin extends Vue {
     if (currentDownload) {
       currentDownload.abortController.abort()
 
-      this.$store.dispatch('files/removeFileDownload', currentDownload.uid)
+      this.$typedDispatch('files/removeFileDownload', currentDownload.uid)
     }
 
     // Sort out the filepath
@@ -93,7 +93,7 @@ export default class FilesMixin extends Vue {
       const abortController = new AbortController()
 
       // Add an entry to vuex indicating we're downloading a file.
-      this.$store.dispatch('files/updateFileDownload', {
+      this.$typedDispatch('files/updateFileDownload', {
         uid,
         filepath,
         size,
@@ -128,7 +128,7 @@ export default class FilesMixin extends Vue {
             size = payload.size = event.total
           }
 
-          this.$store.dispatch('files/updateFileDownload', payload)
+          this.$typedDispatch('files/updateFileDownload', payload)
         }
       })
 
@@ -136,7 +136,7 @@ export default class FilesMixin extends Vue {
 
       return response
     } finally {
-      this.$store.dispatch('files/removeFileDownload', uid)
+      this.$typedDispatch('files/removeFileDownload', uid)
     }
   }
 
@@ -204,7 +204,7 @@ export default class FilesMixin extends Vue {
     try {
       const abortController = new AbortController()
 
-      this.$store.dispatch('files/updateFileUpload', {
+      this.$typedDispatch('files/updateFileUpload', {
         uid,
         filepath,
         size: file.size,
@@ -224,7 +224,7 @@ export default class FilesMixin extends Vue {
             return
           }
 
-          this.$store.dispatch('files/updateFileUpload', {
+          this.$typedDispatch('files/updateFileUpload', {
             uid,
             loaded: event.loaded,
             percent: event.progress ? Math.round(event.progress * 100) : 0,
@@ -237,7 +237,7 @@ export default class FilesMixin extends Vue {
 
       return response
     } finally {
-      this.$store.dispatch('files/removeFileUpload', uid)
+      this.$typedDispatch('files/removeFileUpload', uid)
     }
   }
 
@@ -269,7 +269,7 @@ export default class FilesMixin extends Vue {
           ? `${fullPath}/${fileObject.name}`
           : fileObject.name
 
-        this.$store.dispatch('files/updateFileUpload', {
+        this.$typedDispatch('files/updateFileUpload', {
           uid,
           filepath,
           size: fileObject.size,
@@ -304,7 +304,7 @@ export default class FilesMixin extends Vue {
           consola.error('[FileUpload] file', error)
         }
       } else {
-        this.$store.dispatch('files/removeFileUpload', fileUpload.uid)
+        this.$typedDispatch('files/removeFileUpload', fileUpload.uid)
       }
     }
   }

--- a/src/mixins/services.ts
+++ b/src/mixins/services.ts
@@ -20,7 +20,7 @@ export default class ServicesMixin extends Vue {
    * Resets the UI when restarting/resetting Klipper
    */
   async _klipperReset () {
-    await this.$store.dispatch('resetKlippy', undefined, { root: true })
+    await this.$typedDispatch('resetKlippy')
   }
 
   /**
@@ -57,7 +57,7 @@ export default class ServicesMixin extends Vue {
   async serviceRestartByName (name: string) {
     if (name === this.moonrakerServiceName) {
       SocketActions.serverRestart()
-      this.$store.commit('socket/setSocketDisconnecting', true)
+      this.$typedCommit('socket/setSocketDisconnecting', true)
     } else {
       if (name === this.klipperServiceName) {
         await this._klipperReset()

--- a/src/mixins/state.ts
+++ b/src/mixins/state.ts
@@ -153,7 +153,7 @@ RESTORE_GCODE_STATE NAME=_ui_retract`
   }
 
   addConsoleEntry (message: string) {
-    this.$store.dispatch('console/onAddConsoleEntry', { message, type: 'command' })
+    this.$typedDispatch('console/onAddConsoleEntry', { message, type: 'command' })
   }
 
   async emergencyStop () {

--- a/src/mixins/toolhead.ts
+++ b/src/mixins/toolhead.ts
@@ -101,7 +101,7 @@ export default class ToolheadMixin extends Vue {
   }
 
   set manualProbeDialogOpen (value: boolean) {
-    this.$store.dispatch('printer/manualProbeDialogOpen', value)
+    this.$typedDispatch('printer/manualProbeDialogOpen', value)
   }
 
   get bedScrewsAdjustDialogOpen (): boolean {
@@ -109,7 +109,7 @@ export default class ToolheadMixin extends Vue {
   }
 
   set bedScrewsAdjustDialogOpen (value: boolean) {
-    this.$store.dispatch('printer/bedScrewsAdjustDialogOpen', value)
+    this.$typedDispatch('printer/bedScrewsAdjustDialogOpen', value)
   }
 
   get screwsTiltAdjustDialogOpen (): boolean {
@@ -117,7 +117,7 @@ export default class ToolheadMixin extends Vue {
   }
 
   set screwsTiltAdjustDialogOpen (value: boolean) {
-    this.$store.dispatch('printer/screwsTiltAdjustDialogOpen', value)
+    this.$typedDispatch('printer/screwsTiltAdjustDialogOpen', value)
   }
 
   get forceMoveEnabled (): boolean {

--- a/src/plugins/filters.ts
+++ b/src/plugins/filters.ts
@@ -11,7 +11,7 @@ import dateTimeFormatters from '@/util/date-time-formatters'
 import stringFormatters from '@/util/string-formatters'
 import isNullOrEmpty, { type NullableOrEmpty } from '@/util/is-null-or-empty'
 import consola from 'consola'
-import type { RootGetters, RootState } from '@/store/types'
+import type { RootActions, RootGetters, RootMutations, RootState } from '@/store/types'
 
 const Filters = {
   /**
@@ -170,6 +170,14 @@ export const FiltersPlugin = {
     Vue.$globals = Globals
     Vue.$waits = Waits
 
+    Vue.prototype.$typedCommit = function (...params: any[]) {
+      return this.$store.commit(...params)
+    }
+
+    Vue.prototype.$typedDispatch = function (...params: any[]) {
+      return this.$store.dispatch(...params)
+    }
+
     Object.defineProperty(Vue.prototype, '$typedState', {
       get (): RootState {
         return this.$store.state as RootState
@@ -194,6 +202,8 @@ declare module 'vue/types/vue' {
     $waits: typeof Waits;
     $typedState: RootState;
     $typedGetters: RootGetters;
+    $typedCommit: RootMutations;
+    $typedDispatch: RootActions;
   }
 
   interface VueConstructor {
@@ -203,5 +213,7 @@ declare module 'vue/types/vue' {
     $waits: typeof Waits;
     $typedState: RootState;
     $typedGetters: RootGetters;
+    $typedCommit: RootMutations;
+    $typedDispatch: RootActions;
   }
 }

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -188,8 +188,8 @@ const router = new VueRouter({
 })
 
 router.beforeEach((to, from, next) => {
-  router.app?.$store.commit('config/setContainerColumnCount', 2)
-  router.app?.$store.commit('config/setLayoutMode', false)
+  router.app?.$typedCommit('config/setContainerColumnCount', 2)
+  router.app?.$typedCommit('config/setLayoutMode', false)
   next()
 })
 

--- a/src/store/analysis/actions.ts
+++ b/src/store/analysis/actions.ts
@@ -4,7 +4,7 @@ import type { RootState } from '../types'
 import { SocketActions } from '@/api/socketActions'
 import type { ObjectWithRequest } from '@/plugins/socketClient'
 
-export const actions: ActionTree<AnalysisState, RootState> = {
+export const actions = {
   async reset ({ commit }) {
     commit('setReset')
   },
@@ -24,4 +24,4 @@ export const actions: ActionTree<AnalysisState, RootState> = {
       }
     }
   }
-}
+} satisfies ActionTree<AnalysisState, RootState>

--- a/src/store/analysis/mutations.ts
+++ b/src/store/analysis/mutations.ts
@@ -2,7 +2,7 @@ import type { MutationTree } from 'vuex'
 import type { AnalysisState, AnalysisStatus } from './types'
 import { defaultState } from './state'
 
-export const mutations: MutationTree<AnalysisState> = {
+export const mutations = {
   /**
    * Reset state
    */
@@ -13,4 +13,4 @@ export const mutations: MutationTree<AnalysisState> = {
   setAnalysisStatus (state, payload: AnalysisStatus) {
     state.status = payload
   }
-}
+} satisfies MutationTree<AnalysisState>

--- a/src/store/announcements/actions.ts
+++ b/src/store/announcements/actions.ts
@@ -3,7 +3,7 @@ import type { AnnouncementsState, Announcement } from './types'
 import type { RootState } from '../types'
 import { SocketActions } from '@/api/socketActions'
 
-export const actions: ActionTree<AnnouncementsState, RootState> = {
+export const actions = {
   /**
    * Reset our store
    */
@@ -51,4 +51,4 @@ export const actions: ActionTree<AnnouncementsState, RootState> = {
 
     entries.forEach(async (entry: Announcement) => await SocketActions.serverAnnouncementsDismiss(entry.entry_id))
   }
-}
+} satisfies ActionTree<AnnouncementsState, RootState>

--- a/src/store/announcements/mutations.ts
+++ b/src/store/announcements/mutations.ts
@@ -3,7 +3,7 @@ import type { MutationTree } from 'vuex'
 import { defaultState } from './state'
 import type { AnnouncementsState } from './types'
 
-export const mutations: MutationTree<AnnouncementsState> = {
+export const mutations = {
   /**
    * Reset state
    */
@@ -33,4 +33,4 @@ export const mutations: MutationTree<AnnouncementsState> = {
 
     Vue.set(state, 'entries', entries)
   }
-}
+} satisfies MutationTree<AnnouncementsState>

--- a/src/store/auth/actions.ts
+++ b/src/store/auth/actions.ts
@@ -6,7 +6,7 @@ import { httpClientActions } from '@/api/httpClientActions'
 import router from '@/router'
 import { consola } from 'consola'
 
-export const actions: ActionTree<AuthState, RootState> = {
+export const actions = {
   /**
    * Reset our store
    */
@@ -254,4 +254,4 @@ export const actions: ActionTree<AuthState, RootState> = {
 
     commit('setApiKey', key)
   }
-}
+} satisfies ActionTree<AuthState, RootState>

--- a/src/store/auth/mutations.ts
+++ b/src/store/auth/mutations.ts
@@ -3,7 +3,7 @@ import { defaultState } from './state'
 import type { AuthState } from './types'
 import { jwtDecode } from 'jwt-decode'
 
-export const mutations: MutationTree<AuthState> = {
+export const mutations = {
   /**
    * Reset state
    */
@@ -43,4 +43,4 @@ export const mutations: MutationTree<AuthState> = {
   setApiKey (state, key) {
     state.apiKey = key
   }
-}
+} satisfies MutationTree<AuthState>

--- a/src/store/charts/actions.ts
+++ b/src/store/charts/actions.ts
@@ -5,7 +5,7 @@ import type { ChartData, ChartState } from './types'
 import type { RootState } from '../types'
 import { isEqual } from 'lodash-es'
 
-export const actions: ActionTree<ChartState, RootState> = {
+export const actions = {
   /**
    * Reset our store
    */
@@ -104,4 +104,4 @@ export const actions: ActionTree<ChartState, RootState> = {
       SocketActions.serverWrite(Globals.MOONRAKER_DB.fluidd.ROOTS.charts.name + '.selectedLegends', payload)
     }
   }
-}
+} satisfies ActionTree<ChartState, RootState>

--- a/src/store/charts/mutations.ts
+++ b/src/store/charts/mutations.ts
@@ -3,7 +3,7 @@ import type { MutationTree } from 'vuex'
 import type { ChartData, ChartState } from './types'
 import { defaultState } from './state'
 
-export const mutations: MutationTree<ChartState> = {
+export const mutations = {
   /**
    * Reset state
    */
@@ -57,4 +57,4 @@ export const mutations: MutationTree<ChartState> = {
   setSelectedLegends (state, payload) {
     state.selectedLegends = payload
   }
-}
+} satisfies MutationTree<ChartState>

--- a/src/store/config/actions.ts
+++ b/src/store/config/actions.ts
@@ -8,7 +8,7 @@ import { Waits } from '@/globals'
 import type { FileFilterType } from '../files/types'
 import { TinyColor } from '@ctrl/tinycolor'
 
-export const actions: ActionTree<ConfigState, RootState> = {
+export const actions = {
   /**
    * Reset our store
    */
@@ -111,7 +111,7 @@ export const actions: ActionTree<ConfigState, RootState> = {
   /**
    * Updates a known instance
    */
-  async updateInstance ({ commit, dispatch, state, getters }, value: InstanceConfig) {
+  async updateInstance ({ commit, dispatch, state, getters }, value: string) {
     // First, update the name in ui settings.
     dispatch('saveByPath', {
       path: 'uiSettings.general.instanceName',
@@ -206,4 +206,4 @@ export const actions: ActionTree<ConfigState, RootState> = {
       server: true
     })
   }
-}
+} satisfies ActionTree<ConfigState, RootState>

--- a/src/store/config/mutations.ts
+++ b/src/store/config/mutations.ts
@@ -8,7 +8,7 @@ import { v4 as uuidv4 } from 'uuid'
 import type { FileFilterType } from '../files/types'
 import consola from 'consola'
 
-export const mutations: MutationTree<ConfigState> = {
+export const mutations = {
   /**
    * Reset state
    */
@@ -206,4 +206,4 @@ export const mutations: MutationTree<ConfigState> = {
   setUpdateHeaders (state, payload: { name: string; headers: ConfiguredTableHeader[] }) {
     Vue.set(state.uiSettings.tableHeaders, payload.name, payload.headers)
   }
-}
+} satisfies MutationTree<ConfigState>

--- a/src/store/config/types.ts
+++ b/src/store/config/types.ts
@@ -169,7 +169,7 @@ export interface DashboardConfig {
 
 export interface SaveByPath {
   path: string;
-  value: string | boolean | number;
+  value: unknown;
   server?: boolean;
 }
 

--- a/src/store/console/actions.ts
+++ b/src/store/console/actions.ts
@@ -6,7 +6,7 @@ import { SocketActions } from '@/api/socketActions'
 import DOMPurify from 'dompurify'
 import { takeRightWhile } from 'lodash-es'
 
-export const actions: ActionTree<ConsoleState, RootState> = {
+export const actions = {
   /**
    * Reset our store
    */
@@ -193,4 +193,4 @@ export const actions: ActionTree<ConsoleState, RootState> = {
     commit('setLastCleared')
     SocketActions.serverWrite(Globals.MOONRAKER_DB.fluidd.ROOTS.console.name + '.lastCleared', state.lastCleared)
   }
-}
+} satisfies ActionTree<ConsoleState, RootState>

--- a/src/store/console/mutations.ts
+++ b/src/store/console/mutations.ts
@@ -17,7 +17,7 @@ const compileExpression = (filter: ConsoleFilter): RegExp => {
   }
 }
 
-export const mutations: MutationTree<ConsoleState> = {
+export const mutations = {
   /**
    * Reset state
    */
@@ -160,4 +160,4 @@ export const mutations: MutationTree<ConsoleState> = {
   setLastCleared (state) {
     Vue.set(state, 'lastCleared', Date.now())
   }
-}
+} satisfies MutationTree<ConsoleState>

--- a/src/store/files/actions.ts
+++ b/src/store/files/actions.ts
@@ -20,7 +20,7 @@ const itemAsMoonrakerDir = (item: FileChangeItem, paths: FilePaths): MoonrakerDi
   permissions: item.permissions
 })
 
-export const actions: ActionTree<FilesState, RootState> = {
+export const actions = {
   /**
    * Reset our store
    */
@@ -181,4 +181,4 @@ export const actions: ActionTree<FilesState, RootState> = {
   async updateCurrentPathByRoot ({ commit }, payload) {
     commit('setCurrentPath', payload)
   }
-}
+} satisfies ActionTree<FilesState, RootState>

--- a/src/store/files/mutations.ts
+++ b/src/store/files/mutations.ts
@@ -4,7 +4,7 @@ import type { FilesState, MoonrakerRootFile, MoonrakerPathContent, MoonrakerFile
 import { defaultState } from './state'
 import { Globals } from '@/globals'
 
-export const mutations: MutationTree<FilesState> = {
+export const mutations = {
   /**
    * Reset state
    */
@@ -174,5 +174,4 @@ export const mutations: MutationTree<FilesState> = {
   setDiskUsage (state, payload) {
     Vue.set(state, 'diskUsage', payload)
   }
-
-}
+} satisfies MutationTree<FilesState>

--- a/src/store/gcodePreview/actions.ts
+++ b/src/store/gcodePreview/actions.ts
@@ -6,7 +6,7 @@ import { consola } from 'consola'
 
 import ParseGcodeWorker from '../../workers/parseGcode.worker.ts?worker'
 
-export const actions: ActionTree<GcodePreviewState, RootState> = {
+export const actions = {
   /**
    * Reset our store
    */
@@ -86,4 +86,4 @@ export const actions: ActionTree<GcodePreviewState, RootState> = {
 
     worker.postMessage(message)
   }
-}
+} satisfies ActionTree<GcodePreviewState, RootState>

--- a/src/store/gcodePreview/mutations.ts
+++ b/src/store/gcodePreview/mutations.ts
@@ -4,7 +4,7 @@ import type { GcodePreviewState } from './types'
 import Vue from 'vue'
 import type { AppFile } from '@/store/files/types'
 
-export const mutations: MutationTree<GcodePreviewState> = {
+export const mutations = {
   /**
    * Reset state
    */
@@ -39,4 +39,4 @@ export const mutations: MutationTree<GcodePreviewState> = {
   setParserWorker (state, payload: Worker) {
     state.parserWorker = payload
   }
-}
+} satisfies MutationTree<GcodePreviewState>

--- a/src/store/history/actions.ts
+++ b/src/store/history/actions.ts
@@ -5,7 +5,7 @@ import { SocketActions } from '@/api/socketActions'
 import { Globals } from '@/globals'
 import getFilePaths from '@/util/get-file-paths'
 
-export const actions: ActionTree<HistoryState, RootState> = {
+export const actions = {
   /**
    * Reset our store
    */
@@ -87,4 +87,4 @@ export const actions: ActionTree<HistoryState, RootState> = {
   async onDelete ({ commit }, payload) {
     commit('setDeleteJob', payload.deleted_jobs)
   }
-}
+} satisfies ActionTree<HistoryState, RootState>

--- a/src/store/history/mutations.ts
+++ b/src/store/history/mutations.ts
@@ -3,7 +3,7 @@ import type { MutationTree } from 'vuex'
 import { defaultState } from './state'
 import type { HistoryState, MoonrakerHistoryItem } from './types'
 
-export const mutations: MutationTree<HistoryState> = {
+export const mutations = {
   /**
    * Reset state
    */
@@ -72,4 +72,4 @@ export const mutations: MutationTree<HistoryState> = {
       })
     }
   }
-}
+} satisfies MutationTree<HistoryState>

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,5 +1,5 @@
 import Vue from 'vue'
-import Vuex from 'vuex'
+import Vuex, { type StoreOptions } from 'vuex'
 import { consola } from 'consola'
 import type { RootModules, RootState } from './types'
 import type { InitConfig } from './config/types'
@@ -30,38 +30,36 @@ import { spoolman } from './spoolman'
 import { sensors } from './sensors'
 import { analysis } from './analysis'
 
-const modules: RootModules = {
-  socket,
-  auth,
-  server,
-  printer,
-  config,
-  files,
-  layout,
-  charts,
-  console,
-  macros,
-  power,
-  history,
-  version,
-  mesh,
-  notifications,
-  announcements,
-  wait,
-  gcodePreview,
-  timelapse,
-  webcams,
-  jobQueue,
-  spoolman,
-  sensors,
-  analysis
-}
-
 Vue.use(Vuex)
 
-export default new Vuex.Store<RootState>({
+export const storeOptions = {
   strict: (import.meta.env.DEV),
-  modules,
+  modules: {
+    socket,
+    auth,
+    server,
+    printer,
+    config,
+    files,
+    layout,
+    charts,
+    console,
+    macros,
+    power,
+    history,
+    version,
+    mesh,
+    notifications,
+    announcements,
+    wait,
+    gcodePreview,
+    timelapse,
+    webcams,
+    jobQueue,
+    spoolman,
+    sensors,
+    analysis
+  } satisfies RootModules,
   mutations: {},
   actions: {
     /**
@@ -115,4 +113,6 @@ export default new Vuex.Store<RootState>({
       consola.debug('void action', payload)
     }
   }
-})
+} satisfies StoreOptions<RootState>
+
+export default new Vuex.Store<RootState>(storeOptions)

--- a/src/store/jobQueue/actions.ts
+++ b/src/store/jobQueue/actions.ts
@@ -4,7 +4,7 @@ import type { RootState } from '../types'
 import { SocketActions } from '@/api/socketActions'
 import getFilePaths from '@/util/get-file-paths'
 
-export const actions: ActionTree<JobQueueState, RootState> = {
+export const actions = {
   async reset ({ commit }) {
     commit('setReset')
   },
@@ -54,4 +54,4 @@ export const actions: ActionTree<JobQueueState, RootState> = {
       }
     }
   }
-}
+} satisfies ActionTree<JobQueueState, RootState>

--- a/src/store/jobQueue/mutations.ts
+++ b/src/store/jobQueue/mutations.ts
@@ -2,7 +2,7 @@ import type { MutationTree } from 'vuex'
 import type { JobQueueState, QueuedJob, QueueState } from './types'
 import { defaultState } from './state'
 
-export const mutations: MutationTree<JobQueueState> = {
+export const mutations = {
   setReset (state) {
     Object.assign(state, defaultState())
   },
@@ -14,4 +14,4 @@ export const mutations: MutationTree<JobQueueState> = {
   setQueuedJobs (state, payload: QueuedJob[]) {
     state.queuedJobs = payload || []
   }
-}
+} satisfies MutationTree<JobQueueState>

--- a/src/store/layout/actions.ts
+++ b/src/store/layout/actions.ts
@@ -1,10 +1,10 @@
 import type { ActionTree } from 'vuex'
-import type { LayoutConfig, LayoutState } from './types'
+import type { LayoutConfig, LayoutContainer, LayoutState } from './types'
 import type { RootState } from '../types'
 import { SocketActions } from '@/api/socketActions'
 import { Globals } from '@/globals'
 
-export const actions: ActionTree<LayoutState, RootState> = {
+export const actions = {
   /**
    * Reset our store
    */
@@ -16,7 +16,7 @@ export const actions: ActionTree<LayoutState, RootState> = {
     commit('setInitLayout', payload)
   },
 
-  async onLayoutChange ({ commit, state }, payload: { name: string; value: LayoutConfig }) {
+  async onLayoutChange ({ commit, state }, payload: { name: string; value: LayoutContainer }) {
     const layout = state.layouts[payload.name]
     if (layout || payload.name.startsWith('dashboard')) {
       commit('setLayoutChange', payload)
@@ -48,4 +48,4 @@ export const actions: ActionTree<LayoutState, RootState> = {
       }
     }
   }
-}
+} satisfies ActionTree<LayoutState, RootState>

--- a/src/store/layout/mutations.ts
+++ b/src/store/layout/mutations.ts
@@ -1,10 +1,10 @@
 import Vue from 'vue'
 import type { MutationTree } from 'vuex'
 import { defaultState as getDefaultState } from './state'
-import type { LayoutConfig, LayoutState, Layouts } from './types'
+import type { LayoutConfig, LayoutState, LayoutContainer } from './types'
 import type { DiagnosticsCardContainer } from '../diagnostics/types'
 
-export const mutations: MutationTree<LayoutState> = {
+export const mutations = {
   /**
    * Reset state
    */
@@ -75,7 +75,7 @@ export const mutations: MutationTree<LayoutState> = {
     }
   },
 
-  setLayoutChange (state, payload: { name: string; value: Layouts }) {
+  setLayoutChange (state, payload: { name: string; value: LayoutContainer }) {
     Vue.set(state.layouts, payload.name, payload.value)
   },
 
@@ -85,4 +85,4 @@ export const mutations: MutationTree<LayoutState> = {
   setUpdateConfig (state, payload: { name: string; container: string; i: number; value: LayoutConfig }) {
     Vue.set(state.layouts[payload.name][payload.container], payload.i, payload.value)
   }
-}
+} satisfies MutationTree<LayoutState>

--- a/src/store/macros/actions.ts
+++ b/src/store/macros/actions.ts
@@ -4,7 +4,7 @@ import type { RootState } from '../types'
 import { SocketActions } from '@/api/socketActions'
 import { Globals } from '@/globals'
 
-export const actions: ActionTree<MacrosState, RootState> = {
+export const actions = {
   /**
    * Reset our store
    */
@@ -93,4 +93,4 @@ export const actions: ActionTree<MacrosState, RootState> = {
     // Save to moonraker.
     SocketActions.serverWrite(Globals.MOONRAKER_DB.fluidd.ROOTS.macros.name + '.expanded', state.expanded)
   }
-}
+} satisfies ActionTree<MacrosState, RootState>

--- a/src/store/macros/mutations.ts
+++ b/src/store/macros/mutations.ts
@@ -15,7 +15,7 @@ const sanitizeMacroForStorage = (macro: Macro) => {
   return macro
 }
 
-export const mutations: MutationTree<MacrosState> = {
+export const mutations = {
   /**
    * Reset state
    */
@@ -91,4 +91,4 @@ export const mutations: MutationTree<MacrosState> = {
   setExpanded (state, expanded: number[]) {
     Vue.set(state, 'expanded', expanded)
   }
-}
+} satisfies MutationTree<MacrosState>

--- a/src/store/mesh/actions.ts
+++ b/src/store/mesh/actions.ts
@@ -2,7 +2,7 @@ import type { ActionTree } from 'vuex'
 import type { MeshState } from './types'
 import type { RootState } from '../types'
 
-export const actions: ActionTree<MeshState, RootState> = {
+export const actions = {
   /**
    * Reset our store
    */
@@ -29,4 +29,4 @@ export const actions: ActionTree<MeshState, RootState> = {
   async onFlatSurface ({ commit }, payload) {
     commit('setFlatSurface', payload)
   }
-}
+} satisfies ActionTree<MeshState, RootState>

--- a/src/store/mesh/mutations.ts
+++ b/src/store/mesh/mutations.ts
@@ -2,7 +2,7 @@ import type { MutationTree } from 'vuex'
 import { defaultState } from './state'
 import type { MeshState } from './types'
 
-export const mutations: MutationTree<MeshState> = {
+export const mutations = {
   /**
    * Reset state
    */
@@ -29,4 +29,4 @@ export const mutations: MutationTree<MeshState> = {
   setFlatSurface (state, payload) {
     state.flatSurface = payload
   }
-}
+} satisfies MutationTree<MeshState>

--- a/src/store/notifications/actions.ts
+++ b/src/store/notifications/actions.ts
@@ -4,7 +4,7 @@ import { v4 as uuidv4 } from 'uuid'
 import type { NotificationsState, AppPushNotification, AppNotification } from './types'
 import type { RootState } from '../types'
 
-export const actions: ActionTree<NotificationsState, RootState> = {
+export const actions = {
   /**
    * Reset our store
    */
@@ -71,4 +71,4 @@ export const actions: ActionTree<NotificationsState, RootState> = {
 
     dispatch('announcements/dismissAll', {}, { root: true })
   }
-}
+} satisfies ActionTree<NotificationsState, RootState>

--- a/src/store/notifications/mutations.ts
+++ b/src/store/notifications/mutations.ts
@@ -3,7 +3,7 @@ import type { MutationTree } from 'vuex'
 import { defaultState } from './state'
 import type { NotificationsState, AppNotification } from './types'
 
-export const mutations: MutationTree<NotificationsState> = {
+export const mutations = {
   /**
    * Reset state
    */
@@ -36,4 +36,4 @@ export const mutations: MutationTree<NotificationsState> = {
   setClearAllNotifications (state) {
     Vue.set(state, 'notifications', [...state.notifications.filter(n => !n.clear)])
   }
-}
+} satisfies MutationTree<NotificationsState>

--- a/src/store/power/actions.ts
+++ b/src/store/power/actions.ts
@@ -3,7 +3,7 @@ import type { DevicePowerState } from './types'
 import type { RootState } from '../types'
 import { SocketActions } from '@/api/socketActions'
 
-export const actions: ActionTree<DevicePowerState, RootState> = {
+export const actions = {
   /**
    * Reset our store
    */
@@ -36,4 +36,4 @@ export const actions: ActionTree<DevicePowerState, RootState> = {
   async onStatus ({ commit }, payload) {
     commit('setStatus', payload)
   },
-}
+} satisfies ActionTree<DevicePowerState, RootState>

--- a/src/store/power/mutations.ts
+++ b/src/store/power/mutations.ts
@@ -3,7 +3,7 @@ import type { MutationTree } from 'vuex'
 import type { DevicePowerState } from './types'
 import { defaultState } from './state'
 
-export const mutations: MutationTree<DevicePowerState> = {
+export const mutations = {
   /**
    * Reset state
    */
@@ -23,4 +23,4 @@ export const mutations: MutationTree<DevicePowerState> = {
       }
     }
   }
-}
+} satisfies MutationTree<DevicePowerState>

--- a/src/store/printer/actions.ts
+++ b/src/store/printer/actions.ts
@@ -13,7 +13,7 @@ import i18n from '@/plugins/i18n'
 
 // let retryTimeout: number
 
-export const actions: ActionTree<PrinterState, RootState> = {
+export const actions = {
   /**
    * Reset our store
    */
@@ -291,4 +291,4 @@ export const actions: ActionTree<PrinterState, RootState> = {
       data
     }, { root: true })
   }
-}
+} satisfies ActionTree<PrinterState, RootState>

--- a/src/store/printer/mutations.ts
+++ b/src/store/printer/mutations.ts
@@ -4,7 +4,7 @@ import type { PrinterState } from './types'
 import { defaultState } from './state'
 import { get } from 'lodash-es'
 
-export const mutations: MutationTree<PrinterState> = {
+export const mutations = {
   /**
    * Reset state
    */
@@ -87,5 +87,4 @@ export const mutations: MutationTree<PrinterState> = {
       }
     }
   }
-
-}
+} satisfies MutationTree<PrinterState>

--- a/src/store/sensors/actions.ts
+++ b/src/store/sensors/actions.ts
@@ -3,7 +3,7 @@ import type { MoonrakerSensors, MoonrakerSensorsState } from './types'
 import type { RootState } from '../types'
 import { SocketActions } from '@/api/socketActions'
 
-export const actions: ActionTree<MoonrakerSensorsState, RootState> = {
+export const actions = {
   async reset ({ commit }) {
     commit('setReset')
   },
@@ -23,4 +23,4 @@ export const actions: ActionTree<MoonrakerSensorsState, RootState> = {
       commit('setSensorUpdate', payload)
     }
   }
-}
+} satisfies ActionTree<MoonrakerSensorsState, RootState>

--- a/src/store/sensors/mutations.ts
+++ b/src/store/sensors/mutations.ts
@@ -3,7 +3,7 @@ import type { MutationTree } from 'vuex'
 import type { MoonrakerSensors, MoonrakerSensorsState } from './types'
 import { defaultState } from './state'
 
-export const mutations: MutationTree<MoonrakerSensorsState> = {
+export const mutations = {
   /**
    * Reset state
    */
@@ -20,4 +20,4 @@ export const mutations: MutationTree<MoonrakerSensorsState> = {
       Vue.set(state.sensors[sensorKey], 'values', payload[sensorKey])
     }
   }
-}
+} satisfies MutationTree<MoonrakerSensorsState>

--- a/src/store/server/actions.ts
+++ b/src/store/server/actions.ts
@@ -12,7 +12,7 @@ import type { ObjectWithRequest } from '@/plugins/socketClient'
 
 let retryTimeout: number
 
-export const actions: ActionTree<ServerState, RootState> = {
+export const actions = {
   /**
    * Reset our store
    */
@@ -231,4 +231,4 @@ export const actions: ActionTree<ServerState, RootState> = {
       commit('setMoonrakerStats', { throttled_state: payload })
     }
   }
-}
+} satisfies ActionTree<ServerState, RootState>

--- a/src/store/server/mutations.ts
+++ b/src/store/server/mutations.ts
@@ -3,7 +3,7 @@ import type { MutationTree } from 'vuex'
 import { defaultState } from './state'
 import type { CanbusUuid, Peripherals, ServerInfo, ServerState, ServiceState, SystemInfo } from './types'
 
-export const mutations: MutationTree<ServerState> = {
+export const mutations = {
   /**
    * Reset state
    */
@@ -86,4 +86,4 @@ export const mutations: MutationTree<ServerState> = {
   setKlippyRetries (state, payload: number) {
     state.klippy_retries = payload
   }
-}
+} satisfies MutationTree<ServerState>

--- a/src/store/socket/actions.ts
+++ b/src/store/socket/actions.ts
@@ -11,7 +11,7 @@ import isKeyOf from '@/util/is-key-of'
 
 let retryTimeout: number
 
-export const actions: ActionTree<SocketState, RootState> = {
+export const actions = {
   /**
    * Reset our store
    */
@@ -262,4 +262,4 @@ export const actions: ActionTree<SocketState, RootState> = {
   async notifySpoolmanStatusChanged ({ dispatch }, payload) {
     dispatch('spoolman/onStatusChanged', payload.spoolman_connected, { root: true })
   }
-}
+} satisfies ActionTree<SocketState, RootState>

--- a/src/store/socket/mutations.ts
+++ b/src/store/socket/mutations.ts
@@ -2,7 +2,7 @@ import type { MutationTree } from 'vuex'
 import type { SocketState } from './types'
 import { defaultState } from './state'
 
-export const mutations: MutationTree<SocketState> = {
+export const mutations = {
   /**
    * Reset state
    */
@@ -38,4 +38,4 @@ export const mutations: MutationTree<SocketState> = {
   setConnectionId (state, payload) {
     state.connectionId = payload
   }
-}
+} satisfies MutationTree<SocketState>

--- a/src/store/spoolman/actions.ts
+++ b/src/store/spoolman/actions.ts
@@ -38,7 +38,7 @@ const payloadAsSpoolmanProxyResponseV2 = <T>(payload: SpoolmanProxyResponse<T>):
   }
 }
 
-export const actions: ActionTree<SpoolmanState, RootState> = {
+export const actions = {
   /**
    * Reset our store
    */
@@ -236,4 +236,4 @@ export const actions: ActionTree<SpoolmanState, RootState> = {
       state.socket = undefined
     }
   }
-}
+} satisfies ActionTree<SpoolmanState, RootState>

--- a/src/store/spoolman/mutations.ts
+++ b/src/store/spoolman/mutations.ts
@@ -7,7 +7,7 @@ import type {
   SpoolSelectionDialogState
 } from '@/store/spoolman/types'
 
-export const mutations: MutationTree<SpoolmanState> = {
+export const mutations = {
   /**
    * Reset state
    */
@@ -38,4 +38,4 @@ export const mutations: MutationTree<SpoolmanState> = {
   setConnected (state, payload) {
     state.connected = payload
   }
-}
+} satisfies MutationTree<SpoolmanState>

--- a/src/store/timelapse/actions.ts
+++ b/src/store/timelapse/actions.ts
@@ -6,7 +6,7 @@ import { consola } from 'consola'
 import { EventBus } from '@/eventBus'
 import i18n from '@/plugins/i18n'
 
-export const actions: ActionTree<TimelapseState, RootState> = {
+export const actions = {
   /**
    * Reset our store
    */
@@ -103,4 +103,4 @@ export const actions: ActionTree<TimelapseState, RootState> = {
       }
     }
   }
-}
+} satisfies ActionTree<TimelapseState, RootState>

--- a/src/store/timelapse/mutations.ts
+++ b/src/store/timelapse/mutations.ts
@@ -2,7 +2,7 @@ import type { MutationTree } from 'vuex'
 import { defaultState } from './state'
 import type { TimelapseState, TimelapseLastFrame, TimelapseSettings, RenderStatus } from './types'
 
-export const mutations: MutationTree<TimelapseState> = {
+export const mutations = {
   /**
    * Reset state
    */
@@ -22,4 +22,4 @@ export const mutations: MutationTree<TimelapseState> = {
   setRenderStatus (state, payload: RenderStatus) {
     state.renderStatus = payload
   }
-}
+} satisfies MutationTree<TimelapseState>

--- a/src/store/version/actions.ts
+++ b/src/store/version/actions.ts
@@ -5,7 +5,7 @@ import type { RootState } from '../types'
 import { SocketActions } from '@/api/socketActions'
 import i18n from '@/plugins/i18n'
 
-export const actions: ActionTree<VersionState, RootState> = {
+export const actions = {
   /**
    * Reset our store
    */
@@ -81,4 +81,4 @@ export const actions: ActionTree<VersionState, RootState> = {
     consola.debug('Finished updating all services', payload)
     window.location.reload()
   }
-}
+} satisfies ActionTree<VersionState, RootState>

--- a/src/store/version/mutations.ts
+++ b/src/store/version/mutations.ts
@@ -3,7 +3,7 @@ import type { MutationTree } from 'vuex'
 import type { VersionState } from './types'
 import { defaultState } from './state'
 
-export const mutations: MutationTree<VersionState> = {
+export const mutations = {
   /**
    * Reset state
    */
@@ -44,4 +44,4 @@ export const mutations: MutationTree<VersionState> = {
   setClearUpdateResponse (state) {
     state.responses = []
   }
-}
+} satisfies MutationTree<VersionState>

--- a/src/store/wait/actions.ts
+++ b/src/store/wait/actions.ts
@@ -2,7 +2,7 @@ import type { ActionTree } from 'vuex'
 import type { WaitState } from './types'
 import type { RootState } from '../types'
 
-export const actions: ActionTree<WaitState, RootState> = {
+export const actions = {
   /**
    * Reset our store
    */
@@ -23,4 +23,4 @@ export const actions: ActionTree<WaitState, RootState> = {
   async removeWait ({ commit }, wait) {
     commit('setRemoveWait', wait)
   }
-}
+} satisfies ActionTree<WaitState, RootState>

--- a/src/store/wait/mutations.ts
+++ b/src/store/wait/mutations.ts
@@ -2,7 +2,7 @@ import type { MutationTree } from 'vuex'
 import type { WaitState } from './types'
 import { defaultState } from './state'
 
-export const mutations: MutationTree<WaitState> = {
+export const mutations = {
   /**
    * Reset state
    */
@@ -25,4 +25,4 @@ export const mutations: MutationTree<WaitState> = {
     const i = state.waits.indexOf(payload)
     if (i !== -1) state.waits.splice(i, 1)
   }
-}
+} satisfies MutationTree<WaitState>

--- a/src/store/webcams/actions.ts
+++ b/src/store/webcams/actions.ts
@@ -18,7 +18,7 @@ const mjpegstreamerServices: WebcamService[] = [
   'mjpegstreamer-adaptive'
 ]
 
-export const actions: ActionTree<WebcamsState, RootState> = {
+export const actions = {
   async reset ({ commit }) {
     commit('setReset')
   },
@@ -90,4 +90,4 @@ export const actions: ActionTree<WebcamsState, RootState> = {
       commit('setWebcamsList', payload)
     }
   }
-}
+} satisfies ActionTree<WebcamsState, RootState>

--- a/src/store/webcams/mutations.ts
+++ b/src/store/webcams/mutations.ts
@@ -3,7 +3,7 @@ import type { MutationTree } from 'vuex'
 import type { WebcamConfig, WebcamsState } from './types'
 import { defaultState } from './state'
 
-export const mutations: MutationTree<WebcamsState> = {
+export const mutations = {
   setReset (state) {
     Object.assign(state, defaultState())
   },
@@ -39,4 +39,4 @@ export const mutations: MutationTree<WebcamsState> = {
   setActiveWebcam (state, payload: string) {
     state.activeWebcam = payload
   }
-}
+} satisfies MutationTree<WebcamsState>

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -107,7 +107,7 @@ export default class Dashboard extends Mixins(StateMixin) {
 
   @Watch('columnCount')
   onColumnCount (value: number) {
-    this.$store.commit('config/setContainerColumnCount', value)
+    this.$typedCommit('config/setContainerColumnCount', value)
 
     this.updateMenuCollapsed()
   }
@@ -208,7 +208,7 @@ export default class Dashboard extends Mixins(StateMixin) {
   handleUpdateLayout () {
     const name: string = this.$typedGetters['layout/getSpecificLayoutName']
 
-    this.$store.dispatch('layout/onLayoutChange', {
+    this.$typedDispatch('layout/onLayoutChange', {
       name,
       value: {
         container1: this.containers[0],

--- a/src/views/Diagnostics.vue
+++ b/src/views/Diagnostics.vue
@@ -174,7 +174,7 @@ export default class Diagnostics extends Mixins(StateMixin) {
   }
 
   updateLayout () {
-    this.$store.dispatch('layout/onLayoutChange', {
+    this.$typedDispatch('layout/onLayoutChange', {
       name: 'diagnostics',
       value: {
         container1: this.containers[0],

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -114,7 +114,7 @@ export default class Login extends Vue {
   availableSources = [this.source]
 
   async mounted () {
-    const authInfo = await this.$store.dispatch('auth/getAuthInfo')
+    const authInfo = await this.$typedDispatch('auth/getAuthInfo')
     this.source = authInfo.defaultSource ?? this.source
     this.availableSources = authInfo.availableSources ?? this.availableSources
   }
@@ -123,7 +123,7 @@ export default class Login extends Vue {
     this.error = false
     this.loading = true
     try {
-      await this.$store.dispatch('auth/login', { username: this.username, password: this.password, source: this.source })
+      await this.$typedDispatch('auth/login', { username: this.username, password: this.password, source: this.source })
     } catch {
       this.error = true
     }


### PR DESCRIPTION
State management with Vuex is lacking in terms of TypeScript typings, so this is my attempt to fix that by introducing:

- `$typedState.*` - replaces `$store.state.*`
- `$typedGetters[]` - replaces `$store.getters[]`
- `$typedCommit()` - replaces `$store.commit()`
- `$typedDispatch()` - replaces `$store.dispatch()`