### PR TITLE
feat(Thermals): highlight series on mouse hover

### DIFF
--- a/src/components/widgets/thermals/TemperatureCard.vue
+++ b/src/components/widgets/thermals/TemperatureCard.vue
@@ -95,6 +95,8 @@
 
     <temperature-targets
       @updateChartSelectedLegends="updateChartSelectedLegends"
+      @highlightChartSeries="highlightChartSeries"
+      @downplayChartSeries="downplayChartSeries"
     />
 
     <template v-if="chartReady && chartVisible">
@@ -146,6 +148,18 @@ export default class TemperatureCard extends Mixins(StateMixin, BrowserMixin) {
   updateChartSelectedLegends (chartSelectedLegends: ChartSelectedLegends) {
     if (this.chartVisible) {
       this.thermalChartElement.updateChartSelectedLegends(chartSelectedLegends)
+    }
+  }
+
+  highlightChartSeries (key: string) {
+    if (this.chartVisible) {
+      this.thermalChartElement.highlightSeries(key)
+    }
+  }
+
+  downplayChartSeries () {
+    if (this.chartVisible) {
+      this.thermalChartElement.downplaySeries()
     }
   }
 

--- a/src/components/widgets/thermals/TemperatureTargets.vue
+++ b/src/components/widgets/thermals/TemperatureTargets.vue
@@ -29,6 +29,8 @@
           v-for="item in heaters"
           :key="item.key"
           @contextmenu.prevent="handleHeaterRowClick(item, $event)"
+          @mouseenter="handleHeaterMouseEnter(item)"
+          @mouseleave="handleHeaterMouseLeave"
         >
           <td>
             <v-icon
@@ -105,6 +107,8 @@
         <tr
           v-for="item in fans"
           :key="item.key"
+          @mouseenter="handleHeaterMouseEnter(item)"
+          @mouseleave="handleHeaterMouseLeave"
         >
           <td>
             <v-icon
@@ -189,6 +193,8 @@
         <tr
           v-for="item in sensors"
           :key="item.key"
+          @mouseenter="handleHeaterMouseEnter(item)"
+          @mouseleave="handleHeaterMouseLeave"
         >
           <td>
             <v-icon
@@ -459,6 +465,14 @@ export default class TemperatureTargets extends Mixins(StateMixin) {
     }
 
     this.$emit('updateChartSelectedLegends', chartSelectedLegends)
+  }
+
+  handleHeaterMouseEnter (item: Heater | Fan | Sensor) {
+    this.$emit('highlightChartSeries', item.key)
+  }
+
+  handleHeaterMouseLeave () {
+    this.$emit('downplayChartSeries')
   }
 
   getNevermoreSensors (item: Record<string, number | undefined>) {

--- a/src/components/widgets/thermals/ThermalChart.vue
+++ b/src/components/widgets/thermals/ThermalChart.vue
@@ -337,9 +337,7 @@ export default class ThermalChart extends Mixins(BrowserMixin) {
       animation: false,
       color,
       emphasis: {
-        lineStyle: {
-          width: 1.5
-        }
+        focus: 'series'
       },
       lineStyle: {
         color,
@@ -359,7 +357,6 @@ export default class ThermalChart extends Mixins(BrowserMixin) {
     // If this is a target, adjust its display.
     if (subKey === '#target') {
       series.yAxisIndex = 0
-      series.emphasis!.lineStyle!.width = 1
       series.lineStyle!.width = 1
       series.lineStyle!.type = 'dashed'
       series.lineStyle!.opacity = 0.8
@@ -369,7 +366,6 @@ export default class ThermalChart extends Mixins(BrowserMixin) {
     // If this is a power or speed, adjust its display.
     if (subKey === '#power' || subKey === '#speed') {
       series.yAxisIndex = 1
-      series.emphasis!.lineStyle!.width = 1
       series.lineStyle!.width = 1
       series.lineStyle!.type = 'dotted'
       series.lineStyle!.opacity = 1
@@ -392,6 +388,23 @@ export default class ThermalChart extends Mixins(BrowserMixin) {
         ) &&
         selected[key] === true
       )
+  }
+
+  highlightSeries (key: string) {
+    if (this.chart && !this.loading) {
+      const seriesName = this.series
+        .map(series => series.name as string)
+        .filter(name => name === key || name.startsWith(`${key}#`))
+
+      this.chart.dispatchAction({ type: 'downplay' })
+      this.chart.dispatchAction({ type: 'highlight', seriesName })
+    }
+  }
+
+  downplaySeries () {
+    if (this.chart && !this.loading) {
+      this.chart.dispatchAction({ type: 'downplay' })
+    }
   }
 
   updateChartSelectedLegends (chartSelectedLegends: ChartSelectedLegends) {


### PR DESCRIPTION
Enables series highlighting on the thermal chart by hovering the series directly on the chart or hovering the item in the thermal entries list.

## Screen Capture

https://github.com/user-attachments/assets/1028e7ce-e4c9-4fdf-a224-0988c722670e

Resolves #1536