### PR TITLE
fix: Spoolman URL protocol

### DIFF
--- a/src/store/spoolman/getters.ts
+++ b/src/store/spoolman/getters.ts
@@ -108,7 +108,14 @@ export const getters = {
     const server = rootState.server.config.spoolman?.server
 
     if (server) {
-      const serverUrl = new URL(server)
+      const protocol = (
+        !server.startsWith('http://') &&
+        !server.startsWith('https://')
+      )
+        ? 'http://'
+        : ''
+
+      const serverUrl = new URL(protocol + server)
 
       if (isLoopback(serverUrl.hostname)) {
         const apiHostname = new URL(rootState.config.apiUrl).hostname


### PR DESCRIPTION
Moonraker currently allows the Spoolman server to be set as just a host (without protocol), and that would break Fluidd when we use `URL()` function to build the URL.

This fix ensures that the setting value starts with either "http://" or "https://" and if not, it will default to "http://"

Fixes #1791 