### PR TITLE
refactor: freeze immutable entries

### DIFF
--- a/src/store/announcements/mutations.ts
+++ b/src/store/announcements/mutations.ts
@@ -1,4 +1,3 @@
-import Vue from 'vue'
 import type { MutationTree } from 'vuex'
 import { defaultState } from './state'
 import type { AnnouncementsState } from './types'
@@ -36,6 +35,6 @@ export const mutations = {
       }
     }
 
-    Vue.set(state, 'entries', entries)
+    state.entries = entries
   }
 } satisfies MutationTree<AnnouncementsState>

--- a/src/store/config/mutations.ts
+++ b/src/store/config/mutations.ts
@@ -51,7 +51,7 @@ export const mutations = {
         (dest, src) => Array.isArray(dest) ? src : undefined
       )
 
-      Vue.set(state, 'uiSettings', mergedSettings)
+      state.uiSettings = mergedSettings
     }
   },
 
@@ -107,7 +107,7 @@ export const mutations = {
       })
     }
     localStorage.setItem(Globals.LOCAL_INSTANCES_STORAGE_KEY, JSON.stringify(instances))
-    Vue.set(state, 'instances', instances)
+    state.instances = instances
   },
 
   setUpdateInstanceName (state, payload) {
@@ -120,12 +120,10 @@ export const mutations = {
   },
 
   setRemoveInstance (state, payload) {
-    const instances = state.instances
-    const i = instances.findIndex((instance: InstanceConfig) => instance.apiUrl === payload.apiUrl)
-    if (i >= 0) {
-      instances.splice(i, 1)
-      Vue.set(state, 'instances', instances)
-      localStorage.setItem(Globals.LOCAL_INSTANCES_STORAGE_KEY, JSON.stringify(instances))
+    const index = state.instances.findIndex((instance: InstanceConfig) => instance.apiUrl === payload.apiUrl)
+    if (index >= 0) {
+      state.instances.splice(index, 1)
+      localStorage.setItem(Globals.LOCAL_INSTANCES_STORAGE_KEY, JSON.stringify(state.instances))
     }
   },
 

--- a/src/store/console/mutations.ts
+++ b/src/store/console/mutations.ts
@@ -36,7 +36,7 @@ export const mutations = {
     while (state.console.length >= Globals.CONSOLE_HISTORY_RETENTION) {
       state.console.shift()
     }
-    state.console.push(entry)
+    state.console.push(Object.freeze(entry))
   },
 
   /**
@@ -45,6 +45,7 @@ export const mutations = {
   setAllEntries (state, payload: ConsoleEntry[]) {
     state.consoleEntryCount = payload.length
     state.console = payload
+      .map(entry => Object.freeze(entry))
   },
 
   setResetPromptDialog (state, payload: string) {

--- a/src/store/console/mutations.ts
+++ b/src/store/console/mutations.ts
@@ -163,6 +163,6 @@ export const mutations = {
   },
 
   setLastCleared (state) {
-    Vue.set(state, 'lastCleared', Date.now())
+    state.lastCleared = Date.now()
   }
 } satisfies MutationTree<ConsoleState>

--- a/src/store/database/mutations.ts
+++ b/src/store/database/mutations.ts
@@ -1,4 +1,3 @@
-import Vue from 'vue'
 import type { MutationTree } from 'vuex'
 import { defaultState } from './state'
 import type { DatabaseInfo, DatabaseState } from './types'
@@ -10,7 +9,7 @@ export const mutations = {
   },
 
   setServerDatabaseList (state, payload: DatabaseInfo) {
-    Vue.set(state, 'info', payload)
+    state.info = payload
   },
 
   setServerDatabasePostBackup (state, payload: { backup_path: string }) {

--- a/src/store/files/mutations.ts
+++ b/src/store/files/mutations.ts
@@ -21,7 +21,7 @@ export const mutations = {
     }
 
     if (state.currentPaths[root]) {
-      Vue.set(state.currentPaths, root, undefined)
+      Vue.delete(state.currentPaths, root)
     }
   },
 

--- a/src/store/macros/mutations.ts
+++ b/src/store/macros/mutations.ts
@@ -93,6 +93,6 @@ export const mutations = {
   },
 
   setExpanded (state, expanded: number[]) {
-    Vue.set(state, 'expanded', expanded)
+    state.expanded = expanded
   }
 } satisfies MutationTree<MacrosState>

--- a/src/store/notifications/mutations.ts
+++ b/src/store/notifications/mutations.ts
@@ -34,6 +34,6 @@ export const mutations = {
   },
 
   setClearAllNotifications (state) {
-    Vue.set(state, 'notifications', [...state.notifications.filter(n => !n.clear)])
+    state.notifications = [...state.notifications.filter(n => !n.clear)]
   }
 } satisfies MutationTree<NotificationsState>

--- a/src/store/notifications/mutations.ts
+++ b/src/store/notifications/mutations.ts
@@ -34,6 +34,7 @@ export const mutations = {
   },
 
   setClearAllNotifications (state) {
-    state.notifications = [...state.notifications.filter(n => !n.clear)]
+    state.notifications = state.notifications
+      .filter(n => !n.clear)
   }
 } satisfies MutationTree<NotificationsState>

--- a/src/store/power/mutations.ts
+++ b/src/store/power/mutations.ts
@@ -1,4 +1,3 @@
-import Vue from 'vue'
 import type { MutationTree } from 'vuex'
 import type { DevicePowerState } from './types'
 import { defaultState } from './state'
@@ -19,7 +18,7 @@ export const mutations = {
     for (const key in payload) {
       const i = state.devices.findIndex(device => device.device === key)
       if (i >= 0) {
-        Vue.set(state.devices[i], 'status', payload[key])
+        state.devices[i].status = payload[key]
       }
     }
   }

--- a/src/store/sensors/actions.ts
+++ b/src/store/sensors/actions.ts
@@ -18,7 +18,7 @@ export const actions = {
     }
   },
 
-  async onSensorUpdate ({ commit }, payload: Record<string, Moonraker.Sensor.Entry>) {
+  async onSensorUpdate ({ commit }, payload: Record<string, Moonraker.Sensor.Values>) {
     if (payload) {
       commit('setSensorUpdate', payload)
     }

--- a/src/store/sensors/actions.ts
+++ b/src/store/sensors/actions.ts
@@ -12,7 +12,7 @@ export const actions = {
     SocketActions.serverSensorsList()
   },
 
-  async onSensorsList ({ commit }, payload: { sensors: Moonraker.Sensor.ListResponse }) {
+  async onSensorsList ({ commit }, payload: Moonraker.Sensor.ListResponse) {
     if (payload) {
       commit('setSensorsList', payload)
     }

--- a/src/store/sensors/mutations.ts
+++ b/src/store/sensors/mutations.ts
@@ -1,4 +1,3 @@
-import Vue from 'vue'
 import type { MutationTree } from 'vuex'
 import type { MoonrakerSensorsState } from './types'
 import { defaultState } from './state'
@@ -12,12 +11,15 @@ export const mutations = {
   },
 
   setSensorsList (state, payload: Moonraker.Sensor.ListResponse) {
+    for (const sensorKey in payload.sensors) {
+      payload.sensors[sensorKey].values = Object.freeze(payload.sensors[sensorKey].values)
+    }
     state.sensors = payload.sensors
   },
 
   setSensorUpdate (state, payload: Record<string, Moonraker.Sensor.Entry>) {
     for (const sensorKey in payload) {
-      Vue.set(state.sensors[sensorKey], 'values', payload[sensorKey])
+      state.sensors[sensorKey].values = Object.freeze(payload[sensorKey])
     }
   }
 } satisfies MutationTree<MoonrakerSensorsState>

--- a/src/store/sensors/mutations.ts
+++ b/src/store/sensors/mutations.ts
@@ -17,7 +17,7 @@ export const mutations = {
     state.sensors = payload.sensors
   },
 
-  setSensorUpdate (state, payload: Record<string, Moonraker.Sensor.Entry>) {
+  setSensorUpdate (state, payload: Record<string, Moonraker.Sensor.Values>) {
     for (const sensorKey in payload) {
       state.sensors[sensorKey].values = Object.freeze(payload[sensorKey])
     }

--- a/src/store/sensors/mutations.ts
+++ b/src/store/sensors/mutations.ts
@@ -11,10 +11,16 @@ export const mutations = {
   },
 
   setSensorsList (state, payload: Moonraker.Sensor.ListResponse) {
-    for (const sensorKey in payload.sensors) {
-      payload.sensors[sensorKey].values = Object.freeze(payload.sensors[sensorKey].values)
-    }
-    state.sensors = payload.sensors
+    state.sensors = Object.fromEntries(
+      Object.entries(payload.sensors)
+        .map(([key, entry]) => [
+          key,
+          {
+            ...entry,
+            values: Object.freeze(entry.values)
+          }
+        ])
+    )
   },
 
   setSensorUpdate (state, payload: Record<string, Moonraker.Sensor.Values>) {


### PR DESCRIPTION
Minor optimization by freezing immutable entries on Console and Sensors store.

Also includes:
- Fix `setSensorUpdate` payload type from `Record<string, Moonraker.Sensor.Entry>` to `Record<string, Moonraker.Sensor.Values>`, matching what Moonraker actually sends in update notifications
- Remove redundant `Vue.set` calls across store mutations where the property already exists in initial state (plain assignment is sufficient and clearer)
- Replace `Vue.set(state.currentPaths, root, undefined)` with `Vue.delete` in `files/mutations.ts` (correct semantics for key removal)