### PR TITLE
fix: incorrect update status on system packages

### DIFF
--- a/src/components/settings/VersionSettings.vue
+++ b/src/components/settings/VersionSettings.vue
@@ -116,7 +116,7 @@
                 </v-icon>
               </app-btn>
             </template>
-            <span v-if="'name' in component">{{ $t('app.version.tooltip.release_notes') }}</span>
+            <span v-if="'name' in component && component.name !== 'system'">{{ $t('app.version.tooltip.release_notes') }}</span>
             <span v-else-if="'commits_behind' in component">{{ $t('app.version.tooltip.commit_history') }}</span>
             <span v-else-if="'package_list' in component">{{ $t('app.version.tooltip.packages') }}</span>
           </v-tooltip>

--- a/src/store/version/getters.ts
+++ b/src/store/version/getters.ts
@@ -39,7 +39,7 @@ export const getters = {
   hasUpdate: (state) => (component: string): boolean => {
     const componentVersionInfo = state.version_info[component]
 
-    if ('name' in componentVersionInfo) {
+    if ('name' in componentVersionInfo && componentVersionInfo.name !== 'system') {
       const version = valid(componentVersionInfo.version)
       const remoteVersion = valid(componentVersionInfo.remote_version)
       if (version && remoteVersion) {


### PR DESCRIPTION
Since [this](https://github.com/Arksine/moonraker/commit/50e1f3c0c4da92ed90f1014861b042c5c50d3bf0), Moonraker now sends a "name" property as part of the "system" updates and that broke the way we check if OS updates are available or not.

Easy fix is to check the name!

Fixes #1652 