### PR TITLE
feat: adjustable thumbnail size on Job Queue and History

### DIFF
--- a/src/components/widgets/filesystem/FileSystemBrowser.vue
+++ b/src/components/widgets/filesystem/FileSystemBrowser.vue
@@ -179,8 +179,8 @@ export default class FileSystemBrowser extends Mixins(FilesMixin) {
     return this.rootProperties.readonly
   }
 
-  get thumbnailSize () {
-    const thumbnailSize: number = this.$typedState.config.uiSettings.general.thumbnailSize
+  get thumbnailSize (): number {
+    const thumbnailSize: number = this.$typedState.config.uiSettings.thumbnailSizes[this.root] ?? 32
 
     return this.dense ? thumbnailSize / 2 : thumbnailSize
   }

--- a/src/components/widgets/filesystem/FileSystemToolbar.vue
+++ b/src/components/widgets/filesystem/FileSystemToolbar.vue
@@ -218,15 +218,11 @@ export default class FileSystemToolbar extends Mixins(StatesMixin) {
   }
 
   get thumbnailSize (): number {
-    return this.$typedState.config.uiSettings.general.thumbnailSize
+    return this.$typedState.config.uiSettings.thumbnailSizes[this.root] ?? 32
   }
 
   set thumbnailSize (value: number) {
-    this.$typedDispatch('config/saveByPath', {
-      path: 'uiSettings.general.thumbnailSize',
-      value,
-      server: true
-    })
+    this.$typedDispatch('config/updateThumbnailSizes', { name: this.root, size: value })
   }
 
   handleUpload (files: FileList | File[], print: boolean) {

--- a/src/components/widgets/history/JobHistory.vue
+++ b/src/components/widgets/history/JobHistory.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="file-system">
-    <v-toolbar
-      dense
-    >
+    <v-toolbar dense>
       <v-spacer />
+
+      <app-thumbnail-size v-model="thumbnailSize" />
 
       <app-column-picker
         v-if="headers"
@@ -32,7 +32,6 @@
       :items="history"
       :headers="headers"
       :items-per-page="15"
-      single-expand
       :search="search"
       mobile-breakpoint="0"
       item-key="job_id"
@@ -51,32 +50,38 @@
           :custom-getter="getItemValue"
         >
           <template #[`item.data-table-icons`]>
-            <!-- If the item no longer exists. -->
-            <v-icon
-              v-if="!item.exists"
-              class="mr-2"
-              color="grey"
+            <v-layout
+              justify-center
+              class="no-pointer-events"
             >
-              $fileCancel
-            </v-icon>
+              <!-- If the item no longer exists. -->
+              <v-icon
+                v-if="!item.exists"
+                color="grey"
+              >
+                $fileCancel
+              </v-icon>
 
-            <!-- If the item exists, but has no thumbnail data. -->
-            <v-icon
-              v-else-if="!item.metadata.thumbnails?.length"
-              class="mr-2"
-              color="grey"
-            >
-              $file
-            </v-icon>
+              <!-- If the item exists, but has no thumbnail data. -->
+              <v-icon
+                v-else-if="!item.metadata.thumbnails?.length"
+                color="grey"
+              >
+                $file
+              </v-icon>
 
-            <!-- If the item exists, and we have thumbnail data. -->
-            <img
-              v-else
-              class="mr-2 file-icon-thumb"
-              :src="getThumbUrl(item.metadata, 'gcodes', getFilePaths(item.filename).path, false, item.metadata.modified)"
-              :width="24"
-              @error="handleJobThumbnailError(item)"
-            >
+              <!-- If the item exists, and we have thumbnail data. -->
+              <img
+                v-else
+                class="file-icon-thumb"
+                :style="{
+                  'max-width': `${thumbnailSize}px`,
+                  'max-height': `${thumbnailSize}px`
+                }"
+                :src="getThumbUrl(item.metadata, 'gcodes', getFilePaths(item.filename).path, thumbnailSize > 16, item.metadata.modified)"
+                @error="handleJobThumbnailError(item)"
+              >
+            </v-layout>
           </template>
 
           <template #[`item.status`]>
@@ -384,6 +389,14 @@ export default class JobHistory extends Mixins(FilesMixin) {
         align: 'end'
       }
     ]
+  }
+
+  get thumbnailSize (): number {
+    return this.$typedState.config.uiSettings.thumbnailSizes.history ?? 32
+  }
+
+  set thumbnailSize (value: number) {
+    this.$typedDispatch('config/updateThumbnailSizes', { name: 'history', size: value })
   }
 
   get sensors (): MoonrakerSensor[] {

--- a/src/components/widgets/job-queue/JobQueueBrowser.vue
+++ b/src/components/widgets/job-queue/JobQueueBrowser.vue
@@ -70,8 +70,11 @@
                 <img
                   v-else
                   class="file-icon-thumb"
-                  :src="getThumbUrl(item.file, 'gcodes', getFilePaths(item.filename).path, dense != true, item.file.modified)"
-                  :width="dense ? 16 : 32"
+                  :style="{
+                    'max-width': `${thumbnailSize}px`,
+                    'max-height': `${thumbnailSize}px`
+                  }"
+                  :src="getThumbUrl(item.file, 'gcodes', getFilePaths(item.filename).path, thumbnailSize > 16, item.file.modified)"
                 >
               </v-layout>
             </template>
