### PR TITLE
fix: vue-json-viewer import

### DIFF
--- a/src/components/widgets/diagnostics/StateExplorer.vue
+++ b/src/components/widgets/diagnostics/StateExplorer.vue
@@ -11,10 +11,15 @@
 <script lang="ts">
 import { Component, Mixins } from 'vue-property-decorator'
 import StateMixin from '@/mixins/state'
-import JsonViewer from 'vue-json-viewer'
+import JsonViewerModule from 'vue-json-viewer'
+
+// Rolldown (Vite 8) doesn't auto-unwrap __esModule CJS modules
+const JsonViewer = JsonViewerModule.default ?? JsonViewerModule
 
 @Component({
-  components: { JsonViewer }
+  components: {
+    JsonViewer
+  }
 })
 export default class StateExplorer extends Mixins(StateMixin) {
   get state () {


### PR DESCRIPTION
When we upgraded to Vite 8 in d2932898978424388fd842dec9e0c63d8b4b4d93, that caused any UMD import to fail as Rolldown (Vite 8) doesn't auto-unwrap __esModule CJS modules.

This fixes the problem by adding a manual unwrap.

Fixed #1847