### PR TITLE
feat: warn of very old Moonraker

### DIFF
--- a/src/store/server/actions.ts
+++ b/src/store/server/actions.ts
@@ -47,6 +47,18 @@ export const actions = {
     }
   },
 
+  async notifyOldMoonraker ({ dispatch }) {
+    dispatch('notifications/pushNotification', {
+      id: 'old-moonraker',
+      title: 'Moonraker',
+      description: i18n.t('app.version.label.old_component_version', { name: 'Moonraker', version: Globals.MOONRAKER_MIN_VERSION }),
+      to: '/settings#versions',
+      btnText: i18n.t('app.version.btn.view_versions'),
+      type: 'warning',
+      merge: true
+    }, { root: true })
+  },
+
   async checkMoonrakerMinVersion ({ state, dispatch }) {
     const moonrakerVersion = state.info.moonraker_version ?? '?'
 
@@ -59,15 +71,7 @@ export const actions = {
       valid(Globals.MOONRAKER_MIN_VERSION) &&
       !gte(fullMoonrakerVersion, Globals.MOONRAKER_MIN_VERSION)
     ) {
-      dispatch('notifications/pushNotification', {
-        id: `old-moonraker-${moonrakerVersion}`,
-        title: 'Moonraker',
-        description: i18n.t('app.version.label.old_component_version', { name: 'Moonraker', version: Globals.MOONRAKER_MIN_VERSION }),
-        to: '/settings#versions',
-        btnText: i18n.t('app.version.btn.view_versions'),
-        type: 'warning',
-        merge: true
-      }, { root: true })
+      dispatch('notifyOldMoonraker')
     }
   },
 

--- a/src/store/server/actions.ts
+++ b/src/store/server/actions.ts
@@ -48,7 +48,7 @@ export const actions = {
   },
 
   async notifyOldMoonraker ({ dispatch }) {
-    dispatch('notifications/pushNotification', {
+    await dispatch('notifications/pushNotification', {
       id: 'old-moonraker',
       title: 'Moonraker',
       description: i18n.t('app.version.label.old_component_version', { name: 'Moonraker', version: Globals.MOONRAKER_MIN_VERSION }),
@@ -71,7 +71,7 @@ export const actions = {
       valid(Globals.MOONRAKER_MIN_VERSION) &&
       !gte(fullMoonrakerVersion, Globals.MOONRAKER_MIN_VERSION)
     ) {
-      dispatch('notifyOldMoonraker')
+      await dispatch('notifyOldMoonraker')
     }
   },
 

--- a/src/store/socket/actions.ts
+++ b/src/store/socket/actions.ts
@@ -8,6 +8,7 @@ import { EventBus } from '@/eventBus'
 import { upperFirst, camelCase } from 'lodash-es'
 import { jwtDecode } from 'jwt-decode'
 import type { TokenKeys } from '../config/types'
+import i18n from '@/plugins/i18n'
 
 const MODULES_TO_RESET_ON_DROP = [
   'server',
@@ -186,8 +187,9 @@ export const actions = {
    * token expiry: if the access token is expired but the refresh token is valid,
    * refreshes first. If both are expired, identify is still called but without an
    * access token (anonymous/trusted identify). Terminal transitions: → `ready` on
-   * success, → `authenticating` on failure. Aborts silently if the socket drops
-   * mid-flight.
+   * success; → `authenticating` on auth failure; → `ready` with a warning on
+   * JSON-RPC -32601 (very old Moonraker that predates `server.connection.identify`).
+   * Aborts silently if the socket drops mid-flight.
    */
   async runIdentify ({ dispatch, rootGetters, state }) {
     // Skip identify when the socket is already identified (e.g. post-access.login
@@ -210,9 +212,26 @@ export const actions = {
 
         if (state.status !== 'identifying') return
 
-        await dispatch('onSetStatus', 'authenticating')
+        // Very old Moonraker that predates server.connection.identify returns
+        // JSON-RPC -32601 ("Method not found"). Warn the user and continue
+        // loading unauthenticated through the normal bootstrap → ready path.
+        if (
+          e != null &&
+          typeof e === 'object' &&
+          'code' in e &&
+          e.code === -32601
+        ) {
+          EventBus.$emit(
+            i18n.t('app.version.label.old_component_version', { name: 'Moonraker', version: Globals.MOONRAKER_MIN_VERSION }).toString(),
+            { type: 'warning' }
+          )
 
-        return
+          await dispatch('server/notifyOldMoonraker', undefined, { root: true })
+        } else {
+          await dispatch('onSetStatus', 'authenticating')
+
+          return
+        }
       }
     }
 


### PR DESCRIPTION
When `server.connection.identify` returns JSON-RPC -32601 ("Method not found"), the old code transitioned the socket to `authenticating` state, dead-ending users on a login screen that an old Moonraker can't satisfy.

This change detects -32601 specifically and instead continues loading the app unauthenticated through the normal bootstrap to `ready` path, while surfacing both a transient flash warning and a persistent notification telling the user to update Moonraker.