### PR TITLE
fix: iOS device upload

### DIFF
--- a/src/components/layout/AppUploadAndPrintBtn.vue
+++ b/src/components/layout/AppUploadAndPrintBtn.vue
@@ -30,10 +30,11 @@
 
 <script lang="ts">
 import type { RootProperties } from '@/store/files/types'
-import { Component, Vue, Ref, Prop } from 'vue-property-decorator'
+import { Component, Ref, Prop, Mixins } from 'vue-property-decorator'
+import BrowserMixin from '@/mixins/browser'
 
 @Component({})
-export default class AppUploadAndPrintBtn extends Vue {
+export default class AppUploadAndPrintBtn extends Mixins(BrowserMixin) {
   @Prop({ type: Boolean })
   readonly disabled?: boolean
 
@@ -45,7 +46,9 @@ export default class AppUploadAndPrintBtn extends Vue {
   }
 
   get accepts () {
-    return this.rootProperties.accepts.join(',')
+    return this.isIOS
+      ? undefined
+      : this.rootProperties.accepts.join(',')
   }
 
   fileChanged (event: Event) {

--- a/src/components/settings/GeneralSettings.vue
+++ b/src/components/settings/GeneralSettings.vue
@@ -264,7 +264,7 @@
     <input
       ref="uploadSettingsFile"
       type="file"
-      accept=".json"
+      :accept="isIOS ? undefined : '.json'"
       style="display: none"
       @change="handleRestoreSettings"
     >
@@ -274,6 +274,7 @@
 <script lang="ts">
 import { Component, Mixins, Ref } from 'vue-property-decorator'
 import StateMixin from '@/mixins/state'
+import BrowserMixin from '@/mixins/browser'
 import type { VInput } from '@/types'
 import { SupportedLocales, DateFormats, TimeFormats } from '@/globals'
 import type { OutputPin } from '@/store/printer/types'
@@ -288,7 +289,7 @@ import { getAllLocales } from '@/plugins/i18n'
 import downloadUrl from '@/util/download-url'
 
 @Component({})
-export default class GeneralSettings extends Mixins(StateMixin) {
+export default class GeneralSettings extends Mixins(StateMixin, BrowserMixin) {
   @Ref('instanceName')
   readonly instanceNameElement!: VInput
 

--- a/src/components/widgets/filesystem/FileSystemAddMenu.vue
+++ b/src/components/widgets/filesystem/FileSystemAddMenu.vue
@@ -42,6 +42,7 @@
       </v-list-item>
 
       <v-list-item
+        v-if="!isIOS"
         :disabled="disabled"
         @click="emulateClick(false, true)"
       >
@@ -120,12 +121,13 @@
 
 <script lang="ts">
 import StateMixin from '@/mixins/state'
+import BrowserMixin from '@/mixins/browser'
 import type { RootProperties } from '@/store/files/types'
 import { getFilesWithPathFromHTMLInputElement } from '@/util/file-system-entry'
 import { Component, Prop, Ref, Mixins } from 'vue-property-decorator'
 
 @Component({})
-export default class FileSystemAddMenu extends Mixins(StateMixin) {
+export default class FileSystemAddMenu extends Mixins(StateMixin, BrowserMixin) {
   @Prop({ type: String, required: true })
   readonly root!: string
 
@@ -143,7 +145,9 @@ export default class FileSystemAddMenu extends Mixins(StateMixin) {
   }
 
   get accepts () {
-    return this.rootProperties.accepts.join(',')
+    return this.isIOS
+      ? undefined
+      : this.rootProperties.accepts.join(',')
   }
 
   get printerReady () {

--- a/src/mixins/browser.ts
+++ b/src/mixins/browser.ts
@@ -15,4 +15,18 @@ export default class BrowserMixin extends Vue {
     return /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i
       .test(navigator.userAgent)
   }
+
+  get isIOS (): boolean {
+    return (
+      [
+        'iPad Simulator',
+        'iPhone Simulator',
+        'iPod Simulator',
+        'iPad',
+        'iPhone',
+        'iPod'
+      ].includes(navigator.platform) ||
+      (navigator.userAgent.includes('Mac') && 'ontouchend' in document)
+    )
+  }
 }


### PR DESCRIPTION
The HTML file input doesn't work correctly when we set the `accept` property on iOS devices.

This PR fixes that by adding a detection for iOS devices and thus not setting the property on these devices.

We are also hiding the "upload folder" on iOS devices as there is no support for it there.

Fixes #1601 