### PR TITLE
feat: disable controls for disconnected Kalico MCU

### DIFF
--- a/src/components/widgets/outputs/OutputFan.vue
+++ b/src/components/widgets/outputs/OutputFan.vue
@@ -9,7 +9,7 @@
       :rules="[
         customRules.minFan
       ]"
-      :disabled="!klippyReady"
+      :disabled="!klippyReady || fan.disconnected"
       :locked="isMobileUserAgent"
       :loading="hasWait(`${$waits.onSetFanSpeed}${fan.name}`)"
       @submit="handleChange"
@@ -19,7 +19,7 @@
       v-else
       align-center
       justify-space-between
-      :class="{ 'text--disabled': !klippyReady }"
+      :class="{ 'text--disabled': !klippyReady || fan.disconnected }"
     >
       <div class="text-body-1">
         {{ fan.prettyName }}

--- a/src/components/widgets/outputs/OutputLed.vue
+++ b/src/components/widgets/outputs/OutputLed.vue
@@ -7,7 +7,7 @@
       align-self="center"
       cols="5"
       class="text-body-1"
-      :class="{ 'text--disabled': !klippyReady }"
+      :class="{ 'text--disabled': !klippyReady || led.disconnected }"
     >
       {{ led.prettyName }}
     </v-col>
@@ -17,7 +17,7 @@
         :white.sync="whiteValue"
         :title="led.prettyName"
         :supported-channels="supportedChannels"
-        :disabled="!klippyReady"
+        :disabled="!klippyReady || led.disconnected"
         dot
       />
     </v-col>

--- a/src/components/widgets/outputs/OutputPin.vue
+++ b/src/components/widgets/outputs/OutputPin.vue
@@ -8,7 +8,7 @@
       :max="100"
       :value="value"
       :reset-value="resetValue"
-      :disabled="!klippyReady"
+      :disabled="!klippyReady || pin.disconnected"
       :locked="isMobileUserAgent"
       :loading="hasWait(`${$waits.onSetOutputPin}${pin.name}`)"
       @submit="handleChange"
@@ -16,7 +16,7 @@
 
     <app-named-switch
       v-else
-      :disabled="!klippyReady"
+      :disabled="!klippyReady || pin.disconnected"
       :label="pin.prettyName"
       :value="pin.value > 0"
       :loading="hasWait(`${$waits.onSetOutputPin}${pin.name}`)"

--- a/src/components/widgets/system/McuCard.vue
+++ b/src/components/widgets/system/McuCard.vue
@@ -48,8 +48,8 @@
               </v-icon>
               {{
                 mcu.non_critical_disconnected
-                  ? $t('app.system_info.label.disconnected')
-                  : $t('app.system_info.label.connected')
+                  ? $t('app.general.label.disconnected')
+                  : $t('app.general.label.connected')
               }}
             </v-chip>
           </td>

--- a/src/components/widgets/thermals/HeaterContextMenu.vue
+++ b/src/components/widgets/thermals/HeaterContextMenu.vue
@@ -10,7 +10,7 @@
   >
     <v-list dense>
       <v-list-item
-        :disabled="!klippyReady || printerPrinting || !heaterIsOn"
+        :disabled="!klippyReady || printerPrinting || !heaterIsOn || heater.disconnected"
         @click="$emit('turn-off', heater)"
       >
         <v-list-item-icon>
@@ -26,7 +26,7 @@
       <v-divider />
 
       <v-list-item
-        :disabled="!klippyReady || printerPrinting"
+        :disabled="!klippyReady || printerPrinting || heater.disconnected"
         @click="$emit('pid-calibrate', heater)"
       >
         <v-list-item-icon>
@@ -41,7 +41,7 @@
 
       <v-list-item
         v-if="klippyApp.isKalicoOrDangerKlipper"
