### PR TITLE
feat(JobQueue): use current print ETA in queue ETA

### DIFF
--- a/src/components/widgets/job-queue/JobQueueBrowser.vue
+++ b/src/components/widgets/job-queue/JobQueueBrowser.vue
@@ -121,7 +121,7 @@
               small
               class="ma-1"
             >
-              {{ $t('app.job_queue.label.eta') }}: {{ $filters.formatAbsoluteDateTime(Date.now() + jobTotals.time * 1000) }}
+              {{ $t('app.job_queue.label.eta') }}: {{ $filters.formatAbsoluteDateTime(eta) }}
             </v-chip>
           </div>
         </template>
@@ -138,6 +138,7 @@ import StateMixin from '@/mixins/state'
 import type { DataTableHeader } from 'vuetify'
 import FilesMixin from '@/mixins/files'
 import getFilePaths from '@/util/get-file-paths'
+import type { TimeEstimates } from '@/store/printer/types'
 
 type JobTotals = {
   filamentLength: number,
@@ -215,6 +216,18 @@ export default class JobQueueBrowser extends Mixins(StateMixin, FilesMixin) {
     const thumbnailSize: number = this.$typedState.config.uiSettings.thumbnailSizes.jobQueue ?? 32
 
     return this.dense ? thumbnailSize / 2 : thumbnailSize
+  }
+
+  get estimates (): TimeEstimates {
+    return this.$typedGetters['printer/getTimeEstimates']
+  }
+
+  get eta () {
+    const base = this.printerPrinting || this.printerPaused
+      ? this.estimates.eta
+      : Date.now()
+
+    return base + this.jobTotals.time * 1000
   }
 
   getFilePaths (filename: string) {


### PR DESCRIPTION
If the printer is printing or paused, take the current printing job ETA as base to calculate the Job Queue ETA

Related with https://github.com/fluidd-core/fluidd/issues/1667