### PR TITLE
refactor: sandboxedEval context support

### DIFF
--- a/src/components/widgets/diagnostics/config/MetricsCollectorConfig.vue
+++ b/src/components/widgets/diagnostics/config/MetricsCollectorConfig.vue
@@ -93,9 +93,14 @@ export default class MetricsCollectorConfig extends Vue {
   async runCollector () {
     try {
       const data = await sandboxedEval(`
-        const printer = ${JSON.stringify(this.$typedState.printer.printer)}
-        return eval(${JSON.stringify(this.metric.collector)})
-      `)
+        const { printer, collector } = context
+        return eval(collector)
+      `, {
+        context: {
+          printer: this.$typedState.printer.printer,
+          collector: this.metric.collector
+        }
+      })
 
       this.result = String(
         typeof data === 'number'

--- a/src/plugins/sandboxedEval.ts
+++ b/src/plugins/sandboxedEval.ts
@@ -4,7 +4,15 @@ import SandboxedEvalWorker from '@/workers/sandboxedEval.worker?ts?worker'
 
 const workers: Record<string, Worker> = {}
 
-const sandboxedEval = async (code: string, feature?: string, timeout = 800): Promise<unknown> => {
+export interface SandboxedEvalOptions {
+  feature?: string;
+  timeout?: number;
+  context?: unknown;
+}
+
+const sandboxedEval = async (code: string, options?: SandboxedEvalOptions): Promise<unknown> => {
+  const { feature, timeout = 800, context } = options ?? {}
+
   const id = Date.now()
   const worker = getWorker(feature)
 
@@ -51,6 +59,7 @@ const sandboxedEval = async (code: string, feature?: string, timeout = 800): Pro
 
   const message: SandboxedEvalWorkerRequestMessage = {
     code,
+    context,
     id
   }
 

--- a/src/store/printer/actions.ts
+++ b/src/store/printer/actions.ts
@@ -14,8 +14,7 @@ import i18n from '@/plugins/i18n'
 const evalCollectors = async (printer: Klipper.PrinterState, collectors: string[]): Promise<Record<string, unknown>> => {
   try {
     const data = await sandboxedEval(`
-    const printer = ${JSON.stringify(printer)}
-    const collectors = ${JSON.stringify(collectors)}
+    const { printer, collectors } = context
     const result = {}
 
     for (const collector of collectors) {
@@ -27,7 +26,13 @@ const evalCollectors = async (printer: Klipper.PrinterState, collectors: string[
     }
 
     return result
-  `, 'metrics') as Record<string, unknown>
+  `, {
+      feature: 'metrics',
+      context: {
+        printer,
+        collectors
+      }
+    }) as Record<string, unknown>
 
     return data
   } catch (e) {

--- a/src/workers/sandboxedEval.worker.ts
+++ b/src/workers/sandboxedEval.worker.ts
@@ -2,6 +2,7 @@ import { consola } from 'consola'
 
 export type SandboxedEvalWorkerRequestMessage = {
   code: string,
+  context?: unknown,
   id?: unknown
 }
 
@@ -73,7 +74,8 @@ self.onmessage = async (event: MessageEvent<SandboxedEvalWorkerRequestMessage>) 
 
   try {
     // eslint-disable-next-line no-eval
-    const result = (0, eval)(`(function (self) { ${message.code} })(null)`)
+    const fn = (0, eval)(`(function (self, context) { ${message.code} })`)
+    const result = fn(null, message.context)
 
     sendResult(result, message.id)
   } catch (e) {


### PR DESCRIPTION
As `sandboxedEval` now uses a worker, we don't need to serialize the printer state and deserialize in the worker as it will always receive a copy of the state anyway.

As such, we've now refactored `sandboxedEval` so we can just pass everything as an object that will be copied into the worker automatically.