### PR TITLE
fix(i18n): OS packages label

### DIFF
--- a/src/components/settings/VersionSettings.vue
+++ b/src/components/settings/VersionSettings.vue
@@ -94,7 +94,7 @@
               -> {{ component.remote_version }}
             </span>
             <span v-if="'package_count' in component && component.package_count > 0">
-              {{ component.package_count }} packages
+              {{ $tc('app.version.label.packages', component.package_count) }}
             </span>
           </template>
 

--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -842,6 +842,8 @@ app:
       invalid: INVALID
       os_packages: OS Packages
       package_list: Package List
+      packages: >-
+        {count} package | {count} packages
       up_to_date: UP TO DATE
       updates_available: Updates are available
       old_component_version: >-


### PR DESCRIPTION
This pull request introduces an enhancement to the localization of package count labels in the `VersionSettings` component. It replaces hardcoded text with a translatable string to support internationalization.

### Localization Improvements:

* [`src/components/settings/VersionSettings.vue`](diffhunk://#diff-7a16ae617d6f79cefd15b3fe34e12f796794c78a2186383afdfd3287698bf934L97-R97): Replaced the hardcoded package count text with the `$tc` function to enable translation and pluralization of the "packages" label.
* [`src/locales/en.yaml`](diffhunk://#diff-e97720333256f91a9b02ce78dd9c8db3a90c329d215dcf0f5dd5bc65e402ec11R845-R846): Added a new translatable string for the "packages" label with support for singular and plural forms.

Fixes #1695 