### PR TITLE
fix: undefined property access in case of deleted macro lookup

### DIFF
--- a/src/store/macros/getters.ts
+++ b/src/store/macros/getters.ts
@@ -25,7 +25,7 @@ export const getters = {
         const lowerCaseKey = key.toLowerCase()
         const lowerCaseName = name.toLowerCase()
         const config = rootState.printer.printer.configfile.settings[lowerCaseKey]
-        const stored = state.stored.find(macro => macro.name.toLowerCase() === lowerCaseName)
+        const stored = state.stored.find(macro => macro.name?.toLowerCase() === lowerCaseName)
         const variables = rootState.printer.printer[key]
 
         const macro: Macro = {


### PR DESCRIPTION
When a macro is removed from the config, it isn't deleted from the stored config in the database. This can lead to an undefined property access while looking up the stored macro data:

![image](https://github.com/user-attachments/assets/f73de270-3536-42bf-a968-9251d1b2959d)
