### PR TITLE
feat: adds basic support for cartographer

### DIFF
--- a/src/components/widgets/toolhead/ToolheadCard.vue
+++ b/src/components/widgets/toolhead/ToolheadCard.vue
@@ -223,6 +223,11 @@ export default class ToolheadCard extends Mixins(StateMixin, ToolheadMixin) {
       this.printerSettings.probe != null ||
       this.printerSettings.bltouch != null ||
       this.printerSettings.smart_effector != null ||
+      (
+        this.printerSettings.scanner != null &&
+        'sensor' in this.printerSettings.scanner &&
+        this.printerSettings.scanner.sensor === 'cartographer'
+      ) ||
       Object.keys(this.printerSettings)
         .some(x => x.startsWith('probe_eddy_current '))
     )

--- a/src/store/printer/types.ts
+++ b/src/store/printer/types.ts
@@ -843,6 +843,8 @@ type KlipperPrinterSettingsBaseType =
 
     beacon: KlipperPrinterBeaconSettings;
 
+    scanner: KlipperPrinterCartographerScannerSettings;
+
     [key: `beacon model ${Lowercase<string>}`]: KlipperPrinterBeaconModelSettings;
   }>
 
@@ -1404,6 +1406,9 @@ export interface KalicoPrinterZTiltNgSettings {
 }
 
 export interface KlipperPrinterBeaconSettings extends Record<string, unknown> {
+}
+
+export interface KlipperPrinterCartographerScannerSettings extends Record<string, unknown> {
 }
 
 export interface KlipperPrinterBeaconModelSettings extends Record<string, unknown> {


### PR DESCRIPTION
Adds some basic support for Cartographer, just to ensure `PROBE_ACCURACY` and `PROBE_CALIBRATE` commands are shown.

Fixes #1721