-        :disabled="!klippyReady || printerPrinting || !heaterUsesMpcControl"
+        :disabled="!klippyReady || printerPrinting || !heaterUsesMpcControl || heater.disconnected"
         @click="$emit('mpc-calibrate', heater)"
       >
         <v-list-item-icon>

--- a/src/components/widgets/thermals/TemperatureTargets.vue
+++ b/src/components/widgets/thermals/TemperatureTargets.vue
@@ -72,12 +72,18 @@
             </span>
           </td>
           <td class="temp-actual">
-            {{ (item.temperature) ? item.temperature.toFixed(1) : 0 }}<small>°C</small>
+            <span v-if="item.temperature != null && !item.disconnected">
+              {{ item.temperature.toFixed(1) }}<small>°C</small>
+            </span>
+            <span v-else>
+              -
+            </span>
           </td>
           <td>/</td>
           <td @contextmenu.stop>
             <app-text-field
               v-if="klippyReady"
+              :disabled="item.disconnected"
               :value="item.target"
               :rules="[
                 $rules.required,
@@ -147,7 +153,7 @@
             </span>
           </td>
           <td class="temp-actual">
-            <span v-if="item.temperature">
+            <span v-if="item.temperature != null && !item.disconnected">
               {{ item.temperature.toFixed(1) }}<small>°C</small>
               <small v-if="item.humidity != null && showRelativeHumidity"><br>{{ item.humidity.toFixed(1) }} %</small>
               <small v-if="item.pressure != null && showBarometricPressure"><br>{{ $filters.getReadableAtmosphericPressureString(item.pressure) }}</small>
@@ -161,6 +167,7 @@
           <td @contextmenu.stop>
             <app-text-field
               v-if="klippyReady && item.type === 'temperature_fan'"
+              :disabled="item.disconnected"
               :value="item.target"
               :rules="[
                 $rules.required,
@@ -221,7 +228,7 @@
                   v-bind="attrs"
                   v-on="on"
                 >
-                  <span v-if="item.temperature != null">
+                  <span v-if="item.temperature != null && !item.disconnected">
                     {{ item.temperature.toFixed(1) }}<small>°C</small>
                     <small v-if="item.humidity != null && showRelativeHumidity"><br>{{ item.humidity.toFixed(1) }} %</small>
                     <small v-if="item.pressure != null && showBarometricPressure"><br>{{ $filters.getReadableAtmosphericPressureString(item.pressure) }}</small>

--- a/src/components/widgets/toolhead/ExtruderMoves.vue
+++ b/src/components/widgets/toolhead/ExtruderMoves.vue
@@ -30,7 +30,7 @@
       </v-col>
       <v-col cols="6">
         <app-btn
-          :disabled="!klippyReady || !extruderReady || !valid"
+          :disabled="!klippyReady || !extruderReady || extruderDisconnected || !valid"
           block
           @click="retract"
         >
@@ -68,7 +68,7 @@
       </v-col>
       <v-col cols="6">
         <app-btn
-          :disabled="!klippyReady || !extruderReady || !valid"
+          :disabled="!klippyReady || !extruderReady || extruderDisconnected || !valid"
           block
           @click="extrude"
         >

--- a/src/components/widgets/toolhead/ExtruderStepperSync.vue
+++ b/src/components/widgets/toolhead/ExtruderStepperSync.vue
@@ -26,7 +26,7 @@
       <app-named-switch
         :value="extruderStepper.enabled"
         :label="$t('app.general.label.stepper_enabled')"
-        :disabled="!klippyReady || printerPrinting"
+        :disabled="!klippyReady || printerPrinting || extruderStepper.disconnected"
         :loading="hasWait(`${$waits.onStepperEnable}${extruderStepper.name}`)"
         @change="sendSetStepperEnable"
       />

