### PR TITLE
fix(afc): pull remaining weight from Spoolman when enabled

### DIFF
--- a/src/components/widgets/afc/AfcCardUnitLaneBody.vue
+++ b/src/components/widgets/afc/AfcCardUnitLaneBody.vue
@@ -148,6 +148,9 @@ export default class AfcCardUnitLaneBody extends Mixins(StateMixin, AfcMixin) {
   }
 
   get spoolRemainingWeight (): number {
+    if (this.afcExistsSpoolman && this.spool?.remaining_weight != null) {
+      return Math.round(this.spool.remaining_weight)
+    }
     return Math.round(this.lane?.weight ?? 0)
   }
 


### PR DESCRIPTION
When Spoolman is configured, `spoolRemainingWeight` now reads
`spool.remaining_weight` from the Spoolman spool data instead of
`lane.weight` from the AFC lane state.

This keeps the displayed weight and spool fill percentage in sync
with Spoolman's tracking (which accounts for filament consumed
across all prints), rather than relying solely on the value AFC
reports for the lane.

Falls back to `lane.weight` when Spoolman is not enabled or the
spool has no `remaining_weight` recorded.

Signed-off-by: paxx12 <paxx12dev@gmail.com>