### PR TITLE
feat(GcodePreview): improved arc support

### DIFF
--- a/src/store/gcodePreview/types.ts
+++ b/src/store/gcodePreview/types.ts
@@ -26,11 +26,14 @@ export interface ArcMove extends LinearMove {
   k?: number;
   r?: number;
   d: Rotation;
+  plane: ArcPlane;
 }
 
 export type Move = LinearMove | ArcMove
 
 export type Rotation = 'clockwise' | 'counter-clockwise'
+
+export type ArcPlane = 'xy' | 'xz' | 'yz'
 
 export type Tool = `T${number}`
 

--- a/src/util/gcode-preview.ts
+++ b/src/util/gcode-preview.ts
@@ -62,63 +62,56 @@ function arcIJMoveToSVGPath (toolhead: Point, move: ArcMove): string {
   switch (move.d) {
     case 'clockwise':
       return `A${radius},${radius},0,${+(angle < 0)},0,${destination.x},${destination.y}`
+
     case 'counter-clockwise':
       return `M${destination.x},${destination.y}` +
         `A${radius},${radius},0,${+(angle > 0)},0,${toolhead.x},${toolhead.y}` +
         `M${destination.x},${destination.y}`
+
     default:
       throw new TypeError('move has no direction')
   }
 }
 
-/**
- * Taken from https://stackoverflow.com/a/42803692
- */
-// function findIntersections (center1: Point, center2: Point, radius: number) {
-//   const d = Math.sqrt((center2.x - center1.x) ** 2 + (center2.y - center1.y) ** 2)
-//   const a = (d ** 2) / (2 * d)
-//   const h = Math.sqrt(radius ** 2 - a ** 2)
-//   const x2 = center1.x + a * (center2.x - center1.x) / d
-//   const y2 = center1.y + a * (center2.y - center1.y) / d
+function arcRMoveToSVGPath (toolhead: Point, move: ArcMove): string {
+  const destination = {
+    x: move.x ?? toolhead.x,
+    y: move.y ?? toolhead.y
+  }
 
-//   const x3 = x2 + h * (center2.y - center1.y) / d
-//   const y3 = y2 - h * (center2.x - center1.x) / d
+  const delta = {
+    x: destination.x - toolhead.x,
+    y: destination.y - toolhead.y
+  }
 
-//   const x4 = x2 - h * (center2.y - center1.y) / d
-//   const y4 = y2 + h * (center2.x - center1.x) / d
+  const r = move.r ?? 0
+  const chord = Math.hypot(delta.x, delta.y)
 
-//   return [{
-//     x: x3,
-//     y: y3
-//   }, {
-//     x: x4,
-//     y: y4
-//   }]
-// }
+  if (chord === 0 || chord > 2 * Math.abs(r)) {
+    return `L${destination.x},${destination.y}`
+  }
 
-// function arcRMoveToSVGPath (toolhead: Point, move: ArcMove): string {
-//   const intersections = findIntersections(
-//     toolhead,
-//     {
-//       x: move.x ?? toolhead.x,
-//       y: move.y ?? toolhead.y
-//     },
-//     move.r ?? NaN
-//   )
+  const h = Math.sqrt(r * r - (chord * chord) / 4)
+  const sign = ((r < 0) !== (move.d === 'clockwise')) ? -1 : 1
+  const i = delta.x / 2 + (sign * h * -delta.y) / chord
+  const j = delta.y / 2 + (sign * h * delta.x) / chord
 
-//   throw new Error('Arcs with the R parameter are currently not supported. ' +
-//     'Please make a Github issue with some sample gcode so we can resolve this')
-// }
+  return arcIJMoveToSVGPath(toolhead, { ...move, i, j })
+}
 
 export function arcMoveToSvgPath (toolhead: Point, move: ArcMove): string {
+  if (move.plane === 'xz' || move.plane === 'yz') {
+    // G18/G19: arc lies in a vertical plane; the XY projection is not a clean
+    // SVG arc, so render as a straight line to the destination XY.
+    return `L${move.x ?? toolhead.x},${move.y ?? toolhead.y}`
+  }
+
   if (move.i !== undefined || move.j !== undefined) {
     return arcIJMoveToSVGPath(toolhead, move)
   }
 
   if (move.r !== undefined) {
-    // return arcRMoveToSVGPath(toolhead, move)
-    throw new Error('Arcs with the R parameter are currently not supported. ' +
-    'Please make a Github issue with some sample gcode so we can resolve this')
+    return arcRMoveToSVGPath(toolhead, move)
   }
 
   throw new TypeError('Move is not a valid arc')

--- a/src/workers/parseGcode.ts
+++ b/src/workers/parseGcode.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-fallthrough */
-import type { ArcMove, BBox, Layer, LinearMove, Move, Part, PositioningMode } from '@/store/gcodePreview/types'
+import type { ArcMove, ArcPlane, BBox, Layer, LinearMove, Move, Part, PositioningMode } from '@/store/gcodePreview/types'
 import isKeyOf from '@/util/is-key-of'
 import { pick } from 'lodash-es'
 import { split } from 'shlex'
@@ -83,6 +83,7 @@ const parseGcode = (gcode: string, sendProgress: (filePosition: number) => void)
   let newLayerForNextMove = false
   let extrusionMode: PositioningMode = 'relative'
   let positioningMode: PositioningMode = 'absolute'
+  let plane: ArcPlane = 'xy'
   const toolhead = {
     x: 0,
     y: 0,
@@ -180,12 +181,22 @@ const parseGcode = (gcode: string, sendProgress: (filePosition: number) => void)
               d: command === 'G2'
                 ? 'clockwise'
                 : 'counter-clockwise',
+              plane,
               tool,
               filePosition
             } satisfies ArcMove
           }
           break
         }
+        case 'G17':
+          plane = 'xy'
+          break
+        case 'G18':
+          plane = 'xz'
+          break
+        case 'G19':
+          plane = 'yz'
+          break
         case 'G10':
           move = {
             e: -fwretraction.length,


### PR DESCRIPTION
Improved `G2` and `G3` command support, to include `R` argument, and `G17`, `G18`, and `G19` multi-planar handling.

The 'xy' plane (`G17`) is the currently handled case, for 'xz' and 'yz' (`G18` and `G19`), we just represent it as line from the origin point to the destination.