--- a/src/components/widgets/toolhead/ExtruderSteppers.vue
+++ b/src/components/widgets/toolhead/ExtruderSteppers.vue
@@ -68,9 +68,19 @@ export default class ExtruderSteppers extends Vue {
 
     return extruderSteppers
       .map(x => {
-        const motionQueueName = (x.motion_queue && extruders.find(y => y.key === x.motion_queue)?.name) ?? this.$t('app.setting.label.none')
-        const enabledDesc = x.enabled !== undefined && this.$t(`app.general.label.${x.enabled ? 'on' : 'off'}`)
-        const description = enabledDesc ? `${motionQueueName}, ${enabledDesc}` : motionQueueName
+        const labels = [
+          (x.motion_queue && extruders.find(y => y.key === x.motion_queue)?.name) || this.$t('app.setting.label.none')
+        ]
+
+        if (x.enabled !== undefined) {
+          labels.push(this.$t(`app.general.label.${x.enabled ? 'on' : 'off'}`).toString())
+        }
+
+        if (x.disconnected) {
+          labels.push(this.$t('app.general.label.disconnected').toString())
+        }
+
+        const description = labels.join(', ')
 
         return {
           ...x,

--- a/src/components/widgets/toolhead/ToolheadCard.vue
+++ b/src/components/widgets/toolhead/ToolheadCard.vue
@@ -12,7 +12,28 @@
       </v-icon>
       <span class="font-weight-light">{{ $t('app.general.title.tool') }}</span>
 
-      <v-tooltip bottom>
+      <v-tooltip
+        v-if="extruderDisconnected"
+        bottom
+      >
+        <template #activator="{ on, attrs }">
+          <v-icon
+            v-bind="attrs"
+            class="ml-3"
+            color="warning"
+            small
+            v-on="on"
+          >
+            $warning
+          </v-icon>
+        </template>
+        <span v-html="$t('app.general.label.disconnected')" />
+      </v-tooltip>
+
+      <v-tooltip
+        v-else
+        bottom
+      >
         <template #activator="{ on, attrs }">
           <v-icon
             v-show="hasExtruder && !extruderReady"
@@ -251,7 +272,7 @@ export default class ToolheadCard extends Mixins(StateMixin, ToolheadMixin) {
         name: loadFilamentMacro.name.toUpperCase(),
         label: loadFilamentMacro.name.toLowerCase() === 'm701' ? 'M701 (Load Filament)' : undefined,
         icon: '$loadFilament',
-        disabled: !(ignoreMinExtrudeTemp || this.extruderReady)
+        disabled: !(ignoreMinExtrudeTemp || this.extruderReady) || this.extruderDisconnected
       })
     }
 
@@ -264,7 +285,7 @@ export default class ToolheadCard extends Mixins(StateMixin, ToolheadMixin) {
         name: unloadFilamentMacro.name.toUpperCase(),
         label: unloadFilamentMacro.name.toLowerCase() === 'm702' ? 'M702 (Unload Filament)' : undefined,
         icon: '$unloadFilament',
-        disabled: !(ignoreMinExtrudeTemp || this.extruderReady)
+        disabled: !(ignoreMinExtrudeTemp || this.extruderReady) || this.extruderDisconnected
       })
     }
 

--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -270,6 +270,7 @@ app:
       cross: Cross
       circle: Circle
       compact: Compact
+      connected: Connected
       current_password: Current password
       current_user: Current user
       default: Default
@@ -302,6 +303,7 @@ app:
       minimum_cruise_ratio: Minimum Cruise Ratio
       user_managed_source: User managed by %{source} authentication
       m117: M117
+      disconnected: Disconnected
       moonraker: Moonraker
       name: Name
       new_password: New password
@@ -751,11 +753,9 @@ app:
       application: Application
       awake_time: awake time
       capacity: Capacity
-      connected: Connected
       constants: Constants
       cpu_desc: CPU Description
       devices: Devices
-      disconnected: Disconnected
       distribution_codename: Codename
       distribution_like: Distribution Like
       distribution_name: Distribution

