### PR TITLE
fix: always show update status indicator

### DIFF
--- a/src/components/settings/VersionStatus.vue
+++ b/src/components/settings/VersionStatus.vue
@@ -5,6 +5,7 @@
       small
       outlined
       :color="(disabled) ? 'grey darken-2' : 'success'"
+      class="ml-1"
     >
       {{ $t('app.version.label.up_to_date') }}
     </v-chip>
@@ -19,6 +20,7 @@
           outlined
           :disabled="disabled"
           :color="(disabled) ? 'grey darken-2' : 'error'"
+          class="ml-1"
           v-on="on"
         >
           {{ $t('app.version.label.dirty') }}
@@ -37,6 +39,7 @@
           small
           outlined
           :color="(disabled) ? 'grey darken-2' : 'error'"
+          class="ml-1"
           v-on="on"
         >
           {{ $t('app.version.label.invalid') }}


### PR DESCRIPTION
Always show the update status info icon regardless of the error status

<img width="2187" height="1055" alt="image" src="https://github.com/user-attachments/assets/e6a41b4c-e1aa-4541-9610-5527ec66e658" />

Fixes #1697