### PR TITLE
feat: add drop tool G-code functionality and related UI settings

### DIFF
--- a/src/components/settings/ToolheadSettings.vue
+++ b/src/components/settings/ToolheadSettings.vue
@@ -376,6 +376,23 @@
         <v-divider />
       </template>
 
+      <app-setting
+        :title="$t('app.setting.label.toolhead_drop_tool_gcode')"
+        :sub-title="$t('app.setting.tooltip.toolhead_drop_tool_gcode')"
+      >
+        <app-text-field
+          :value="toolheadDropToolGcode"
+          filled
+          dense
+          single-line
+          hide-details="auto"
+          submit-on-change
+          @submit="setToolheadDropToolGcode"
+        />
+      </app-setting>
+
+      <v-divider />
+
       <app-setting :title="$t('app.setting.label.reset')">
         <app-btn
           outlined
@@ -475,6 +492,18 @@ export default class ToolHeadSettings extends Mixins(ToolheadMixin) {
     this.$typedDispatch('config/saveByPath', {
       path: 'uiSettings.general.defaultToolheadZSpeed',
       value: +value,
+      server: true
+    })
+  }
+
+  get toolheadDropToolGcode (): string {
+    return this.$typedState.config.uiSettings.general.toolheadDropToolGcode
+  }
+
+  setToolheadDropToolGcode (value: string) {
+    this.$typedDispatch('config/saveByPath', {
+      path: 'uiSettings.general.toolheadDropToolGcode',
+      value: value.trim(),
       server: true
     })
   }

--- a/src/components/widgets/toolhead/ToolChangeCommands.vue
+++ b/src/components/widgets/toolhead/ToolChangeCommands.vue
@@ -48,6 +48,26 @@
           </template>
           {{ macro.description }}
         </v-tooltip>
+        <v-tooltip
+          v-if="dropToolGcode && index2 === toolChangeCommandsGrouped.length - 1"
+          top
+        >
+          <template #activator="{ on, attrs }">
+            <app-btn
+              v-bind="attrs"
+              min-width="10"
+              :disabled="!klippyReady || printerPrinting"
+              class="px-0 flex-grow-1"
+              v-on="on"
+              @click="sendGcode(dropToolGcode)"
+            >
+              <v-icon small>
+                $mmuEject
+              </v-icon>
+            </app-btn>
+          </template>
+          {{ $t('app.tool.tooltip.drop_tool') }}
+        </v-tooltip>
       </app-btn-group>
     </v-col>
   </v-row>
@@ -98,6 +118,10 @@ export default class ToolChangeCommands extends Mixins(StateMixin) {
         }
       })
       .sort((a, b) => +a.name.substring(1) - +b.name.substring(1))
+  }
+
+  get dropToolGcode (): string {
+    return this.$typedState.config.uiSettings.general.toolheadDropToolGcode
   }
 
   get toolChangeCommandsGrouped (): ToolChangeCommand[][] {

--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -832,6 +832,7 @@ app:
       to_browser_local_storage: To browser local storage
       to_browser_session_storage: To browser session storage
       toolhead_control_style: Toolhead control style
+      toolhead_drop_tool_gcode: Drop tool G-code
       toolhead_move_distances: Toolhead distance values
       toolhead_xy_move_distances: Toolhead XY distance values
       toolhead_z_move_distances: Toolhead Z distance values
@@ -968,6 +969,7 @@ app:
       manual_probe: Manual Probe
       motors_off: Motors Off
       relative_positioning: Relative Positioning
+      drop_tool: Drop current tool
       select_tool: Select tool %{tool}
       tools: Tools
     label:

--- a/src/store/config/state.ts
+++ b/src/store/config/state.ts
@@ -31,6 +31,7 @@ export const defaultState = (): ConfigState => {
         defaultToolheadXYSpeed: 130,
         defaultToolheadZSpeed: 10,
         toolheadControlStyle: 'cross',
+        toolheadDropToolGcode: 'TOOL_DROPOFF',
         toolheadMoveDistances: [0.1, 1, 10, 25, 50, 100],
         toolheadXYMoveDistances: [1, 10, 50],
         toolheadZMoveDistances: [0.1, 1, 10],

--- a/src/store/config/types.ts
+++ b/src/store/config/types.ts
@@ -109,6 +109,7 @@ export interface GeneralConfig {
   defaultToolheadXYSpeed: number;
   defaultToolheadZSpeed: number;
   toolheadControlStyle: ToolheadControlStyle;
+  toolheadDropToolGcode: string;
   toolheadMoveDistances: number[];
   toolheadXYMoveDistances: number[];
   toolheadZMoveDistances: number[];


### PR DESCRIPTION
closes: #1839 

This pr adds a new button to the tool card which executes a g-code command to drop the current tool.
The g-code command can be adjusted in the settings. If the g-code command is not set the button is hidden.

preview:
<img width="879" height="147" alt="image" src="https://github.com/user-attachments/assets/6e831825-542c-4d62-a11d-d64c908a8b36" />

maybe a different icon should be used