@@ -118,7 +121,7 @@
               small
               class="ma-1"
             >
-              {{ $t('app.job_queue.label.eta') }}: {{ $filters.formatDateTime(Date.now() + jobTotals.time * 1000) }}
+              {{ $t('app.job_queue.label.eta') }}: {{ $filters.formatAbsoluteDateTime(Date.now() + jobTotals.time * 1000) }}
             </v-chip>
           </div>
         </template>
@@ -206,6 +209,12 @@ export default class JobQueueBrowser extends Mixins(StateMixin, FilesMixin) {
 
       return totals
     }, { filamentLength: 0, filamentWeight: 0, time: 0, withoutFile: 0 })
+  }
+
+  get thumbnailSize () {
+    const thumbnailSize: number = this.$typedState.config.uiSettings.thumbnailSizes.jobQueue ?? 32
+
+    return this.dense ? thumbnailSize / 2 : thumbnailSize
   }
 
   getFilePaths (filename: string) {

--- a/src/components/widgets/job-queue/JobQueueToolbar.vue
+++ b/src/components/widgets/job-queue/JobQueueToolbar.vue
@@ -2,6 +2,8 @@
   <v-toolbar dense>
     <v-spacer />
 
+    <app-thumbnail-size v-model="thumbnailSize" />
+
     <app-column-picker
       v-if="headers"
       key-name="job_queue"
@@ -48,5 +50,13 @@ import type { AppDataTableHeader } from '@/types'
 export default class JobQueueToolbar extends Vue {
   @Prop({ type: Array })
   readonly headers?: AppDataTableHeader[]
+
+  get thumbnailSize (): number {
+    return this.$typedState.config.uiSettings.thumbnailSizes.jobQueue ?? 32
+  }
+
+  set thumbnailSize (value: number) {
+    this.$typedDispatch('config/updateThumbnailSizes', { name: 'jobQueue', size: value })
+  }
 }
 </script>

--- a/src/store/config/actions.ts
+++ b/src/store/config/actions.ts
@@ -192,6 +192,14 @@ export const actions = {
     }
   },
 
+  async updateThumbnailSizes ({ commit, state }, payload: { name: string; size: number }) {
+    commit('setupdateThumbnailSizes', payload)
+
+    if (state.uiSettings.thumbnailSizes[payload.name]) {
+      SocketActions.serverWrite(`uiSettings.thumbnailSizes.${payload.name}`, state.uiSettings.thumbnailSizes[payload.name])
+    }
+  },
+
   async updateTheme ({ state, dispatch }, payload: Partial<ThemeConfig>) {
     const updatedTheme: ThemeConfig = {
       ...state.uiSettings.theme,

--- a/src/store/config/mutations.ts
+++ b/src/store/config/mutations.ts
@@ -205,5 +205,9 @@ export const mutations = {
 
   setUpdateHeaders (state, payload: { name: string; headers: ConfiguredTableHeader[] }) {
     Vue.set(state.uiSettings.tableHeaders, payload.name, payload.headers)
+  },
+
+  setupdateThumbnailSizes (state, payload: { name: string; size: number }) {
+    Vue.set(state.uiSettings.thumbnailSizes, payload.name, payload.size)
   }
 } satisfies MutationTree<ConfigState>

--- a/src/store/config/state.ts
+++ b/src/store/config/state.ts
@@ -68,7 +68,6 @@ export const defaultState = (): ConfigState => {
         printProgressCalculation: ['file'],
         printEtaCalculation: ['file'],
         enableDiagnostics: false,
-        thumbnailSize: 32,
         colorPickerValueRange: 'absolute'
       },
       theme: {
@@ -90,6 +89,7 @@ export const defaultState = (): ConfigState => {
         tempPresets: []
       },
       tableHeaders: {},
+      thumbnailSizes: {},
       gcodePreview: {
         extrusionLineWidth: 0.3,
         moveLineWidth: 0.1,

--- a/src/store/config/types.ts
+++ b/src/store/config/types.ts
@@ -18,6 +18,7 @@ export interface UiSettings {
   editor: EditorConfig;
   dashboard: DashboardConfig;
   tableHeaders: TableHeadersConfig;
+  thumbnailSizes: ThumbnailSizesConfig;
   gcodePreview: GcodePreviewConfig;
   fileSystem: FileSystemConfig;
   toolhead: ToolheadConfig;
@@ -121,7 +122,6 @@ export interface GeneralConfig {
   printProgressCalculation: PrintProgressCalculation[];
   printEtaCalculation: PrintEtaCalculation[];
   enableDiagnostics: boolean;
-  thumbnailSize: number;
   colorPickerValueRange: ColorPickerValueRange;
 }
 
@@ -222,7 +222,10 @@ export interface TemperaturePresetValue {
   active: boolean;
 }
 
-export interface TableHeadersConfig extends Record<string, ConfiguredTableHeader[]> {
+export interface TableHeadersConfig extends Record<string, ConfiguredTableHeader[] | undefined> {
+}
+
+export interface ThumbnailSizesConfig extends Record<string, number | undefined> {
 }
 
 export interface ConfiguredTableHeader {


### PR DESCRIPTION
We currently only allow configuring the thumbnail size for the Jobs, this change allow it to be configurable also on the Job History and Job Queue lists.

Related with #1667 