### PR TITLE
feat: adds config editor symbol support

### DIFF
--- a/src/components/widgets/filesystem/setupMonaco.features.ts
+++ b/src/components/widgets/filesystem/setupMonaco.features.ts
@@ -3,6 +3,7 @@ import 'monaco-editor/esm/vs/editor/editor.all.js'
 // full list of features on 'monaco-editor/esm/metadata.js'
 import 'monaco-editor/esm/vs/editor/standalone/browser/iPadShowKeyboard/iPadShowKeyboard.js'
 import 'monaco-editor/esm/vs/editor/standalone/browser/quickAccess/standaloneGotoLineQuickAccess.js'
+import 'monaco-editor/esm/vs/editor/standalone/browser/quickAccess/standaloneGotoSymbolQuickAccess.js'
 import 'monaco-editor/esm/vs/editor/standalone/browser/quickAccess/standaloneCommandsQuickAccess.js'
 
 import 'monaco-editor/esm/vs/language/css/monaco.contribution'


### PR DESCRIPTION
This pull request enhances the Monaco editor integration for `klipper-config` files by adding improved symbol navigation and document structure awareness. The main changes introduce a document symbol provider to support outline and symbol navigation features, and ensure the necessary Monaco quick access functionality is included.

**Monaco Editor Feature Enhancements:**

* Added import for `standaloneGotoSymbolQuickAccess.js` to enable symbol navigation (e.g., "Go to Symbol") in the Monaco editor.

**klipper-config Language Support:**

* Registered a document symbol provider for `klipper-config` files, allowing the editor to display sections and properties in the outline view and support symbol navigation. This groups lines into sections (as namespaces) and properties (as child symbols), improving code navigation and structure visibility.

## Klipper config editor showing "Go to symbol" menu

<img width="2612" height="1222" alt="image" src="https://github.com/user-attachments/assets/1ca908ba-68fd-4cbb-a8ec-cee42afadac2" />
