### PR TITLE
fix(GcodePreview): use approximate position

### DIFF
--- a/src/store/gcodePreview/getters.ts
+++ b/src/store/gcodePreview/getters.ts
@@ -298,7 +298,7 @@ export const getters = {
 
     const moves: readonly Move[] = state.moves
 
-    return binarySearch(moves, move => filePosition - move.filePosition)
+    return binarySearch(moves, move => filePosition - move.filePosition, true)
   },
 
   getLayerNrByFilePosition: (state, getters) => (filePosition: number): number => {


### PR DESCRIPTION
This issue was introduced with the changes from ce219dfb2adb1f5c137ca8ad75991b0621a6dd5b, where previously we were returning the approximate value from the binary search instead of the exact one as we were now, so this reverts back to the previous method.

Fix #1774