### PR TITLE
fix(notifications): fix suffix icon display

### DIFF
--- a/src/components/layout/AppNotificationMenu.vue
+++ b/src/components/layout/AppNotificationMenu.vue
@@ -125,9 +125,10 @@
             >
               <v-icon
                 v-if="n.suffixIcon"
-                v-safe-html="n.suffixIcon"
                 :color="color"
-              />
+              >
+                {{ n.suffixIcon }}
+              </v-icon>
               <div
                 v-safe-html="n.suffix"
                 class="notification-temp"


### PR DESCRIPTION
fixes support for suffix icons in the notification system. this has been bugging me for a while :p

before:
<img width="414" height="207" alt="image" src="https://github.com/user-attachments/assets/d711b988-13c5-4486-a101-230217a53264" />

after:
<img width="448" height="212" alt="image" src="https://github.com/user-attachments/assets/4340587a-b99e-4c7a-8de2-be95888cb7ab" />
