### PR TITLE
fix: use path & filename in MmuEditTtgMapDialog

### DIFF
--- a/src/components/widgets/mmu/MmuEditTtgMapDialog.vue
+++ b/src/components/widgets/mmu/MmuEditTtgMapDialog.vue
@@ -584,16 +584,17 @@ export default class MmuEditTtgMapDialog extends Mixins(BrowserMixin, StateMixin
   async commit () {
     const mapStr = this.localTtgMap.join(',')
     const esGrpStr = this.localEndlessSpoolGroups.join(',')
-    let cmd = 'MMU_SLICER_TOOL_MAP SKIP_AUTOMAP=' + (this.skipAutomap ? 1 : 0)
-    this.sendGcode(cmd)
-    cmd = `MMU_TTG_MAP MAP="${mapStr}" QUIET=1`
-    this.sendGcode(cmd)
-    cmd = `MMU_ENDLESS_SPOOL GROUPS="${esGrpStr}" QUIET=1`
-    this.sendGcode(cmd)
+
+    const gcode = `MMU_SLICER_TOOL_MAP SKIP_AUTOMAP=${this.skipAutomap ? 1 : 0}
+MMU_TTG_MAP MAP="${mapStr}" QUIET=1
+MMU_ENDLESS_SPOOL GROUPS="${esGrpStr}" QUIET=1`
+
+    this.sendGcode(gcode)
 
     // Mimick Fluidd workflow: If called prior to print, start print now
-    if (this.file) {
-      await SocketActions.printerPrintStart(this.file.filename)
+    if (this.filename) {
+      await SocketActions.printerPrintStart(this.filename)
+
       if (this.$route.name !== 'home') {
         this.$router.push({ name: 'home' })
       }


### PR DESCRIPTION
The `AppFile.filename` attribute is related to the just the filename (no path) as returned by moonraker - this PR replaces it with the full path + filename to fix the issue.

Fixes #1675 