### PR TITLE
fix: allow dialog title to wrap

### DIFF
--- a/src/components/ui/AppDialog.vue
+++ b/src/components/ui/AppDialog.vue
@@ -26,14 +26,8 @@
             'collapsable-card-title': titleShadow
           }"
         >
-          <v-row
-            no-gutters
-            class="flex-nowrap"
-          >
-            <v-col
-              align-self="center"
-              class="text-no-wrap"
-            >
+          <v-row no-gutters>
+            <v-col align-self="center">
               <slot name="title">
                 <span class="focus--text">{{ title }}</span>
                 <app-inline-help


### PR DESCRIPTION
Allow the dialog title to flow normally and wrap.

## Before

<img width="1459" height="816" alt="image" src="https://github.com/user-attachments/assets/22eaf412-5a4c-4539-9cee-33eb0ff3fcda" />

## After

<img width="1460" height="862" alt="image" src="https://github.com/user-attachments/assets/04228b1f-849a-4c01-825b-779c9ba9ee7c" />

Fixes #1723