### PR TITLE
fix: correct color for selected tool

### DIFF
--- a/src/store/gcodePreview/getters.ts
+++ b/src/store/gcodePreview/getters.ts
@@ -193,7 +193,7 @@ export const getters = {
       .reduce<Record<Tool, string>>((tools, toolIndex, index) => {
         const tool: Tool = `T${toolIndex}`
         const color: string = (
-          colorsFromFileMetadata[index] ||
+          colorsFromFileMetadata[toolIndex] ||
           defaultColors[index - colorsFromFileMetadata.length] ||
           defaultColors[0]
         )


### PR DESCRIPTION
Corrects the tool index to ensure that the proper color is shown on the gcode preview.

Fixes #1864 