### PR TITLE
feat: show relative Z in Screws Tilt Adjust dialog

### DIFF
--- a/src/components/common/ScrewsTiltAdjustDialog.vue
+++ b/src/components/common/ScrewsTiltAdjustDialog.vue
@@ -26,6 +26,10 @@
               <small class="secondary--text">{{ `X = ${screw.x}, Y = ${screw.y}` }}</small>
             </td>
             <td class="focus--text text-right">
+              <small
+                v-if="screw.relativeZ"
+                class="secondary--text"
+              >({{ screw.relativeZ.toFixed(4) }})</small>
               {{ screw.z.toFixed(4) }}
             </td>
             <td class="text-right">

--- a/src/components/common/ScrewsTiltAdjustDialog.vue
+++ b/src/components/common/ScrewsTiltAdjustDialog.vue
@@ -29,7 +29,7 @@
               <small
                 v-if="screw.relativeZ"
                 class="secondary--text"
-              >({{ screw.relativeZ.toFixed(4) }})</small>
+              >({{ `${screw.relativeZ < 0 ? '' : '+'}${screw.relativeZ.toFixed(4)}` }})</small>
               {{ screw.z.toFixed(4) }}
             </td>
             <td class="text-right">

--- a/src/store/printer/getters.ts
+++ b/src/store/printer/getters.ts
@@ -957,6 +957,14 @@ export const getters = {
       }
     }
 
+    const baseZ = screws.find(screw => screw.is_base)?.z
+
+    if (baseZ != null) {
+      for (const screw of screws) {
+        screw.relativeZ = screw.z - baseZ
+      }
+    }
+
     return {
       ...rest,
       screws

--- a/src/store/printer/types.ts
+++ b/src/store/printer/types.ts
@@ -1532,6 +1532,7 @@ export interface ScrewsTiltAdjustScrew {
   name: string;
   prettyName: string;
   adjustMinutes: number;
+  relativeZ?: number;
   x: number;
   y: number;
   z: number;


### PR DESCRIPTION
Displays the relative Z position of each screw in the Screws Tilt Adjust dialog, making it easier to compare screw heights.

The relative Z is calculated based on the base screw's Z value and shown alongside the absolute Z in the UI.

## Screws Tilt Adjust dialog

<img width="1028" height="768" alt="image" src="https://github.com/user-attachments/assets/74e9b0a3-680b-4727-aefa-bb5027b3b9f8" />

Resolves #1703 