### PR TITLE
fix: store macro names casing as-is

### DIFF
--- a/src/components/settings/macros/MacroCategorySettings.vue
+++ b/src/components/settings/macros/MacroCategorySettings.vue
@@ -144,8 +144,14 @@ export default class MacroCategorySettings extends Vue {
   }
 
   get macros () {
+    if (!this.search) {
+      return this.macrosForCategory
+    }
+
+    const search = this.search.toLowerCase()
+
     return this.macrosForCategory
-      .filter((macro: Macro) => !this.search ? true : macro.name.includes(this.search.toLowerCase()))
+      .filter(macro => macro.name.toLowerCase().includes(search))
   }
 
   set macros (macros: Macro[]) {

--- a/src/components/widgets/spoolman/SpoolSelectionDialog.vue
+++ b/src/components/widgets/spoolman/SpoolSelectionDialog.vue
@@ -3,7 +3,7 @@
     v-model="open"
     scrollable
     :max-width="$vuetify.breakpoint.mdAndDown ? '90vw' : '75vw'"
-    :title="$tc('app.spoolman.title.spool_selection', targetMacro ? 2 : 1, { macro: targetMacro })"
+    :title="$tc('app.spoolman.title.spool_selection', targetMacro ? 2 : 1, { macro: targetMacro?.toUpperCase() })"
     title-shadow
   >
     <template #menu>

--- a/src/components/widgets/spoolman/SpoolmanCard.vue
+++ b/src/components/widgets/spoolman/SpoolmanCard.vue
@@ -255,7 +255,7 @@ export default class SpoolmanCard extends Mixins(StateMixin) {
 
     return macros
       .filter((macro): macro is MacroWithSpoolId => macro.variables != null && 'spool_id' in macro.variables)
-      .sort((a, b) => a.name.localeCompare(b.name))
+      .sort((a, b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase()))
   }
 
   get remainingFilamentUnit (): SpoolmanRemainingFilamentUnit {

--- a/src/components/widgets/toolhead/ToolheadCard.vue
+++ b/src/components/widgets/toolhead/ToolheadCard.vue
@@ -249,7 +249,7 @@ export default class ToolheadCard extends Mixins(StateMixin, ToolheadMixin) {
 
       tools.push({
         name: loadFilamentMacro.name.toUpperCase(),
-        label: loadFilamentMacro.name === 'm701' ? 'M701 (Load Filament)' : undefined,
+        label: loadFilamentMacro.name.toLowerCase() === 'm701' ? 'M701 (Load Filament)' : undefined,
         icon: '$loadFilament',
         disabled: !(ignoreMinExtrudeTemp || this.extruderReady)
       })
@@ -262,7 +262,7 @@ export default class ToolheadCard extends Mixins(StateMixin, ToolheadMixin) {
 
       tools.push({
         name: unloadFilamentMacro.name.toUpperCase(),
-        label: unloadFilamentMacro.name === 'm702' ? 'M702 (Unload Filament)' : undefined,
+        label: unloadFilamentMacro.name.toLowerCase() === 'm702' ? 'M702 (Unload Filament)' : undefined,
         icon: '$unloadFilament',
         disabled: !(ignoreMinExtrudeTemp || this.extruderReady)
       })
@@ -273,7 +273,7 @@ export default class ToolheadCard extends Mixins(StateMixin, ToolheadMixin) {
     if (cleanNozzleMacro) {
       tools.push({
         name: cleanNozzleMacro.name.toUpperCase(),
-        label: cleanNozzleMacro.name === 'g12' ? 'G12 (Clean the Nozzle)' : undefined,
+        label: cleanNozzleMacro.name.toLowerCase() === 'g12' ? 'G12 (Clean the Nozzle)' : undefined,
         icon: '$cleanNozzle'
       })
     }

--- a/src/store/macros/getters.ts
+++ b/src/store/macros/getters.ts
@@ -21,16 +21,17 @@ export const getters = {
     const macros = Object.keys(rootState.printer.printer)
       .filter(key => key.startsWith('gcode_macro '))
       .map(key => {
+        const name = key.split(' ', 2)[1]
         const lowerCaseKey = key.toLowerCase()
-        const name = lowerCaseKey.split(' ', 2)[1]
+        const lowerCaseName = name.toLowerCase()
         const config = rootState.printer.printer.configfile.settings[lowerCaseKey]
-        const stored = state.stored.find(macro => macro.name === name)
+        const stored = state.stored.find(macro => macro.name.toLowerCase() === lowerCaseName)
         const variables = rootState.printer.printer[key]
 
         const macro: Macro = {
           ...MACRO_DEFAULTS,
-          name,
           ...stored,
+          name,
           variables,
           config
         }
@@ -57,7 +58,7 @@ export const getters = {
 
     for (const name of names) {
       const lowerCaseName = name.toLowerCase()
-      const macro = macros.find(macro => macro.name === lowerCaseName)
+      const macro = macros.find(macro => macro.name.toLowerCase() === lowerCaseName)
 
       if (macro) {
         return macro
@@ -108,7 +109,7 @@ export const getters = {
           return a.order - b.order
         }
 
-        return a.name.localeCompare(b.name)
+        return a.name.toLowerCase().localeCompare(b.name.toLowerCase())
       })
   },
 

--- a/src/store/macros/mutations.ts
+++ b/src/store/macros/mutations.ts
@@ -33,18 +33,22 @@ export const mutations = {
 
   // Updates a singular macro
   setUpdateMacro (state, macro: Macro) {
-    const m = sanitizeMacroForStorage({ ...macro })
-    const i = state.stored.findIndex(m => m.name === macro.name)
+    const lowerCaseName = macro.name.toLowerCase()
+    const i = state.stored.findIndex(m => m.name.toLowerCase() === lowerCaseName)
+    const processed = sanitizeMacroForStorage({
+      ...macro
+    })
     if (i < 0) {
-      state.stored.push(m)
+      state.stored.push(processed)
     } else {
-      Vue.set(state.stored, i, m)
+      Vue.set(state.stored, i, processed)
     }
   },
 
   setUpdateAllVisible (state, payload: { macros: Macro[]; visible: boolean }) {
     payload.macros.forEach((macro: Macro) => {
-      const i = state.stored.findIndex(m => m.name === macro.name)
+      const lowerCaseName = macro.name.toLowerCase()
+      const i = state.stored.findIndex(m => m.name.toLowerCase() === lowerCaseName)
       const processed = sanitizeMacroForStorage({
         ...macro,
         visible: payload.visible


### PR DESCRIPTION
When listing the currently available macros, keep the name casing as-is so it can be correctly used with `SET_GCODE_VARIABLE`.

When searching for macros by name, sorting macros by name, or checking for stored settings, use case-insensitive comparison (normally, just use `toLowerCase()` on the name and call it a day as that is faster then using `.localeCompare()` method)