### PR TITLE
feat(Thermals): customizable sensor colors

### DIFF
--- a/docs/docs/features/thermals.md
+++ b/docs/docs/features/thermals.md
@@ -19,6 +19,18 @@ fans in real time.
 
 ![Thermal graph showing real-time temperature history for heaters and sensors](/assets/images/graph.png)
 
+## Sensor colors
+
+Each heater, fan, and sensor row displays a colored icon. Click it to open a
+color picker and set a custom color for that sensor. The color is reflected
+immediately in both the list and the chart.
+
+To revert to the automatically assigned palette color, open the picker and
+click **Reset to default**.
+
+Colors are saved per sensor in Moonraker's database and restored on the next
+page load.
+
 ## Presets
 
 Fluidd supports custom thermal presets — saved temperature profiles you can

--- a/src/api/socketActions.ts
+++ b/src/api/socketActions.ts
@@ -521,7 +521,7 @@ export const SocketActions = {
     )
   },
 
-  serverDatabasePostItem<T = unknown> (key: string, value: T, namespace: string = Globals.MOONRAKER_DB.fluidd.NAMESPACE, options?: NotifyOptions) {
+  serverDatabasePostItem<T = unknown> (key: string | string[], value: T, namespace: string = Globals.MOONRAKER_DB.fluidd.NAMESPACE, options?: NotifyOptions) {
     return baseEmit<Moonraker.Database.PostItemResponse<T>>(
       'server.database.post_item', {
         ...options,
@@ -534,7 +534,7 @@ export const SocketActions = {
     )
   },
 
-  serverDatabaseDeleteItem<T = unknown> (key: string, namespace: string = Globals.MOONRAKER_DB.fluidd.NAMESPACE, options?: NotifyOptions) {
+  serverDatabaseDeleteItem<T = unknown> (key: string | string[], namespace: string = Globals.MOONRAKER_DB.fluidd.NAMESPACE, options?: NotifyOptions) {
     return baseEmit<Moonraker.Database.DeleteItemResponse<T>>(
       'server.database.delete_item', {
         ...options,
@@ -546,7 +546,7 @@ export const SocketActions = {
     )
   },
 
-  serverDatabaseGetItem<T = unknown> (key?: string, namespace: string = Globals.MOONRAKER_DB.fluidd.NAMESPACE, options?: NotifyOptions) {
+  serverDatabaseGetItem<T = unknown> (key?: string | string[], namespace: string = Globals.MOONRAKER_DB.fluidd.NAMESPACE, options?: NotifyOptions) {
     return baseEmit<Moonraker.Database.GetItemResponse<T>>(
       'server.database.get_item', {
         ...options,

--- a/src/components/ui/AppColorPicker.vue
+++ b/src/components/ui/AppColorPicker.vue
@@ -172,6 +172,7 @@
         <v-spacer />
         <app-btn
           small
+          color="primary"
           text
           @click="$emit('reset')"
         >

--- a/src/components/ui/AppColorPicker.vue
+++ b/src/components/ui/AppColorPicker.vue
@@ -22,11 +22,13 @@
       <v-icon
         v-else
         v-bind="attrs"
+        :class="iconClass"
         :color="controlColor"
         :disabled="disabled"
+        :small="small"
         v-on="on"
       >
-        $circle
+        {{ icon }}
       </v-icon>
     </template>
     <v-card ref="card">
@@ -163,6 +165,19 @@
           </div>
         </v-layout>
       </v-card-text>
+      <v-card-actions
+        v-if="resettable"
+        class="pt-0"
+      >
+        <v-spacer />
+        <app-btn
+          small
+          text
+          @click="$emit('reset')"
+        >
+          {{ $t('app.general.btn.reset_to_default') }}
+        </app-btn>
+      </v-card-actions>
     </v-card>
   </v-menu>
 </template>
@@ -192,6 +207,18 @@ export default class AppColorPicker extends Vue {
 
   @Prop({ type: Boolean })
   readonly dot?: boolean
+
+  @Prop({ type: String, default: '$circle' })
+  readonly icon!: string
+
+  @Prop({ type: [String, Object, Array], default: undefined })
+  readonly iconClass?: string | Record<string, boolean> | unknown[]
+
+  @Prop({ type: Boolean })
+  readonly small?: boolean
+
+  @Prop({ type: Boolean })
+  readonly resettable?: boolean
 
   @Prop({ type: String, default: 'RGB' })
   readonly supportedChannels!: string

--- a/src/components/widgets/thermals/TemperatureTargets.vue
+++ b/src/components/widgets/thermals/TemperatureTargets.vue
@@ -32,13 +32,17 @@
           @mouseenter="handleHeaterMouseEnter(item)"
           @mouseleave="handleHeaterMouseLeave"
         >
-          <td>
-            <v-icon
+          <td @contextmenu.stop>
+            <app-color-picker
+              dot
+              resettable
               small
-              :color="item.color"
-            >
-              $fire
-            </v-icon>
+              icon="$fire"
+              :title="$t('app.setting.label.sensor_color')"
+              :value="item.color"
+              @input="setSensorColor(item.key, $event)"
+              @reset="resetSensorColor(item.key)"
+            />
           </td>
           <td class="temp-name">
             <span
@@ -111,13 +115,17 @@
           @mouseleave="handleHeaterMouseLeave"
         >
           <td>
-            <v-icon
+            <app-color-picker
+              dot
+              resettable
               small
-              :class="{ 'spin': item.speed > 0 && item.target > 0 }"
-              :color="item.color"
-            >
-              $fan
-            </v-icon>
+              icon="$fan"
+              :icon-class="{ 'spin': item.speed > 0 && item.target > 0 }"
+              :title="$t('app.setting.label.sensor_color')"
+              :value="item.color"
+              @input="setSensorColor(item.key, $event)"
+              @reset="resetSensorColor(item.key)"
+            />
           </td>
           <td class="temp-name">
             <span
@@ -197,12 +205,16 @@
           @mouseleave="handleHeaterMouseLeave"
         >
           <td>
-            <v-icon
+            <app-color-picker
+              dot
+              resettable
               small
-              :color="item.color"
-            >
-              $thermometer
-            </v-icon>
+              icon="$thermometer"
+              :title="$t('app.setting.label.sensor_color')"
+              :value="item.color"
+              @input="setSensorColor(item.key, $event)"
+              @reset="resetSensorColor(item.key)"
+            />
           </td>
           <td class="temp-name">
             <span
@@ -412,6 +424,14 @@ export default class TemperatureTargets extends Mixins(StateMixin) {
 
   get showGasResistance (): boolean {
     return this.$typedState.config.uiSettings.general.showGasResistance
+  }
+
+  setSensorColor (key: string, color: string) {
+    this.$typedDispatch('config/updateSensorColor', { key, color })
+  }
+
+  resetSensorColor (key: string) {
+    this.$typedDispatch('config/removeSensorColor', { key })
   }
 
   setHeaterTargetTemp (heater: string, target: number) {

--- a/src/components/widgets/thermals/ThermalChart.vue
+++ b/src/components/widgets/thermals/ThermalChart.vue
@@ -38,6 +38,7 @@
 </template>
 
 <script lang='ts'>
+import { markRaw } from 'vue'
 import { Component, Watch, Prop, Ref, Mixins } from 'vue-property-decorator'
 import type { ECharts, EChartsOption, LineSeriesOption } from 'echarts'
 import getKlipperType from '@/util/get-klipper-type'
@@ -55,7 +56,7 @@ export default class ThermalChart extends Mixins(BrowserMixin) {
   // Stable references so component re-renders (e.g. toggling pause) don't cause
   // vue-echarts to dispose/re-init the chart or re-apply the options, both of
   // which would wipe the imperatively-set dataset and blank the chart.
-  readonly updateOptions = Object.freeze({ notMerge: true })
+  readonly updateOptions = Object.freeze({ notMerge: false })
   readonly initOptions = Object.freeze({ renderer: 'canvas' })
 
   loading = false
@@ -104,6 +105,25 @@ export default class ThermalChart extends Mixins(BrowserMixin) {
     return this.$typedState.charts.selectedLegends
   }
 
+  get sensorColors (): Record<string, string> {
+    return this.$typedState.config.uiSettings.dashboard.sensorColors
+  }
+
+  @Watch('sensorColors', { deep: true })
+  onSensorColorsChange () {
+    if (!this.chart || this.loading) return
+
+    for (const series of this.series) {
+      const baseKey = (series.name as string).replace(/(#target|#power|#speed)$/, '')
+      const color = this.seriesColor(baseKey)
+      series.color = color
+      if (series.lineStyle) series.lineStyle.color = color
+    }
+
+    // Merge (no notMerge) so the imperatively-set dataset is preserved.
+    this.chart.setOption({ series: this.series })
+  }
+
   @Watch('chartData')
   onDataChange (data: any) {
     if (
@@ -135,13 +155,25 @@ export default class ThermalChart extends Mixins(BrowserMixin) {
     // Create the series and associated legends.
     const dataKeys = Object.keys(this.chartData[0])
     const keys = this.chartableSensors
+    const series: LineSeriesOption[] = []
 
     keys.forEach((key) => {
-      this.series.push(this.createSeries(key))
-      if (dataKeys.includes(`${key}#target`)) this.series.push(this.createSeries(key, '#target'))
-      if (dataKeys.includes(`${key}#power`)) this.series.push(this.createSeries(key, '#power'))
-      if (dataKeys.includes(`${key}#speed`)) this.series.push(this.createSeries(key, '#speed'))
+      series.push(this.createSeries(key))
+
+      if (dataKeys.includes(`${key}#target`)) {
+        series.push(this.createSeries(key, '#target'))
+      }
+
+      if (dataKeys.includes(`${key}#power`)) {
+        series.push(this.createSeries(key, '#power'))
+      }
+
+      if (dataKeys.includes(`${key}#speed`)) {
+        series.push(this.createSeries(key, '#speed'))
+      }
     })
+
+    this.series = markRaw(series)
   }
 
   get options (): EChartsOption {
@@ -359,11 +391,14 @@ export default class ThermalChart extends Mixins(BrowserMixin) {
     return options
   }
 
+  seriesColor (baseKey: string): string | undefined {
+    return this.$colorset.next(getKlipperType(baseKey), baseKey, this.sensorColors[baseKey])
+  }
+
   createSeries (baseKey: string, subKey?: '#target' | '#power' | '#speed'): LineSeriesOption {
     // Grab the color
     const key = `${baseKey}${subKey ?? ''}`
-    const sensorColors = this.$typedState.config.uiSettings.dashboard.sensorColors
-    const color = this.$colorset.next(getKlipperType(baseKey), baseKey, sensorColors[baseKey])
+    const color = this.seriesColor(baseKey)
 
     // Base properties
     const series: LineSeriesOption = {

--- a/src/components/widgets/thermals/ThermalChart.vue
+++ b/src/components/widgets/thermals/ThermalChart.vue
@@ -362,7 +362,8 @@ export default class ThermalChart extends Mixins(BrowserMixin) {
   createSeries (baseKey: string, subKey?: '#target' | '#power' | '#speed'): LineSeriesOption {
     // Grab the color
     const key = `${baseKey}${subKey ?? ''}`
-    const color = this.$colorset.next(getKlipperType(baseKey), baseKey)
+    const sensorColors = this.$typedState.config.uiSettings.dashboard.sensorColors
+    const color = this.$colorset.next(getKlipperType(baseKey), baseKey, sensorColors[baseKey])
 
     // Base properties
     const series: LineSeriesOption = {

--- a/src/components/widgets/thermals/ThermalChart.vue
+++ b/src/components/widgets/thermals/ThermalChart.vue
@@ -391,7 +391,7 @@ export default class ThermalChart extends Mixins(BrowserMixin) {
     return options
   }
 
-  seriesColor (baseKey: string): string | undefined {
+  seriesColor (baseKey: string): string {
     return this.$colorset.next(getKlipperType(baseKey), baseKey, this.sensorColors[baseKey])
   }
 

--- a/src/globals.ts
+++ b/src/globals.ts
@@ -747,3 +747,19 @@ export const TimeFormats = Object.freeze<Record<string, DateTimeFormat>>({
     options: { hour: '2-digit', minute: '2-digit', hour12: false }
   }
 })
+
+export interface ColorGenOption {
+  base: string
+  count: number
+  hsplit?: number
+  lsplit?: number
+}
+
+export type PaletteOption = string[] | ColorGenOption
+
+export const DefaultPalettes = Object.freeze<Record<string, PaletteOption>>({
+  heater: { base: '#ff5252', hsplit: 20, count: 4 },
+  bed: { base: '#1fb0ff', hsplit: 20, count: 2 },
+  fan: { base: '#4CAF50', hsplit: 20, count: 4 },
+  sensor: ['#D67600', '#830EE3', '#B366F2', '#E06573', '#E38819', '#795548', '#607D8B', '#3F51B5', '#F50057']
+})

--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -306,6 +306,7 @@ app:
       reset_file: Clear File
       reset_layout: Reset
       reset_default_layout: Reset Default
+      reset_to_default: Reset to default
       restart_firmware: Firmware Restart
       restart_service: Restart %{service}
       restart_service_klipper: Restart Klipper
@@ -810,6 +811,7 @@ app:
       save_and_restore_view_state: Save and restore view state
       sections_to_ignore_pending_configuration_changes: Sections to ignore
         Pending Configuration Changes
+      sensor_color: Sensor Color
       service_restart: Service Restart
       show_animations: Show animations
       show_barometric_pressure: Show barometric pressure

--- a/src/main.ts
+++ b/src/main.ts
@@ -41,7 +41,7 @@ Vue.component('EChart', () => import('./vue-echarts-chunk'))
 // Use any Plugins
 Vue.use(FiltersPlugin)
 Vue.use(VueMeta)
-Vue.use(ColorSetPlugin, {})
+Vue.use(ColorSetPlugin)
 Vue.use(VuetifyConfirm, {
   vuetify
 })

--- a/src/plugins/colorSet.ts
+++ b/src/plugins/colorSet.ts
@@ -1,14 +1,6 @@
 import type _Vue from 'vue'
 import { TinyColor } from '@ctrl/tinycolor'
-
-interface ColorGenOption {
-  base: string
-  count: number
-  hsplit?: number
-  lsplit?: number
-}
-
-type PaletteOption = string[] | ColorGenOption
+import { DefaultPalettes, type PaletteOption } from '@/globals'
 
 interface ColorSlot {
   readonly color: string
@@ -31,17 +23,10 @@ const buildPalette = (option: PaletteOption): string[] => {
   )
 }
 
-const DEFAULT_PALETTES: Record<string, PaletteOption> = {
-  heater: { base: '#ff5252', hsplit: 20, count: 4 },
-  bed: { base: '#1fb0ff', hsplit: 20, count: 2 },
-  fan: { base: '#4CAF50', hsplit: 20, count: 4 },
-  sensor: ['#D67600', '#830EE3', '#B366F2', '#E06573', '#E38819', '#795548', '#607D8B', '#3F51B5', '#F50057']
-}
-
 export class ColorSet {
   readonly lists: Record<string, ColorSlot[]>
 
-  constructor (palettes: Record<string, PaletteOption> = DEFAULT_PALETTES) {
+  constructor (palettes: Record<string, PaletteOption> = DefaultPalettes) {
     this.lists = Object.fromEntries(
       Object.entries(palettes)
         .map(([list, option]) => [
@@ -56,22 +41,23 @@ export class ColorSet {
   }
 
   /**
-   * Get a stable color for `name` within `list`.
+   * Resolve the display color for `name` within `list`.
    *
-   * Returns the color already assigned to `name`, otherwise the next
-   * never-assigned color, otherwise the first non-locked (recyclable) color, or
-   * `undefined` when the list is unknown or every color is assigned and locked.
-   *
-   * `locked` (default true) keeps the assignment permanent until `forceResetAll`.
-   * Pass false to allow the color to be recycled once the palette is exhausted
-   * (e.g. when the key's display color is overridden elsewhere).
+   * When `override` is given it is returned as-is and the key's palette slot is
+   * left recyclable (so an overridden key never permanently consumes a color).
+   * Otherwise returns the color already assigned to `name`, then the next
+   * never-assigned color, then the first non-locked (recyclable) color, locking
+   * the assignment until `forceResetAll`. Returns `undefined` only when there is
+   * no override and the list is unknown or fully assigned-and-locked.
    */
-  next (list: string, name?: string, locked = true): string | undefined {
+  next (list: string, name?: string, override?: string): string | undefined {
     const slots = this.lists[list]
 
     if (!slots) {
-      return undefined
+      return override
     }
+
+    const locked = !override
 
     if (name !== undefined) {
       const existing = slots
@@ -80,7 +66,7 @@ export class ColorSet {
       if (existing) {
         existing.locked = locked
 
-        return existing.color
+        return override ?? existing.color
       }
     }
 
@@ -88,13 +74,13 @@ export class ColorSet {
       slots.find(slot => !slot.locked)
 
     if (!slot) {
-      return undefined
+      return override
     }
 
     slot.name = name
     slot.locked = locked
 
-    return slot.color
+    return override ?? slot.color
   }
 
   /**

--- a/src/plugins/colorSet.ts
+++ b/src/plugins/colorSet.ts
@@ -49,8 +49,8 @@ export class ColorSet {
    * left recyclable (so an overridden key never permanently consumes a color).
    * Otherwise returns the color already assigned to `name`, then the next
    * never-assigned color, then the first non-locked (recyclable) color, locking
-   * the assignment until `forceResetAll`. Returns `undefined` only when there is
-   * no override and the list is unknown or fully assigned-and-locked.
+   * the assignment until `forceResetAll`. Falls back to `FALLBACK_COLOR` when
+   * the list is unknown or fully assigned-and-locked and no override is given.
    */
   next (list: string, name?: string, override?: string): string {
     const slots = this.lists[list]

--- a/src/plugins/colorSet.ts
+++ b/src/plugins/colorSet.ts
@@ -1,125 +1,123 @@
-/**
- * A basic class to manage color steps for our graphs.
- */
 import type _Vue from 'vue'
 import { TinyColor } from '@ctrl/tinycolor'
 
+interface ColorGenOption {
+  base: string
+  count: number
+  hsplit?: number
+  lsplit?: number
+}
+
+type PaletteOption = string[] | ColorGenOption
+
+interface ColorSlot {
+  readonly color: string
+  name?: string
+  locked: boolean
+}
+
+const buildPalette = (option: PaletteOption): string[] => {
+  if (Array.isArray(option)) return option
+  const { base, count, hsplit = 0, lsplit = 0 } = option
+
+  const { h, s, l } = new TinyColor(base).toHsl()
+
+  return Array.from({ length: count }, (_, i) =>
+    new TinyColor({
+      h: h + hsplit * i,
+      s,
+      l: l - (lsplit / 100) * i
+    }).toHexString()
+  )
+}
+
+const DEFAULT_PALETTES: Record<string, PaletteOption> = {
+  heater: { base: '#ff5252', hsplit: 20, count: 4 },
+  bed: { base: '#1fb0ff', hsplit: 20, count: 2 },
+  fan: { base: '#4CAF50', hsplit: 20, count: 4 },
+  sensor: ['#D67600', '#830EE3', '#B366F2', '#E06573', '#E38819', '#795548', '#607D8B', '#3F51B5', '#F50057']
+}
+
 export class ColorSet {
-  colorList: ColorList = {}
+  readonly lists: Record<string, ColorSlot[]>
 
-  constructor (options: ColorSetPluginOptions) {
-    if (options.colorList) {
-      for (const item in options.colorList) {
-        if ('base' in options.colorList[item]) {
-          const opts = options.colorList[item]
-          // this.colorList[item] = new Tinycolor(opts.base).analogous(opts.count, 20)
-          //   .map((color: TinyColor) => {
-          //     // const color = new Tinycolor({ h: num, s: 0.8, l: 0.8 }).toHexString()
-          //     return { color: color.toHexString(), used: false }
-          //   })
-          const base = new TinyColor(opts.base).toHsl()
-          let h = base.h
-          let l = base.l
-          const s = base.s
-          const hsplit = opts.hsplit || 0
-          const lsplit = (opts.lsplit) ? opts.lsplit / 100 : 0
-          // let start = 100
-          this.colorList[item] = [
-            ...Array(opts.count).keys()
-          ]
-            .map(() => {
-              const color = new TinyColor({ h, s, l }).toHexString()
-              h = h + hsplit
-              l = l - lsplit
-              return { color, used: false }
-            })
-          // this.colorList[item].unshift({ color: opts.base, used: false })
-        } else {
-          const opts = options.colorList[item]
-          this.colorList[item] = opts.map(color => {
-            return { color, used: false }
-          })
-        }
+  constructor (palettes: Record<string, PaletteOption> = DEFAULT_PALETTES) {
+    this.lists = Object.fromEntries(
+      Object.entries(palettes)
+        .map(([list, option]) => [
+          list,
+          buildPalette(option)
+            .map((color): ColorSlot => ({
+              color,
+              locked: false
+            }))
+        ])
+    )
+  }
+
+  /**
+   * Get a stable color for `name` within `list`.
+   *
+   * Returns the color already assigned to `name`, otherwise the next
+   * never-assigned color, otherwise the first non-locked (recyclable) color, or
+   * `undefined` when the list is unknown or every color is assigned and locked.
+   *
+   * `locked` (default true) keeps the assignment permanent until `forceResetAll`.
+   * Pass false to allow the color to be recycled once the palette is exhausted
+   * (e.g. when the key's display color is overridden elsewhere).
+   */
+  next (list: string, name?: string, locked = true): string | undefined {
+    const slots = this.lists[list]
+
+    if (!slots) {
+      return undefined
+    }
+
+    if (name !== undefined) {
+      const existing = slots
+        .find(slot => slot.name === name)
+
+      if (existing) {
+        existing.locked = locked
+
+        return existing.color
       }
     }
+
+    const slot = slots.find(slot => slot.name === undefined) ??
+      slots.find(slot => !slot.locked)
+
+    if (!slot) {
+      return undefined
+    }
+
+    slot.name = name
+    slot.locked = locked
+
+    return slot.color
   }
 
   /**
-   * Get the next unused color in the given list.
-   */
-  next (list: string, name?: string) {
-    if (this.colorList[list] === undefined) return // not found
-
-    // Return a named color if given
-    const namedColor = this.colorList[list].find(color => color.name === name)
-    if (namedColor) {
-      return namedColor.color
-    }
-
-    // If no more colors, reset non named.
-    if (this.colorList[list].findIndex(color => !color.used) >= 0) {
-      this.reset(list)
-    }
-
-    for (const color of this.colorList[list]) {
-      if (color.used) continue
-      if (name) color.name = name
-      color.used = true
-      return color.color
-    }
-  }
-
-  /**
-   * Reset the used state for all colors given a list.
-   */
-  reset (list: string, force = false): void {
-    if (this.colorList[list] === undefined) return // not found
-    this.colorList[list].forEach(color => {
-      // don't reset colors that have a name, unless forced.
-      if (!color.name || force) {
-        color.used = false
-        delete color.name
-      }
-    })
-  }
-
-  /**
-   * Reset all color sets.
-   */
-  resetAll (): void {
-    for (const list in this.colorList) {
-      this.reset(list)
-    }
-  }
-
-  /**
-   * Force reset all color sets.
-   * This also clears colors given a name.
+   * Clear every color assignment so all palettes start fresh.
    */
   forceResetAll (): void {
-    for (const list in this.colorList) {
-      this.reset(list, true)
+    for (const slots of Object.values(this.lists)) {
+      for (const slot of slots) {
+        slot.name = undefined
+        slot.locked = false
+      }
     }
   }
 }
 
 export const ColorSetPlugin = {
-  install (Vue: typeof _Vue, options?: ColorSetPluginOptions) {
-    // Provide a specific list, or an option object to
-    // define the color lists.
-    const opts: ColorSetPluginOptions = {
-      colorList: {
-        heater: { base: '#ff5252', hsplit: 20, count: 3 },
-        bed: { base: '#1fb0ff', hsplit: 20, count: 2 },
-        fan: ['#3DC25A', '#58FC7C', '#10EB40', '#7EF297'],
-        sensor: ['#D67600', '#830EE3', '#B366F2', '#E06573', '#E38819', '#795548', '#607D8B', '#3F51B5']
-      }
-    }
-    const colorset = new ColorSet({ ...opts, ...options })
+  install (Vue: typeof _Vue) {
+    const colorset = new ColorSet()
     Vue.prototype.$colorset = colorset
     Vue.$colorset = colorset
   }
 }
+
 declare module 'vue/types/vue' {
   interface Vue {
     $colorset: ColorSet;
@@ -128,29 +126,4 @@ declare module 'vue/types/vue' {
   interface VueConstructor {
     $colorset: ColorSet;
   }
-}
-
-interface ColorSetPluginOptions {
-  colorList?: ColorListOption;
-}
-
-interface ColorListOption {
-  [index: string]: string[] | ColorGenOption;
-}
-
-interface ColorGenOption {
-  base: string;
-  count: number;
-  hsplit?: number;
-  lsplit?: number;
-}
-
-interface ColorList {
-  [index: string]: Color[];
-}
-
-interface Color {
-  name?: string; // allow lookups of a color given its name.
-  color: string;
-  used: boolean;
 }

--- a/src/plugins/colorSet.ts
+++ b/src/plugins/colorSet.ts
@@ -2,6 +2,8 @@ import type _Vue from 'vue'
 import { TinyColor } from '@ctrl/tinycolor'
 import { DefaultPalettes, type PaletteOption } from '@/globals'
 
+const FALLBACK_COLOR = '#2196F3'
+
 interface ColorSlot {
   readonly color: string
   name?: string
@@ -50,11 +52,11 @@ export class ColorSet {
    * the assignment until `forceResetAll`. Returns `undefined` only when there is
    * no override and the list is unknown or fully assigned-and-locked.
    */
-  next (list: string, name?: string, override?: string): string | undefined {
+  next (list: string, name?: string, override?: string): string {
     const slots = this.lists[list]
 
     if (!slots) {
-      return override
+      return override ?? FALLBACK_COLOR
     }
 
     const locked = !override
@@ -74,7 +76,7 @@ export class ColorSet {
       slots.find(slot => !slot.locked)
 
     if (!slot) {
-      return override
+      return override ?? FALLBACK_COLOR
     }
 
     slot.name = name

--- a/src/store/config/actions.ts
+++ b/src/store/config/actions.ts
@@ -7,6 +7,7 @@ import { loadLocaleMessagesAsync, getStartingLocale } from '@/plugins/i18n'
 import { Waits } from '@/globals'
 import type { FileFilterType } from '../files/types'
 import { TinyColor } from '@ctrl/tinycolor'
+import dbKey from '@/util/db-key'
 
 export const actions = {
   /**
@@ -151,7 +152,7 @@ export const actions = {
    */
   async updateSensorColor ({ commit }, payload: { key: string; color: string }) {
     commit('setSensorColor', payload)
-    SocketActions.serverDatabasePostItem(`uiSettings.dashboard.sensorColors.${payload.key}`, payload.color)
+    SocketActions.serverDatabasePostItem(dbKey`uiSettings.dashboard.sensorColors.${payload.key}`, payload.color)
   },
 
   /**
@@ -163,23 +164,23 @@ export const actions = {
     const existed = payload.key in state.uiSettings.dashboard.sensorColors
     commit('setRemoveSensorColor', payload)
     if (existed) {
-      SocketActions.serverDatabaseDeleteItem(`uiSettings.dashboard.sensorColors.${payload.key}`)
+      SocketActions.serverDatabaseDeleteItem(dbKey`uiSettings.dashboard.sensorColors.${payload.key}`)
     }
   },
 
   async updateFileSystemActiveFilters ({ commit, state }, payload: { root: string, value: FileFilterType[] }) {
     commit('setFileSystemActiveFilters', payload)
-    SocketActions.serverDatabasePostItem(`uiSettings.fileSystem.activeFilters.${payload.root}`, state.uiSettings.fileSystem.activeFilters[payload.root])
+    SocketActions.serverDatabasePostItem(dbKey`uiSettings.fileSystem.activeFilters.${payload.root}`, state.uiSettings.fileSystem.activeFilters[payload.root])
   },
 
   async updateFileSystemSortBy ({ commit, state }, payload: { root: string, value: string | null }) {
     commit('setFileSystemSortBy', payload)
-    SocketActions.serverDatabasePostItem(`uiSettings.fileSystem.sortBy.${payload.root}`, state.uiSettings.fileSystem.sortBy[payload.root])
+    SocketActions.serverDatabasePostItem(dbKey`uiSettings.fileSystem.sortBy.${payload.root}`, state.uiSettings.fileSystem.sortBy[payload.root])
   },
 
   async updateFileSystemSortDesc ({ commit, state }, payload: { root: string, value: boolean | null }) {
     commit('setFileSystemSortDesc', payload)
-    SocketActions.serverDatabasePostItem(`uiSettings.fileSystem.sortDesc.${payload.root}`, state.uiSettings.fileSystem.sortDesc[payload.root])
+    SocketActions.serverDatabasePostItem(dbKey`uiSettings.fileSystem.sortDesc.${payload.root}`, state.uiSettings.fileSystem.sortDesc[payload.root])
   },
 
   /**
@@ -189,7 +190,7 @@ export const actions = {
     commit('setUpdateHeader', payload)
 
     if (state.uiSettings.tableHeaders[payload.name]) {
-      SocketActions.serverDatabasePostItem(`uiSettings.tableHeaders.${payload.name}`, state.uiSettings.tableHeaders[payload.name])
+      SocketActions.serverDatabasePostItem(dbKey`uiSettings.tableHeaders.${payload.name}`, state.uiSettings.tableHeaders[payload.name])
     }
   },
 
@@ -197,7 +198,7 @@ export const actions = {
     commit('setUpdateHeaders', payload)
 
     if (state.uiSettings.tableHeaders[payload.name]) {
-      SocketActions.serverDatabasePostItem(`uiSettings.tableHeaders.${payload.name}`, state.uiSettings.tableHeaders[payload.name])
+      SocketActions.serverDatabasePostItem(dbKey`uiSettings.tableHeaders.${payload.name}`, state.uiSettings.tableHeaders[payload.name])
     }
   },
 
@@ -205,7 +206,7 @@ export const actions = {
     commit('setUpdateThumbnailSizes', payload)
 
     if (state.uiSettings.thumbnailSizes[payload.name]) {
-      SocketActions.serverDatabasePostItem(`uiSettings.thumbnailSizes.${payload.name}`, state.uiSettings.thumbnailSizes[payload.name])
+      SocketActions.serverDatabasePostItem(dbKey`uiSettings.thumbnailSizes.${payload.name}`, state.uiSettings.thumbnailSizes[payload.name])
     }
   },
 

--- a/src/store/config/actions.ts
+++ b/src/store/config/actions.ts
@@ -146,6 +146,27 @@ export const actions = {
     SocketActions.serverDatabasePostItem('uiSettings.dashboard.tempPresets', state.uiSettings.dashboard.tempPresets)
   },
 
+  /**
+   * Set or update the color override for a temperature item
+   */
+  async updateSensorColor ({ commit }, payload: { key: string; color: string }) {
+    commit('setSensorColor', payload)
+    SocketActions.serverDatabasePostItem(`uiSettings.dashboard.sensorColors.${payload.key}`, payload.color)
+  },
+
+  /**
+   * Remove the color override for a temperature item
+   */
+  async removeSensorColor ({ commit, state }, payload: { key: string }) {
+    // Guard: delete_item errors on a key Moonraker never stored, so only fire the
+    // network delete when an override actually existed.
+    const existed = payload.key in state.uiSettings.dashboard.sensorColors
+    commit('setRemoveSensorColor', payload)
+    if (existed) {
+      SocketActions.serverDatabaseDeleteItem(`uiSettings.dashboard.sensorColors.${payload.key}`)
+    }
+  },
+
   async updateFileSystemActiveFilters ({ commit, state }, payload: { root: string, value: FileFilterType[] }) {
     commit('setFileSystemActiveFilters', payload)
     SocketActions.serverDatabasePostItem(`uiSettings.fileSystem.activeFilters.${payload.root}`, state.uiSettings.fileSystem.activeFilters[payload.root])

--- a/src/store/config/mutations.ts
+++ b/src/store/config/mutations.ts
@@ -160,6 +160,20 @@ export const mutations = {
     state.uiSettings.dashboard.tempPresets.splice(i, 1)
   },
 
+  /**
+   * Set / update a temperature item color override
+   */
+  setSensorColor (state, payload: { key: string; color: string }) {
+    Vue.set(state.uiSettings.dashboard.sensorColors, payload.key, payload.color)
+  },
+
+  /**
+   * Remove a temperature item color override
+   */
+  setRemoveSensorColor (state, payload: { key: string }) {
+    Vue.delete(state.uiSettings.dashboard.sensorColors, payload.key)
+  },
+
   setFileSystemActiveFilters (state, payload: { root: string, value: FileFilterType[] }) {
     Vue.set(state.uiSettings.fileSystem.activeFilters, payload.root, payload.value)
   },

--- a/src/store/config/state.ts
+++ b/src/store/config/state.ts
@@ -89,7 +89,8 @@ export const defaultState = (): ConfigState => {
         klipperSaveAndRestartAction: 'auto'
       },
       dashboard: {
-        tempPresets: []
+        tempPresets: [],
+        sensorColors: {}
       },
       tableHeaders: {},
       thumbnailSizes: {},

--- a/src/store/config/types.ts
+++ b/src/store/config/types.ts
@@ -206,6 +206,7 @@ export interface AxisConfig {
 
 export interface DashboardConfig {
   tempPresets: TemperaturePreset[];
+  sensorColors: Record<string, string>;
 }
 
 export interface SaveByPath {

--- a/src/store/printer/getters.ts
+++ b/src/store/printer/getters.ts
@@ -19,6 +19,9 @@ const configHasDisconnectedMcu = (config: Record<string, any> | undefined, disco
   false
 )
 
+const resolveSensorColor = (sensorColors: Record<string, string>, key: string): string | undefined =>
+  Vue.$colorset.next(getKlipperType(key), key, sensorColors[key])
+
 export const getters = {
 
   /**
@@ -575,8 +578,9 @@ export const getters = {
   /**
    * Return available heaters
    */
-  getHeaters: (state, getters): Heater[] => {
+  getHeaters: (state, getters, rootState): Heater[] => {
     const nonCriticalDisconnectedMcusSet: Set<string> = getters.getNonCriticalDisconnectedMcusSet
+    const sensorColors: Record<string, string> = rootState.config.uiSettings.dashboard.sensorColors
 
     const heaters: Heater[] = []
 
@@ -592,7 +596,7 @@ export const getters = {
         const nameFromSplit = restSplit.pop()
         const name = nameFromSplit || key
 
-        const color = Vue.$colorset.next(getKlipperType(key), key)
+        const color = resolveSensorColor(sensorColors, key)
         const prettyName = Vue.$filters.prettyCase(name)
 
         const disconnected = configHasDisconnectedMcu(config, nonCriticalDisconnectedMcusSet)
@@ -656,7 +660,9 @@ export const getters = {
   /**
   * Return available fans and output pins
   */
-  getOutputs: (state, getters) => (filter?: string[]): Array<Fan | Led | OutputPin> => {
+  getOutputs: (state, getters, rootState) => (filter?: string[]): Array<Fan | Led | OutputPin> => {
+    const sensorColors: Record<string, string> = rootState.config.uiSettings.dashboard.sensorColors
+
     // Fans..
     const fans = [
       'temperature_fan',
@@ -738,8 +744,8 @@ export const getters = {
           ? 'Part Fan' // If we know its the part fan.
           : Vue.$filters.prettyCase(name)
 
-        const color = (applyColor.includes(type))
-          ? Vue.$colorset.next(getKlipperType(key), key)
+        const color = applyColor.includes(type)
+          ? resolveSensorColor(sensorColors, key)
           : undefined
 
         const config = state.printer.configfile.settings[key.toLowerCase()]
@@ -787,7 +793,7 @@ export const getters = {
   /**
    * Return available temperature probes / sensors.
    */
-  getSensors: (state, getters): Sensor[] => {
+  getSensors: (state, getters, rootState): Sensor[] => {
     const keyGroups = [
       (key: string) => (
         key.startsWith('temperature_sensor ') ||
@@ -797,6 +803,7 @@ export const getters = {
       (key: string) => key === 'z_thermal_adjust'
     ]
     const nonCriticalDisconnectedMcusSet: Set<string> = getters.getNonCriticalDisconnectedMcusSet
+    const sensorColors: Record<string, string> = rootState.config.uiSettings.dashboard.sensorColors
 
     const printerKeys = Object.keys(state.printer)
 
@@ -819,7 +826,7 @@ export const getters = {
                         : Vue.$filters.prettyCase(name)
                   }).toString()
                 : Vue.$filters.prettyCase(name)
-              const color = Vue.$colorset.next(getKlipperType(key), key)
+              const color = resolveSensorColor(sensorColors, key)
               const config = state.printer.configfile.settings[key.toLowerCase()]
 
               const disconnected = configHasDisconnectedMcu(config, nonCriticalDisconnectedMcusSet)

--- a/src/store/printer/getters.ts
+++ b/src/store/printer/getters.ts
@@ -19,7 +19,7 @@ const configHasDisconnectedMcu = (config: Record<string, any> | undefined, disco
   false
 )
 
-const resolveSensorColor = (sensorColors: Record<string, string>, key: string): string | undefined =>
+const resolveSensorColor = (sensorColors: Record<string, string>, key: string): string =>
   Vue.$colorset.next(getKlipperType(key), key, sensorColors[key])
 
 export const getters = {

--- a/src/util/__tests__/db-key.spec.ts
+++ b/src/util/__tests__/db-key.spec.ts
@@ -1,0 +1,45 @@
+import dbKey from '../db-key'
+
+describe('dbKey', () => {
+  it.each([
+    [dbKey`uiSettings`, ['uiSettings']],
+    [dbKey`uiSettings.dashboard`, ['uiSettings', 'dashboard']],
+    [dbKey`uiSettings.dashboard.sensorColors`, ['uiSettings', 'dashboard', 'sensorColors']],
+  ])('splits static dotted key %s into segments', (result, expected) => {
+    expect(result).toStrictEqual(expected)
+  })
+
+  it('appends a simple dynamic value as a single segment', () => {
+    const key = 'extruder'
+    expect(dbKey`uiSettings.dashboard.sensorColors.${key}`).toStrictEqual([
+      'uiSettings', 'dashboard', 'sensorColors', 'extruder',
+    ])
+  })
+
+  it('keeps dots inside a dynamic value unsplit', () => {
+    const key = 'temperature_sensor my.sensor'
+    expect(dbKey`uiSettings.dashboard.sensorColors.${key}`).toStrictEqual([
+      'uiSettings', 'dashboard', 'sensorColors', 'temperature_sensor my.sensor',
+    ])
+  })
+
+  it('handles a dynamic value in the middle of the key', () => {
+    const root = 'gcodes'
+    expect(dbKey`uiSettings.fileSystem.activeFilters.${root}.extra`).toStrictEqual([
+      'uiSettings', 'fileSystem', 'activeFilters', 'gcodes', 'extra',
+    ])
+  })
+
+  it('handles multiple dynamic values', () => {
+    const ns = 'dashboard'
+    const key = 'my.heater'
+    expect(dbKey`uiSettings.${ns}.sensorColors.${key}`).toStrictEqual([
+      'uiSettings', 'dashboard', 'sensorColors', 'my.heater',
+    ])
+  })
+
+  it('filters out empty segments from leading, trailing, or consecutive dots', () => {
+    const key = 'value'
+    expect(dbKey`..a..b..${key}..`).toStrictEqual(['a', 'b', 'value'])
+  })
+})

--- a/src/util/db-key.ts
+++ b/src/util/db-key.ts
@@ -1,0 +1,19 @@
+const dbKey = (strings: TemplateStringsArray, ...values: string[]) => {
+  const result: string[] = []
+
+  for (let index = 0; index < strings.length; index++) {
+    const parts = strings[index]
+      .split('.')
+      .filter(Boolean)
+
+    result.push(...parts)
+
+    if (index < values.length) {
+      result.push(values[index])
+    }
+  }
+
+  return result
+}
+
+export default dbKey


### PR DESCRIPTION
Adds per-sensor color overrides for the Thermals widget, resolving two long-standing issues.

Users can now click the color icon next to any sensor, heater, or fan in the Thermals list to pick a custom color. Colors persist across sessions via Moonraker's database and can be reset to the palette default at any time.

Also fixes a pre-existing bug where `notMerge: true` on the chart's update options would blank the chart for ~1 second whenever the theme or viewport changed.

## Screengrab

https://github.com/user-attachments/assets/277c01b7-0f87-40ca-a069-1d079374993b

Resolves #534
Resolves #1866