### PR TITLE
feat: add pause functionality in ThermalChart

### DIFF
--- a/src/components/ui/AppChart.vue
+++ b/src/components/ui/AppChart.vue
@@ -9,8 +9,8 @@
         ref="chart"
         style="overflow: initial;"
         :option="opts"
-        :update-options="{ notMerge: true }"
-        :init-options="{ renderer: 'canvas' }"
+        :update-options="updateOptions"
+        :init-options="initOptions"
         autoresize
       />
     </div>
@@ -38,6 +38,12 @@ export default class AppChart extends Vue {
 
   @Ref('chart')
   readonly chart!: ECharts
+
+  // Stable references so component re-renders don't make vue-echarts dispose/
+  // re-init the chart or re-apply the options, both of which would wipe the
+  // imperatively-set dataset and blank the chart.
+  readonly updateOptions = Object.freeze({ notMerge: true })
+  readonly initOptions = Object.freeze({ renderer: 'canvas' })
 
   ready = false
 

--- a/src/components/widgets/bedmesh/BedMeshChart.vue
+++ b/src/components/widgets/bedmesh/BedMeshChart.vue
@@ -8,8 +8,8 @@
     <e-chart
       ref="chart"
       :option="opts"
-      :update-options="{ notMerge: false }"
-      :init-options="{ renderer: 'canvas' }"
+      :update-options="updateOptions"
+      :init-options="initOptions"
       autoresize
     />
 
@@ -43,6 +43,11 @@ export default class BedMeshChart extends Mixins(BrowserMixin) {
 
   @Ref('chart')
   readonly chart!: ECharts
+
+  // Stable references so component re-renders don't make vue-echarts dispose/
+  // re-init the chart, which would reset the 3D camera (rotation/zoom) state.
+  readonly updateOptions = Object.freeze({ notMerge: false })
+  readonly initOptions = Object.freeze({ renderer: 'canvas' })
 
   get flatSurface (): boolean {
     return this.$typedState.mesh.flatSurface

--- a/src/components/widgets/thermals/ThermalChart.vue
+++ b/src/components/widgets/thermals/ThermalChart.vue
@@ -9,13 +9,20 @@
       ref="chart"
       style="overflow: initial;"
       :option="options"
-      :update-options="{ notMerge: true }"
-      :init-options="{ renderer: 'canvas' }"
+      :update-options="updateOptions"
+      :init-options="initOptions"
       autoresize
       @legendselectchanged="handleLegendSelectChanged"
       @legendselected="handleLegendSelectChanged"
       @legendunselected="handleLegendSelectChanged"
     />
+
+    <div
+      class="chart-pause"
+      @click="togglePause"
+    >
+      <v-icon>{{ paused ? '$resume' : '$pause' }}</v-icon>
+    </div>
   </div>
 </template>
 
@@ -34,9 +41,24 @@ export default class ThermalChart extends Mixins(BrowserMixin) {
   @Ref('chart')
   readonly chart!: ECharts
 
+  // Stable references so component re-renders (e.g. toggling pause) don't cause
+  // vue-echarts to dispose/re-init the chart or re-apply the options, both of
+  // which would wipe the imperatively-set dataset and blank the chart.
+  readonly updateOptions = Object.freeze({ notMerge: true })
+  readonly initOptions = Object.freeze({ renderer: 'canvas' })
+
   loading = false
+  paused = false
   series: LineSeriesOption[] = []
   initialSelected: Record<string, boolean> = {}
+
+  togglePause () {
+    this.paused = !this.paused
+
+    if (!this.paused) {
+      this.onDataChange(this.chartData)
+    }
+  }
 
   handleLegendSelectChanged (event: { selected: Record<string, boolean> }) {
     this.$typedDispatch('charts/saveSelectedLegends', event.selected)
@@ -73,7 +95,11 @@ export default class ThermalChart extends Mixins(BrowserMixin) {
 
   @Watch('chartData')
   onDataChange (data: any) {
-    if (this.chart && !this.loading) {
+    if (
+      this.chart &&
+      !this.loading &&
+      !this.paused
+    ) {
       this.chart.setOption({
         dataset: {
           source: data
@@ -433,6 +459,17 @@ export default class ThermalChart extends Mixins(BrowserMixin) {
 
 <style lang='scss' scoped>
   .chart {
+    position: relative;
     width: 100%;
+  }
+
+  .chart-pause {
+    position: absolute;
+    top: 0;
+    right: 0;
+    padding: 2px 6px;
+    margin-right: 16px;
+    cursor: pointer;
+    z-index: 1;
   }
 </style>

--- a/src/components/widgets/thermals/ThermalChart.vue
+++ b/src/components/widgets/thermals/ThermalChart.vue
@@ -17,11 +17,22 @@
       @legendunselected="handleLegendSelectChanged"
     />
 
-    <div
-      class="chart-pause"
-      @click="togglePause"
-    >
-      <v-icon>{{ paused ? '$resume' : '$pause' }}</v-icon>
+    <div class="chart-options">
+      <v-tooltip bottom>
+        <template #activator="{ on, attrs }">
+          <v-btn
+            v-bind="attrs"
+            icon
+            small
+            tabindex="-1"
+            v-on="on"
+            @click="togglePause"
+          >
+            <v-icon>{{ paused ? '$resume' : '$pause' }}</v-icon>
+          </v-btn>
+        </template>
+        <span>{{ paused ? $t('app.general.btn.resume') : $t('app.general.btn.pause') }}</span>
+      </v-tooltip>
     </div>
   </div>
 </template>
@@ -463,13 +474,12 @@ export default class ThermalChart extends Mixins(BrowserMixin) {
     width: 100%;
   }
 
-  .chart-pause {
+  .chart-options {
     position: absolute;
     top: 0;
     right: 0;
-    padding: 2px 6px;
+    padding: 2px 0px;
     margin-right: 16px;
-    cursor: pointer;
     z-index: 1;
   }
 </style>


### PR DESCRIPTION
Adds the ability to pause/resume the thermal chart. When resuming, it will show the latest "live" data available.

Also refactors chart options handling to use stable references so component re-renders don't cause vue-echarts to dispose/re-init the chart or re-apply the options.

## Screenshot

https://github.com/user-attachments/assets/f45acc95-93b0-4f5a-b8ce-b4dc4e63ff1e

Resolves #1537