### PR TITLE
fix: raise click event only once

### DIFF
--- a/src/components/ui/AppBtnToolheadMove.vue
+++ b/src/components/ui/AppBtnToolheadMove.vue
@@ -11,7 +11,6 @@
         class="px-2"
         v-bind="{...$attrs, ...attrs}"
         v-on="{...$listeners, ...on}"
-        @click="$emit('click')"
       >
         <v-icon
           v-if="icon"


### PR DESCRIPTION
This bug was introduced by the changes in ca087b7aff306cda71a076d1984014f76a58e85e, when the `v-on="$listeners"` directive was added, the `@click="$emit('click')"` should have been removed - which is exactly what this PR does!

Fixes #1663