--- a/src/mixins/toolhead.ts
+++ b/src/mixins/toolhead.ts
@@ -30,6 +30,10 @@ export default class ToolheadMixin extends Vue {
     )
   }
 
+  get extruderDisconnected (): boolean {
+    return this.activeExtruder?.disconnected ?? false
+  }
+
   get filamentDiameter (): number {
     return this.activeExtruder?.config?.filament_diameter || 1.75
   }

--- a/src/store/chart_helpers.ts
+++ b/src/store/chart_helpers.ts
@@ -119,8 +119,7 @@ export const handleSystemStatsChange = (payload: Partial<KlipperPrinterState>, s
  * Every packet should contain an entry for all known sensors we want to track.
  */
 export const handleAddChartEntry = (retention: number, state: RootState, commit: Commit, getters: any) => {
-  const nonCriticalDisconnectedMcuNames = new Set(
-    getters.getNonCriticalDisconnectedMcuNames as string[])
+  const nonCriticalDisconnectedMcusSet: Set<string> = getters.getNonCriticalDisconnectedMcusSet
 
   const configureChartEntry = () => {
     const chartData: ChartData = {
@@ -133,12 +132,12 @@ export const handleAddChartEntry = (retention: number, state: RootState, commit:
       const sensor = state.printer.printer[key]
 
       if (sensor != null) {
-        if (nonCriticalDisconnectedMcuNames.size > 0) {
+        if (nonCriticalDisconnectedMcusSet.size > 0) {
           const config = state.printer.printer.configfile?.settings[key.toLowerCase()]
 
           if (
             config != null &&
-            getMcusFromConfig(config)?.some(mcu => nonCriticalDisconnectedMcuNames.has(mcu))
+            getMcusFromConfig(config)?.some(mcu => nonCriticalDisconnectedMcusSet.has(mcu))
           ) {
             continue
           }

--- a/src/store/printer/types.ts
+++ b/src/store/printer/types.ts
@@ -1417,8 +1417,10 @@ export interface KnownExtruder {
 }
 
 export interface Extruder extends KlipperPrinterExtruderState {
+  key: string;
   config: KlipperPrinterExtruderSettings;
   min_extrude_temp: number;
+  disconnected: boolean;
 }
 
 type StepperType<T> = {
@@ -1427,6 +1429,7 @@ type StepperType<T> = {
   prettyName: string;
   key: string;
   enabled?: boolean;
+  disconnected: boolean;
 }
 
 export interface ExtruderStepper extends StepperType<KlipperPrinterExtruderStepperSettings> {
@@ -1452,6 +1455,7 @@ type OutputType<T> = {
   key: string;
   color?: string;
   type: string;
+  disconnected: boolean;
 }
 
 export interface Heater extends OutputType<KlipperPrinterHeaterGenericSettings | KlipperPrinterHeaterBedSettings | KlipperPrinterExtruderSettings> {
@@ -1494,6 +1498,7 @@ export interface Sensor extends Partial<KlipperPrinterTemperatureSensorState>, P
   type: string;
   maxTemp?: number;
   minTemp?: number;
+  disconnected: boolean;
 }
 
 export interface RunoutSensor extends Partial<KlipperPrinterFilamentSwitchSensorState>, Partial<KlipperPrinterFilamentMotionSensorState> {

--- a/src/util/get-klipper-mcus-from-config.ts
+++ b/src/util/get-klipper-mcus-from-config.ts
@@ -34,7 +34,7 @@ const getMcusFromPinKeyInConfig = (config: Record<string, any>): string[] | unde
       typeof value === 'string' &&
       value.includes(':')
     ) {
-      const mcu = value.split(':')[0]
+      const mcu = value.split(':')[0]?.replace(/^[!~^]+/, '')
 
       if (mcu) {
         mcus.add(mcu)


### PR DESCRIPTION
This PR will find devices using non-critical disconnected MCUs in Kalico and thus disable said devices controls to avoid a Kalico shutdown.