### PR TITLE
fix(GcodePreview): reset only null coordinates

### DIFF
--- a/src/store/gcodePreview/getters.ts
+++ b/src/store/gcodePreview/getters.ts
@@ -120,10 +120,23 @@ export const getters = {
       z: NaN
     }
 
-    for (let i = moveIndex; i >= 0 && (Number.isNaN(output.x) || Number.isNaN(output.y) || Number.isNaN(output.z)); i--) {
+    for (let i = moveIndex, count = 0; i >= 0 && count < 3; i--) {
       const move = moves[i]
 
-      Object.assign(output, move)
+      if (Number.isNaN(output.x) && move.x != null) {
+        output.x = move.x
+        count++
+      }
+
+      if (Number.isNaN(output.y) && move.y != null) {
+        output.y = move.y
+        count++
+      }
+
+      if (Number.isNaN(output.z) && move.z != null) {
+        output.z = move.z
+        count++
+      }
     }
 
     return {


### PR DESCRIPTION
Previously, the toolhead coordinates were checked and reset individually, but changes from 4e6f7aaeade977805a846e9f2a7d29528fb1f618 caused this issue as the move object was copied completely, overriding previous values - this reverts back to the original approach, fixing the problem.

Fixes #1774