### PR TITLE
fix: reset current path if deleted

### DIFF
--- a/src/store/files/actions.ts
+++ b/src/store/files/actions.ts
@@ -150,13 +150,22 @@ export const actions = {
     }
   },
 
-  async notifyDeleteDir ({ commit }, payload: Moonraker.Files.ChangeResponse) {
+  async notifyDeleteDir ({ commit, getters }, payload: Moonraker.Files.ChangeResponse) {
     const paths = getFilePaths(payload.item.path, payload.item.root)
 
     if (!paths.filtered) {
       commit('setDirDelete', paths)
 
       commit('setPathDelete', paths.rootPathFilename)
+
+      const currentPath: string = getters.getCurrentPathByRoot(paths.root)
+
+      if (
+        currentPath === paths.rootPathFilename ||
+        currentPath.startsWith(`${paths.rootPathFilename}/`)
+      ) {
+        commit('setCurrentPath', { root: paths.root, path: paths.rootPath })
+      }
     }
   },
 
@@ -179,7 +188,7 @@ export const actions = {
     commit('setRemoveFileDownload', payload)
   },
 
-  async updateCurrentPathByRoot ({ commit }, payload) {
+  async updateCurrentPathByRoot ({ commit }, payload: { root: string, path: string }) {
     commit('setCurrentPath', payload)
   }
 } satisfies ActionTree<FilesState, RootState>

--- a/src/store/files/mutations.ts
+++ b/src/store/files/mutations.ts
@@ -167,7 +167,7 @@ export const mutations = {
     }
   },
 
-  setCurrentPath (state, payload) {
+  setCurrentPath (state, payload: { root: string, path: string }) {
     Vue.set(state.currentPaths, payload.root, payload.path)
   },
 


### PR DESCRIPTION
Will check get the root of the deleted folder and if the current path includes it, it resets to the parent path.

Fixes #1764