### PR TITLE
feat(afc): support multiple tools per lane via `map` array

### DIFF
--- a/src/components/widgets/afc/AfcCardUnitLaneHeader.vue
+++ b/src/components/widgets/afc/AfcCardUnitLaneHeader.vue
@@ -38,7 +38,9 @@ export default class AfcCardUnitLaneHeader extends Mixins(StateMixin, AfcMixin) 
   }
 
   get mappedTool (): string {
-    return this.lane?.map ?? '--'
+    const map = this.lane?.map
+    if (map == null || map.length === 0) return 'NONE'
+    return Array.isArray(map) ? map.join(', ') : map
   }
 }
 </script>

--- a/src/components/widgets/afc/AfcCardUnitLaneHeader.vue
+++ b/src/components/widgets/afc/AfcCardUnitLaneHeader.vue
@@ -7,7 +7,7 @@
         class="fill-width elevation-0"
         @click="showDialog = true"
       >
-        {{ $filters.prettyCase(name) }} > {{ mappedTool }}
+        {{ mappedTool }} > {{ $filters.prettyCase(name) }}
       </v-btn>
       <afc-unit-lane-mapping-tool-dialog
         v-model="showDialog"

--- a/src/components/widgets/afc/dialogs/AfcUnitLaneMappingToolDialog.vue
+++ b/src/components/widgets/afc/dialogs/AfcUnitLaneMappingToolDialog.vue
@@ -62,7 +62,7 @@ export default class AfcUnitLaneMappingToolDialog extends Mixins(StateMixin, Afc
 
       const tools = Array.isArray(lane.map) ? lane.map : [lane.map]
       for (const tool of tools) {
-        seen.add(tool)
+        if (tool != null && tool !== '') seen.add(tool)
       }
     }
 

--- a/src/components/widgets/afc/dialogs/AfcUnitLaneMappingToolDialog.vue
+++ b/src/components/widgets/afc/dialogs/AfcUnitLaneMappingToolDialog.vue
@@ -16,7 +16,7 @@
           <v-btn
             v-for="tool in mapList"
             :key="tool"
-            :disabled="tool.toLowerCase() === mappedTool.toLowerCase()"
+            :disabled="mappedTools.includes(tool.toLowerCase())"
             color="primary"
             class="ma-2"
             @click="mapTool(tool)"
@@ -47,23 +47,26 @@ export default class AfcUnitLaneMappingToolDialog extends Mixins(StateMixin, Afc
     return this.getAfcLaneObject(this.name)
   }
 
-  get mappedTool (): string {
-    return this.lane?.map ?? '--'
+  get mappedTools (): string[] {
+    const map = this.lane?.map
+    if (map == null) return []
+    return Array.isArray(map) ? map.map(t => t.toLowerCase()) : [map.toLowerCase()]
   }
 
   get mapList (): string[] {
-    const mapList: string[] = []
+    const seen = new Set<string>()
 
     for (const laneName of this.afcLanes) {
       const lane = this.getAfcLaneObject(laneName)
+      if (lane?.map == null) continue
 
-      if (lane?.map != null) {
-        mapList.push(lane.map)
+      const tools = Array.isArray(lane.map) ? lane.map : [lane.map]
+      for (const tool of tools) {
+        seen.add(tool)
       }
     }
 
-    return mapList
-      .sort((a, b) => a.localeCompare(b))
+    return [...seen].sort((a, b) => a.localeCompare(b))
   }
 
   mapTool (newTool: string) {

--- a/src/typings/klipper.d.ts
+++ b/src/typings/klipper.d.ts
@@ -806,7 +806,7 @@ declare namespace Klipper {
     buffer: string | null;
     buffer_status: AfcBufferStatus | null;
     lane: number;
-    map: string | null;
+    map: string | string[] | null;
     load: boolean;
     prep: boolean;
     tool_loaded: boolean;


### PR DESCRIPTION
Broadens `AfcLaneState.map` from `string | null` to `string | string[] | null` so the backend can assign multiple tools to a single lane. This is backwards-compatible — existing firmware that sends a plain string continues to work without changes.

This is to provide support for mapping logical tools (provided by slicer) to physical topology (actual filament loaded): https://github.com/AFCProject/AFC-Klipper-Add-On/issues/605

## Changes

- **`klipper.d.ts`** — type updated to `string | string[] | null`
- **`AfcCardUnitLaneHeader`** — arrays are joined with `, ` so the button reads `Lane1 > T0, T1`; empty/`null` shows `NONE` (consistent with the runout lane convention)
- **`AfcUnitLaneMappingToolDialog`** — tool roster built by flattening all lanes' `map` values; tools already in the current lane's `map` are disabled (grayed out) rather than hidden

## Screen recording

The behavior of mapping, whether the tool is remapped, or moved depends purely on how `AFC` executes the `SET_MAP`. This basically allows to visualise `map: string[]` values, and select from those values.

<img height="500" alt="recording" src="https://github.com/user-attachments/assets/7b7717ad-68ef-4536-9092-bd5c659c275b" />

> Note: The latest commit swapped `Lane > Tool` to `Tool > Lane`. It otherwise behaves exactly the same.

Signed-off-by: paxx12 <paxx12dev@gmail.com>