### PR TITLE
fix(parseGcode): absolute/relative positioning

### DIFF
--- a/src/workers/parseGcode.ts
+++ b/src/workers/parseGcode.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-fallthrough */
 import type { ArcMove, ArcPlane, BBox, Layer, LinearMove, Move, Part, PositioningMode } from '@/store/gcodePreview/types'
 import isKeyOf from '@/util/is-key-of'
 import { pick } from 'lodash-es'
@@ -243,12 +242,13 @@ const parseGcode = (gcode: string, sendProgress: (filePosition: number) => void)
         }
         case 'G90':
           positioningMode = 'absolute'
+          break
         case 'M82':
           extrusionMode = 'absolute'
-          toolhead.e = 0
           break
         case 'G91':
           positioningMode = 'relative'
+          break
         case 'M83':
           extrusionMode = 'relative'
           break


### PR DESCRIPTION
`G90`/`G91` were falling through into `M82`/`M83`, forcing the extrusion mode whenever the positioning mode changed (and zeroing `toolhead.e` on `M82`). In both Klipper ([gcode_move.py](https://github.com/Klipper3d/klipper/blob/48f0b3cad6d4593746384bf49a39913dcb8cc796/klippy/extras/gcode_move.py) keeps `absolute_coord` and `absolute_extrude` as independent flags) and Marlin (`M82`/`M83` are documented as setting E "independent of the other axes", and neither resets the extruder position), these are independent state.

For typical slicer preludes (`G90` then `M83`) the final state still came out right because `M83` overwrote the bad `M82` assignment, but a mid-file `G90`/`G91` after `M83`/`M82` would silently flip extrusion mode and corrupt subsequent E math — breaking layer detection and retraction tracking downstream.