### PR TITLE
refactor(GcodePreview): stream gcode parsing

### DIFF
--- a/src/components/widgets/filesystem/FileSystem.vue
+++ b/src/components/widgets/filesystem/FileSystem.vue
@@ -854,11 +854,9 @@ export default class FileSystem extends Mixins(StateMixin, FilesMixin, ServicesM
 
   async handlePreviewGcode (file: AppFile | AppFileWithMeta) {
     try {
-      const response = await this.getGcode(file)
+      const url = await this.getGcodePreviewUrl(file)
 
-      const gcode = response?.data
-
-      if (!gcode) return
+      if (!url) return
 
       if (
         this.$route.name !== 'home' ||
@@ -869,7 +867,7 @@ export default class FileSystem extends Mixins(StateMixin, FilesMixin, ServicesM
 
       this.$typedDispatch('gcodePreview/loadGcode', {
         file,
-        gcode
+        url
       })
     } catch (error: unknown) {
       consola.error('[FileSystem] preview gcode', error)

--- a/src/components/widgets/gcode-preview/GcodePreviewCard.vue
+++ b/src/components/widgets/gcode-preview/GcodePreviewCard.vue
@@ -357,15 +357,13 @@ export default class GcodePreviewCard extends Mixins(StateMixin, FilesMixin, Bro
 
   async loadFile (file: AppFile | AppFileWithMeta) {
     try {
-      const response = await this.getGcode(file)
+      const url = await this.getGcodePreviewUrl(file)
 
-      const gcode = response?.data
-
-      if (!gcode) return
+      if (!url) return
 
       this.$typedDispatch('gcodePreview/loadGcode', {
         file,
-        gcode
+        url
       })
     } catch (error: unknown) {
       consola.error('[GcodePreview] load', error)

--- a/src/mixins/files.ts
+++ b/src/mixins/files.ts
@@ -55,9 +55,11 @@ export default class FilesMixin extends Vue {
   }
 
   /**
-   * Loads a gcode file and parses for the gcode-viewer.
+   * Builds a download URL for a gcode file, for the gcode-viewer worker to
+   * stream and parse without buffering the whole file in memory. Prompts
+   * the user for confirmation if the file exceeds 100 MB.
    */
-  async getGcode (file: AppFile) {
+  async getGcodePreviewUrl (file: AppFile): Promise<string | undefined> {
     const sizeInMB = file.size / 1024 / 1024
 
     const result = (
@@ -76,13 +78,7 @@ export default class FilesMixin extends Vue {
     if (result) {
       const path = file.path ? `gcodes/${file.path}` : 'gcodes'
 
-      return await this.getFile<ArrayBuffer>(
-        file.filename,
-        path,
-        file.size,
-        {
-          responseType: 'arraybuffer',
-        })
+      return await this.createFileUrlWithToken(file.filename, path)
     }
   }
 

--- a/src/store/gcodePreview/actions.ts
+++ b/src/store/gcodePreview/actions.ts
@@ -31,11 +31,19 @@ export const actions = {
   },
 
   async loadGcode ({ commit, state, rootState, dispatch }, payload: { file: AppFile | AppFileWithMeta; url: string }) {
+    if (state.parserWorker) {
+      await dispatch('terminateParserWorker')
+    }
+
     const worker = new ParseGcodeWorker()
 
     commit('setParserWorker', worker)
 
     worker.onmessage = (event: MessageEvent<ParseGcodeWorkerResponseMessage>) => {
+      if (state.parserWorker !== worker) {
+        return
+      }
+
       const message = event.data
 
       switch (message.action) {
@@ -66,11 +74,9 @@ export const actions = {
             EventBus.$emit(i18n.t('app.general.msg.gcode_preview_failed').toString(), { type: 'error' })
           }
 
-          if (state.parserWorker) {
-            commit('setParserWorker', null)
+          commit('setParserWorker', null)
 
-            worker.terminate()
-          }
+          worker.terminate()
 
           if (state.moves.length === 0) {
             commit('setFile', null)

--- a/src/store/gcodePreview/actions.ts
+++ b/src/store/gcodePreview/actions.ts
@@ -30,7 +30,7 @@ export const actions = {
     }
   },
 
-  async loadGcode ({ commit, state, rootState, dispatch }, payload: { file: AppFile | AppFileWithMeta; gcode: ArrayBuffer }) {
+  async loadGcode ({ commit, state, rootState, dispatch }, payload: { file: AppFile | AppFileWithMeta; url: string }) {
     const worker = new ParseGcodeWorker()
 
     commit('setParserWorker', worker)
@@ -51,7 +51,7 @@ export const actions = {
             commit('setParts', message.parts)
             commit('setTools', message.tools)
             commit('setBounds', message.bounds)
-            commit('setParserProgress', payload.file.size ?? gcodeByteLength)
+            commit('setParserProgress', payload.file.size)
 
             if (rootState.config.uiSettings.gcodePreview.hideSinglePartBoundingBox && message.parts.length <= 1) {
               dispatch('config/saveByPath', {
@@ -98,13 +98,12 @@ export const actions = {
 
     commit('setFile', payload.file)
 
-    const gcodeByteLength = payload.gcode.byteLength
-
     const message: ParseGcodeWorkerRequestMessage = {
       action: 'parse',
-      gcode: payload.gcode
+      url: payload.url,
+      fileSize: payload.file.size
     }
 
-    worker.postMessage(message, [payload.gcode])
+    worker.postMessage(message)
   }
 } satisfies ActionTree<GcodePreviewState, RootState>

--- a/src/workers/mjpegStream.ts
+++ b/src/workers/mjpegStream.ts
@@ -23,7 +23,7 @@ const mjpegStream = async (url: string, sendFrame: (data: Uint8Array<ArrayBuffer
     mode: 'cors'
   })
 
-  if (!response.ok) {
+  if (!response.ok || !response.body) {
     throw new Error(`Failed to fetch MJPEG stream: ${response.status}`)
   }
 
@@ -41,7 +41,7 @@ const mjpegStream = async (url: string, sendFrame: (data: Uint8Array<ArrayBuffer
 
   const boundaryBytes = new TextEncoder().encode(`--${boundary}`)
 
-  const reader = response.body!.getReader({
+  const reader = response.body.getReader({
     mode: 'byob'
   })
 

--- a/src/workers/parseGcode.ts
+++ b/src/workers/parseGcode.ts
@@ -58,6 +58,15 @@ const parseLine = (line: string) => {
   }
 }
 
+const linearMoveParams: (keyof LinearMove)[] = [
+  'x', 'y', 'z', 'e'
+]
+
+const arcMoveParams: (keyof ArcMove)[] = [
+  'x', 'y', 'z', 'e',
+  'i', 'j', 'k', 'r'
+]
+
 const decimalRound = (a: number) => {
   return Math.round(a * 10000) / 10000
 }
@@ -187,13 +196,9 @@ const parseGcode = async (
       switch (command) {
         case 'G0':
         case 'G1': {
-          const params: (keyof LinearMove)[] = [
-            'x', 'y', 'z', 'e'
-          ]
-
-          if (params.some(param => param in args)) {
+          if (linearMoveParams.some(param => param in args)) {
             move = {
-              ...pick(args, params),
+              ...pick(args, linearMoveParams),
               tool,
               filePosition
             } satisfies LinearMove
@@ -202,14 +207,9 @@ const parseGcode = async (
         }
         case 'G2':
         case 'G3': {
-          const params: (keyof ArcMove)[] = [
-            'x', 'y', 'z', 'e',
-            'i', 'j', 'k', 'r'
-          ]
-
-          if (params.some(param => param in args)) {
+          if (arcMoveParams.some(param => param in args)) {
             move = {
-              ...pick(args, params),
+              ...pick(args, arcMoveParams),
               d: command === 'G2'
                 ? 'clockwise'
                 : 'counter-clockwise',

--- a/src/workers/parseGcode.ts
+++ b/src/workers/parseGcode.ts
@@ -389,10 +389,6 @@ const parseGcode = async (
       buffer += decoder.decode(value, { stream: true })
       drainLines()
     }
-
-    if (buffer.length > 0) {
-      handleLine(buffer)
-    }
   } finally {
     reader.releaseLock()
   }

--- a/src/workers/parseGcode.ts
+++ b/src/workers/parseGcode.ts
@@ -72,12 +72,24 @@ const isPolygonData = (data: unknown): data is [number, number][] => (
     ))
 )
 
-const parseGcode = (gcode: string, sendProgress: (filePosition: number) => void) => {
+const parseGcode = async (
+  url: string,
+  fileSize: number,
+  sendProgress: (filePosition: number) => void
+) => {
+  const response = await fetch(url)
+
+  if (!response.ok || !response.body) {
+    throw new Error(`Failed to download gcode (${response.status} ${response.statusText})`)
+  }
+
+  const progressStep = Math.max(1, Math.floor(fileSize / 100))
+  let nextProgressByte = 0
+
   const moves: Move[] = []
   const layers: Layer[] = []
   const parts: Part[] = []
   const tools = new Set<number>()
-  const lines = gcode.split('\n')
 
   let newLayerForNextMove = false
   let extrusionMode: PositioningMode = 'relative'
@@ -111,8 +123,8 @@ const parseGcode = (gcode: string, sendProgress: (filePosition: number) => void)
     z: 0
   }
 
-  for (let i = 0; i < lines.length; i++) {
-    const { type, command, args } = parseLine(lines[i]) ?? {}
+  const handleLine = (line: string) => {
+    const { type, command, args } = parseLine(line) ?? {}
 
     let move: Move | null = null
 
@@ -332,11 +344,57 @@ const parseGcode = (gcode: string, sendProgress: (filePosition: number) => void)
       }
     }
 
-    if (i % Math.floor(lines.length / 100) === 0) {
+    if (filePosition >= nextProgressByte) {
       sendProgress(filePosition)
+      nextProgressByte = filePosition + progressStep
     }
 
-    filePosition += lines[i].length + 1 // + 1 for newline
+    filePosition += line.length + 1 // + 1 for newline
+  }
+
+  const reader = response.body.getReader()
+  const decoder = new TextDecoder()
+  let buffer = ''
+  let cursor = 0
+
+  const drainLines = () => {
+    while (true) {
+      const nl = buffer.indexOf('\n', cursor)
+
+      if (nl === -1) {
+        break
+      }
+
+      handleLine(buffer.slice(cursor, nl))
+
+      cursor = nl + 1
+    }
+
+    if (cursor > 0) {
+      buffer = buffer.slice(cursor)
+      cursor = 0
+    }
+  }
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+
+      if (done) {
+        buffer += decoder.decode()
+        drainLines()
+        break
+      }
+
+      buffer += decoder.decode(value, { stream: true })
+      drainLines()
+    }
+
+    if (buffer.length > 0) {
+      handleLine(buffer)
+    }
+  } finally {
+    reader.releaseLock()
   }
 
   sendProgress(filePosition)

--- a/src/workers/parseGcode.ts
+++ b/src/workers/parseGcode.ts
@@ -62,6 +62,27 @@ const decimalRound = (a: number) => {
   return Math.round(a * 10000) / 10000
 }
 
+const utf8ByteLength = (str: string) => {
+  let bytes = 0
+
+  for (let i = 0; i < str.length; i++) {
+    const code = str.charCodeAt(i)
+
+    if (code < 0x80) {
+      bytes += 1
+    } else if (code < 0x800) {
+      bytes += 2
+    } else if (code >= 0xd800 && code <= 0xdbff) {
+      bytes += 4 // high surrogate + its low surrogate = one 4-byte sequence
+      i++
+    } else {
+      bytes += 3
+    }
+  }
+
+  return bytes
+}
+
 const isPolygonData = (data: unknown): data is [number, number][] => (
   Array.isArray(data) &&
   data
@@ -349,7 +370,7 @@ const parseGcode = async (
       nextProgressByte = filePosition + progressStep
     }
 
-    filePosition += line.length + 1 // + 1 for newline
+    filePosition += utf8ByteLength(line) + 1 // + 1 for the '\n' (1 byte)
   }
 
   const reader = response.body.getReader()

--- a/src/workers/parseGcode.worker.ts
+++ b/src/workers/parseGcode.worker.ts
@@ -4,7 +4,8 @@ import { consola } from 'consola'
 
 export type ParseGcodeWorkerRequestMessage = {
   action: 'parse',
-  gcode: ArrayBuffer
+  url: string,
+  fileSize: number
 }
 
 export type ParseGcodeWorkerResponseMessage = {
@@ -53,15 +54,13 @@ const sendError = (error?: unknown) => {
   self.postMessage(message)
 }
 
-self.onmessage = (event: MessageEvent<ParseGcodeWorkerRequestMessage>) => {
+self.onmessage = async (event: MessageEvent<ParseGcodeWorkerRequestMessage>) => {
   const message = event.data
 
   try {
     switch (message.action) {
       case 'parse': {
-        const gcode = new TextDecoder().decode(message.gcode)
-
-        const { moves, layers, parts, tools, bounds } = parseGcode(gcode, sendProgress)
+        const { moves, layers, parts, tools, bounds } = await parseGcode(message.url, message.fileSize, sendProgress)
 
         sendResult(moves, layers, parts, tools, bounds)
 


### PR DESCRIPTION
The G-code preview parser used to load the whole file into a string and call `gcode.split('\n')`, peaking at ~3× file size in memory before any rendering could begin. With Bambu/Orca slicers now routinely producing 200–500 MB files, this either OOMs the tab or could block the UI for many seconds.

The worker now does its own `fetch()` and reads `response.body` chunk-by-chunk through `TextDecoder({ stream: true })` and a line-cursor buffer, feeding the existing parser state machine one line at a time. 

Peak memory drops to one chunk plus the accumulated outputs, the parse starts as soon as the first bytes arrive, and cancellation gets simpler - `worker.terminate()` tears down the in-flight fetch automatically (the browser aborts fetches owned by a destroyed worker realm), so no `AbortController` plumbing is needed.