### PR TITLE
fix: Cartographer simple integration

### DIFF
--- a/src/components/widgets/toolhead/ToolheadCard.vue
+++ b/src/components/widgets/toolhead/ToolheadCard.vue
@@ -223,6 +223,7 @@ export default class ToolheadCard extends Mixins(StateMixin, ToolheadMixin) {
       this.printerSettings.probe != null ||
       this.printerSettings.bltouch != null ||
       this.printerSettings.smart_effector != null ||
+      this.printerSettings.cartographer != null ||
       (
         this.printerSettings.scanner != null &&
         'sensor' in this.printerSettings.scanner &&
@@ -231,6 +232,10 @@ export default class ToolheadCard extends Mixins(StateMixin, ToolheadMixin) {
       Object.keys(this.printerSettings)
         .some(x => x.startsWith('probe_eddy_current '))
     )
+  }
+
+  get printerSupportsCartographerCalibrate (): boolean {
+    return this.printerSettings.cartographer != null
   }
 
   get printerSupportsZEndstopCalibrate (): boolean {
@@ -342,6 +347,20 @@ export default class ToolheadCard extends Mixins(StateMixin, ToolheadMixin) {
         name: 'BED_TILT_CALIBRATE',
         disabled: !this.allHomed || this.isManualProbeActive,
         wait: this.$waits.onBedTiltCalibrate
+      })
+    }
+
+    if (this.printerSupportsCartographerCalibrate) {
+      tools.push({
+        name: 'CARTOGRAPHER_SCAN_CALIBRATE',
+        disabled: !this.allHomed || this.isManualProbeActive,
+        wait: this.$waits.onCartographerScanCalibrate
+      })
+
+      tools.push({
+        name: 'CARTOGRAPHER_TOUCH_CALIBRATE',
+        disabled: !this.allHomed || this.isManualProbeActive,
+        wait: this.$waits.onCartographerTouchCalibrate
       })
     }
 

--- a/src/globals.ts
+++ b/src/globals.ts
@@ -546,6 +546,8 @@ export const Waits = Object.freeze({
   onDatabaseDeleteBackup: 'onDatabaseDeleteBackup',
   onBedScrewsCalculate: 'onBedScrewsCalculate',
   onBedTiltCalibrate: 'onBedTiltCalibrate',
+  onCartographerScanCalibrate: 'onCartographerScanCalibrate',
+  onCartographerTouchCalibrate: 'onCartographerTouchCalibrate',
   onDeltaCalibrate: 'onDeltaCalibrate',
   onPrintPause: 'onPrintPause',
   onPrintCancel: 'onPrintCancel',

--- a/src/store/printer/types.ts
+++ b/src/store/printer/types.ts
@@ -843,6 +843,8 @@ type KlipperPrinterSettingsBaseType =
 
     beacon: KlipperPrinterBeaconSettings;
 
+    cartographer: KlipperPrinterCartographerScannerSettings;
+
     scanner: KlipperPrinterCartographerScannerSettings;
 
     [key: `beacon model ${Lowercase<string>}`]: KlipperPrinterBeaconModelSettings;


### PR DESCRIPTION
Cartographer is now using `[cartographer]` as a settings section, so this will now detect this usage and include the `CARTOGRAPHER_SCAN_CALIBRATE` and `CARTOGRAPHER_TOUCH_CALIBRATE` when it finds the section.

Fixes #1735