### PR TITLE
feat: adds HTTP endpoint diagnostics support

### DIFF
--- a/src/components/common/AddInstanceDialog.vue
+++ b/src/components/common/AddInstanceDialog.vue
@@ -72,6 +72,7 @@ import { Globals } from '@/globals'
 import StateMixin from '@/mixins/state'
 import { Debounce } from 'vue-debounce-decorator'
 import webSocketWrapper from '@/util/web-socket-wrapper'
+import diagnoseHttpEndpoint from '@/util/http-endpoint-diagnostics'
 
 @Component({})
 export default class AddInstanceDialog extends Mixins(StateMixin) {
@@ -122,9 +123,9 @@ export default class AddInstanceDialog extends Mixins(StateMixin) {
       this.note = null
       this.verifying = true
 
-      const { socketUrl } = this.$filters.getApiUrls(value)
+      const { apiUrl, socketUrl } = this.$filters.getApiUrls(value)
 
-      // Cancel any in-flight WebSocket probe before starting a new one.
+      // Cancel any in-flight probe before starting a new one.
       this.abortController?.abort()
 
       this.abortController = new AbortController()
@@ -137,8 +138,9 @@ export default class AddInstanceDialog extends Mixins(StateMixin) {
 
       if (result.ok) {
         this.verified = true
-      } else if (result.reason !== 'cancelled') {
-        this.error = result.message
+      } else if (result.reason === 'error') {
+        await this.diagnoseError(apiUrl, result.message, signal)
+      } else if (result.reason === 'timeout') {
         this.note = this.$t('app.endpoint.error.cant_connect').toString()
       }
 
@@ -146,14 +148,39 @@ export default class AddInstanceDialog extends Mixins(StateMixin) {
     }
   }
 
+  async diagnoseError (apiUrl: string, wsMessage: string, signal: AbortSignal) {
+    const diagnostic = await diagnoseHttpEndpoint(apiUrl, {
+      timeout: 3000,
+      signal
+    })
+
+    switch (diagnostic.kind) {
+      case 'mixed-content':
+        this.error = this.$t('app.endpoint.error.mixed_content').toString()
+        break
+
+      case 'cors':
+        this.error = this.$t('app.endpoint.error.cors_error').toString()
+        this.note = this.$t('app.endpoint.error.cors_note', {
+          url: Globals.DOCS_MULTIPLE_INSTANCES
+        }).toString()
+        break
+
+      case 'reachable':
+        this.error = this.$t('app.endpoint.error.websocket_failed').toString()
+        break
+
+      case 'unreachable':
+        this.error = wsMessage
+        this.note = this.$t('app.endpoint.error.cant_connect').toString()
+        break
+    }
+  }
+
   get helpTxt () {
     return this.$t('app.endpoint.msg.trouble', {
       url: Globals.DOCS_MULTIPLE_INSTANCES
     })
-  }
-
-  get hosted (): boolean {
-    return this.$typedState.config.hostConfig.hosted
   }
 
   addInstance () {

--- a/src/components/common/AddInstanceDialog.vue
+++ b/src/components/common/AddInstanceDialog.vue
@@ -144,7 +144,11 @@ export default class AddInstanceDialog extends Mixins(StateMixin) {
         this.note = this.$t('app.endpoint.error.cant_connect').toString()
       }
 
-      this.verifying = false
+      // A newer probe may have superseded this one while awaiting; if so, leave
+      // the spinner for it to own.
+      if (!signal.aborted) {
+        this.verifying = false
+      }
     }
   }
 
@@ -173,6 +177,10 @@ export default class AddInstanceDialog extends Mixins(StateMixin) {
       case 'unreachable':
         this.error = wsMessage
         this.note = this.$t('app.endpoint.error.cant_connect').toString()
+        break
+
+      case 'cancelled':
+        // Superseded by a newer probe; leave the UI state untouched.
         break
     }
   }

--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -147,6 +147,14 @@ app:
         This may mean you need to modify your moonraker configuration. Please
         see the documentation on multi printer setups <a href="%{url}"
         target="_blank">here</a>
+      mixed_content: >-
+        Fluidd is served over HTTPS but this address uses HTTP. Browsers block
+        mixed (insecure) connections. Use an HTTPS/secure address, or open
+        Fluidd over HTTP.
+      websocket_failed: >-
+        The server responded over HTTP but the WebSocket connection failed. If
+        you are behind a reverse proxy, make sure it is configured to upgrade
+        and forward WebSocket connections.
     hint:
       add_printer: E.g., http://fluidd.local
     msg:

--- a/src/util/__tests__/http-endpoint-diagnostics.spec.ts
+++ b/src/util/__tests__/http-endpoint-diagnostics.spec.ts
@@ -1,0 +1,90 @@
+import diagnoseHttpEndpoint from '../http-endpoint-diagnostics'
+
+describe('diagnoseHttpEndpoint', () => {
+  const originalLocation = window.location
+
+  const setProtocol = (protocol: string) => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...originalLocation, protocol }
+    })
+  }
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: originalLocation
+    })
+  })
+
+  it('returns mixed-content for an http target on an https page', async () => {
+    setProtocol('https:')
+
+    const result = await diagnoseHttpEndpoint('http://printer.local')
+
+    expect(result).toEqual({ kind: 'mixed-content' })
+  })
+
+  it.each([200, 401, 404])('returns reachable when the cors fetch resolves (status %i)', async (status) => {
+    setProtocol('http:')
+
+    const fetchMock = vi.fn().mockResolvedValue({ status })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await diagnoseHttpEndpoint('http://printer.local')
+
+    expect(result).toEqual({ kind: 'reachable', status })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns cors when the cors fetch fails but the no-cors fetch succeeds', async () => {
+    setProtocol('http:')
+
+    const fetchMock = vi.fn()
+      .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+      .mockResolvedValueOnce({ type: 'opaque' })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await diagnoseHttpEndpoint('http://printer.local')
+
+    expect(result).toEqual({ kind: 'cors' })
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(fetchMock.mock.calls[1][1]).toMatchObject({ mode: 'no-cors' })
+  })
+
+  it('returns unreachable when both fetches fail', async () => {
+    setProtocol('http:')
+
+    const fetchMock = vi.fn().mockRejectedValue(new TypeError('Failed to fetch'))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await diagnoseHttpEndpoint('http://printer.local')
+
+    expect(result).toEqual({ kind: 'unreachable' })
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('returns cancelled when the signal aborts before the cors fetch settles', async () => {
+    setProtocol('http:')
+
+    const controller = new AbortController()
+
+    vi.stubGlobal('fetch', vi.fn().mockImplementation((_url: string, opts: RequestInit) =>
+      new Promise((_resolve, reject) => {
+        opts.signal?.addEventListener('abort', () => {
+          reject(new DOMException('aborted', 'AbortError'))
+        })
+      })
+    ))
+
+    const promise = diagnoseHttpEndpoint('http://printer.local', { signal: controller.signal })
+
+    controller.abort()
+
+    const result = await promise
+
+    expect(result).toEqual({ kind: 'cancelled' })
+  })
+})

--- a/src/util/http-endpoint-diagnostics.ts
+++ b/src/util/http-endpoint-diagnostics.ts
@@ -1,0 +1,97 @@
+import consola from 'consola'
+
+export type HttpDiagnosticResult =
+  | { kind: 'mixed-content' }
+  | { kind: 'cors' }
+  | { kind: 'reachable'; status: number }
+  | { kind: 'unreachable' }
+  | { kind: 'cancelled' }
+
+export interface DiagnoseOptions {
+  timeout?: number;
+  signal?: AbortSignal;
+}
+
+const diagnoseHttpEndpoint = async (apiUrl: string, options: DiagnoseOptions = {}): Promise<HttpDiagnosticResult> => {
+  const debug = (message: string, ...args: unknown[]) => consola.debug(`[diagnoseHttpEndpoint] ${apiUrl} ${message}`, ...args)
+
+  const { timeout, signal } = options
+
+  // A secure page can't open an insecure connection; detected before any request.
+  if (window.location.protocol === 'https:' && apiUrl.startsWith('http://')) {
+    debug('mixed content')
+
+    return {
+      kind: 'mixed-content'
+    }
+  }
+
+  const timeoutSignal = timeout !== undefined
+    ? AbortSignal.timeout(timeout)
+    : undefined
+
+  const combinedSignal = AbortSignal.any(
+    [timeoutSignal, signal]
+      .filter((x): x is AbortSignal => x !== undefined)
+  )
+
+  const probeUrl = `${apiUrl}/server/info?t=${Date.now()}`
+
+  try {
+    const response = await fetch(probeUrl, {
+      signal: combinedSignal,
+      cache: 'no-cache'
+    })
+
+    // A resolved response (any status) means the server is reachable with CORS
+    // headers, so the WebSocket failure is likely a reverse-proxy/path issue.
+    debug('reachable', response.status)
+
+    return {
+      kind: 'reachable',
+      status: response.status
+    }
+  } catch (error) {
+    if (combinedSignal.aborted && !timeoutSignal?.aborted) {
+      debug('cancelled')
+
+      return {
+        kind: 'cancelled'
+      }
+    }
+
+    debug('cors fetch failed', error)
+
+    // If a no-cors re-probe succeeds, the host is reachable and the earlier
+    // failure was the CORS policy rather than an unreachable host.
+    try {
+      await fetch(probeUrl, {
+        signal: combinedSignal,
+        mode: 'no-cors',
+        cache: 'no-cache'
+      })
+
+      debug('cors')
+
+      return {
+        kind: 'cors'
+      }
+    } catch (noCorsError) {
+      if (combinedSignal.aborted && !timeoutSignal?.aborted) {
+        debug('cancelled')
+
+        return {
+          kind: 'cancelled'
+        }
+      }
+
+      debug('unreachable', noCorsError)
+
+      return {
+        kind: 'unreachable'
+      }
+    }
+  }
+}
+
+export default diagnoseHttpEndpoint


### PR DESCRIPTION
WebSocket errors are opaque, so let's probe over HTTP to classify why a connection failed.