### PR TITLE
feat: show full timestamp tooltip on relative

### DIFF
--- a/src/components/layout/AppNotificationMenu.vue
+++ b/src/components/layout/AppNotificationMenu.vue
@@ -82,9 +82,18 @@
                 v-safe-html="n.description"
                 class="notification-description"
               />
-              <v-list-item-subtitle class="notification-timestamp">
-                {{ $filters.formatRelativeTimeToNow(n.timestamp * 1000) }}
-              </v-list-item-subtitle>
+              <v-tooltip bottom>
+                <template #activator="{ on, attrs }">
+                  <v-list-item-subtitle
+                    v-bind="attrs"
+                    class="notification-timestamp"
+                    v-on="on"
+                  >
+                    {{ $filters.formatRelativeTimeToNow(n.timestamp * 1000) }}
+                  </v-list-item-subtitle>
+                </template>
+                <span>{{ $filters.formatDateTime(n.timestamp * 1000) }}</span>
+              </v-tooltip>
               <v-list-item-subtitle v-if="n.to">
                 <app-btn
                   v-if="!n.to.startsWith('http')"

--- a/src/components/settings/VersionInformationDialog.vue
+++ b/src/components/settings/VersionInformationDialog.vue
@@ -51,7 +51,17 @@
                     >
                       <strong>{{ commit.author }}</strong>
                     </a>
-                    {{ $t('app.version.label.committed') }} {{ $filters.formatRelativeTimeToNow(+commit.date * 1000) }}
+                    <v-tooltip bottom>
+                      <template #activator="{ on, attrs }">
+                        <span
+                          v-bind="attrs"
+                          v-on="on"
+                        >
+                          {{ $t('app.version.label.committed') }} {{ $filters.formatRelativeTimeToNow(+commit.date * 1000) }}
+                        </span>
+                      </template>
+                      <span>{{ $filters.formatDateTime(+commit.date * 1000) }}</span>
+                    </v-tooltip>
                   </div>
                 </div>
                 <div>


### PR DESCRIPTION
Adds tooltips with the full formatted date and time for any relative timestamp indicator.

## In-app Notification

<img width="732" height="429" alt="image" src="https://github.com/user-attachments/assets/783d03b3-a1ef-43b6-b570-c545faeb4565" />

## Git Changes

<img width="1741" height="554" alt="image" src="https://github.com/user-attachments/assets/0bea23e6-fcf0-40e8-981f-5d3219d39408" />

Resolve #1770 