### PR TITLE
refactor: type store action/mutation payloads

### DIFF
--- a/src/components/settings/auth/AddUserDialog.vue
+++ b/src/components/settings/auth/AddUserDialog.vue
@@ -1,17 +1,16 @@
 <template>
   <app-dialog
     v-model="open"
-    :title="(user.created_on) ? $t('app.general.label.edit_user') : $t('app.general.label.add_user')"
-    :save-button-text="(user.created_on) ? $t('app.general.btn.save') : $t('app.general.btn.add')"
+    :title="$t('app.general.label.add_user')"
+    :save-button-text="$t('app.general.btn.add')"
     max-width="500"
     @save="handleSave"
   >
     <v-card-text class="pa-0">
       <app-setting :title="$t('app.general.label.name')">
         <v-text-field
-          v-model="user.username"
+          v-model="username"
           autocomplete="username"
-          :disabled="(user.created_on)"
           filled
           dense
           spellcheck="false"
@@ -28,8 +27,7 @@
 
       <app-setting :title="$t('app.general.label.password')">
         <v-text-field
-          v-model="user.password"
-          autocomplete="current-password"
+          v-model="password"
           filled
           dense
           type="password"
@@ -38,7 +36,7 @@
           :rules="[
             $rules.required,
             $rules.lengthGreaterThanOrEqual(4),
-            $rules.passwordNotEqualUsername(user.username)
+            $rules.passwordNotEqualUsername(username)
           ]"
         />
       </app-setting>
@@ -47,19 +45,22 @@
 </template>
 
 <script lang="ts">
-import { Component, Vue, Prop, VModel } from 'vue-property-decorator'
-import type { AppUserWithPassword } from '@/store/auth/types'
+import { Component, Vue, VModel } from 'vue-property-decorator'
 
 @Component({})
-export default class UserConfigDialog extends Vue {
+export default class AddUserDialog extends Vue {
   @VModel({ type: Boolean })
   open?: boolean
 
-  @Prop({ type: Object, required: true })
-  readonly user!: AppUserWithPassword
+  username: string = ''
+  password: string = ''
 
   handleSave () {
-    this.$emit('save', this.user)
+    this.$emit('save', {
+      username: this.username,
+      password: this.password
+    })
+
     this.open = false
   }
 }

--- a/src/components/settings/auth/AuthSettings.vue
+++ b/src/components/settings/auth/AuthSettings.vue
@@ -92,7 +92,7 @@
 </template>
 
 <script lang="ts">
-import type { AppUser } from '@/store/auth/types'
+import type { AppUser, AppUserWithPassword } from '@/store/auth/types'
 import { Component, Vue } from 'vue-property-decorator'
 import UserConfigDialog from './UserConfigDialog.vue'
 import ApiKeyDialog from './ApiKeyDialog.vue'
@@ -135,14 +135,6 @@ export default class AuthSettings extends Vue {
     }
   }
 
-  handleEditUserDialog (user: AppUser) {
-    this.userDialogState = {
-      open: true,
-      user,
-      handler: this.handleSaveUser
-    }
-  }
-
   handleApiKeyDialog () {
     this.apiKeyDialogState.open = true
   }
@@ -158,7 +150,7 @@ export default class AuthSettings extends Vue {
     }
   }
 
-  async handleSaveUser (user: AppUser) {
+  async handleSaveUser (user: AppUserWithPassword) {
     await this.$typedDispatch('auth/addUser', user)
 
     // We only want to check trust if this is the first user being added.

--- a/src/components/settings/auth/AuthSettings.vue
+++ b/src/components/settings/auth/AuthSettings.vue
@@ -139,10 +139,13 @@ export default class AuthSettings extends Vue {
   }
 
   async handleSaveUser (user: { username: string, password: string }) {
+    const isFirstUser = this.users.length === 0
+
     await SocketActions.accessPostUser(user.username, user.password)
 
-    // We only want to check trust if this is the first user being added.
-    if (this.users.length === 0) this.$typedDispatch('auth/checkTrust')
+    if (isFirstUser) {
+      this.$typedDispatch('auth/checkTrust')
+    }
   }
 }
 </script>

--- a/src/components/settings/auth/AuthSettings.vue
+++ b/src/components/settings/auth/AuthSettings.vue
@@ -76,46 +76,38 @@
         />
       </template>
 
-      <user-config-dialog
-        v-if="userDialogState.open"
-        v-model="userDialogState.open"
-        :user="userDialogState.user"
-        @save="userDialogState.handler"
+      <add-user-dialog
+        v-if="addUserDialogOpen"
+        v-model="addUserDialogOpen"
+        @save="handleSaveUser"
       />
 
       <api-key-dialog
-        v-if="apiKeyDialogState.open"
-        v-model="apiKeyDialogState.open"
+        v-if="apiKeyDialogOpen"
+        v-model="apiKeyDialogOpen"
       />
     </v-card>
   </div>
 </template>
 
 <script lang="ts">
-import type { AppUser, AppUserWithPassword } from '@/store/auth/types'
+import type { AppUser } from '@/store/auth/types'
 import { Component, Vue } from 'vue-property-decorator'
-import UserConfigDialog from './UserConfigDialog.vue'
+import AddUserDialog from './AddUserDialog.vue'
 import ApiKeyDialog from './ApiKeyDialog.vue'
+import { SocketActions } from '@/api/socketActions'
 
 @Component({
   components: {
-    UserConfigDialog,
+    AddUserDialog,
     ApiKeyDialog
   }
 })
 export default class AuthSettings extends Vue {
   search = ''
   categoryId?: string = undefined
-
-  userDialogState: any = {
-    open: false,
-    user: null,
-    handler: null
-  }
-
-  apiKeyDialogState: any = {
-    open: false
-  }
+  addUserDialogOpen = false
+  apiKeyDialogOpen = false
 
   get users (): AppUser[] {
     return this.$typedState.auth.users
@@ -128,15 +120,11 @@ export default class AuthSettings extends Vue {
   }
 
   handleAddUserDialog () {
-    this.userDialogState = {
-      open: true,
-      user: { username: '', password: '' },
-      handler: this.handleSaveUser
-    }
+    this.addUserDialogOpen = true
   }
 
   handleApiKeyDialog () {
-    this.apiKeyDialogState.open = true
+    this.apiKeyDialogOpen = true
   }
 
   async handleRemoveUser (user: AppUser) {
@@ -146,12 +134,12 @@ export default class AuthSettings extends Vue {
     )
 
     if (result) {
-      this.$typedDispatch('auth/removeUser', user)
+      await SocketActions.accessDeleteUser(user.username)
     }
   }
 
-  async handleSaveUser (user: AppUserWithPassword) {
-    await this.$typedDispatch('auth/addUser', user)
+  async handleSaveUser (user: { username: string, password: string }) {
+    await SocketActions.accessPostUser(user.username, user.password)
 
     // We only want to check trust if this is the first user being added.
     if (this.users.length === 0) this.$typedDispatch('auth/checkTrust')

--- a/src/components/settings/auth/UserConfigDialog.vue
+++ b/src/components/settings/auth/UserConfigDialog.vue
@@ -48,7 +48,7 @@
 
 <script lang="ts">
 import { Component, Vue, Prop, VModel } from 'vue-property-decorator'
-import type { AppUser } from '@/store/auth/types'
+import type { AppUserWithPassword } from '@/store/auth/types'
 
 @Component({})
 export default class UserConfigDialog extends Vue {
@@ -56,7 +56,7 @@ export default class UserConfigDialog extends Vue {
   open?: boolean
 
   @Prop({ type: Object, required: true })
-  readonly user!: AppUser
+  readonly user!: AppUserWithPassword
 
   handleSave () {
     this.$emit('save', this.user)

--- a/src/components/widgets/filesystem/FileSystemUploadDialog.vue
+++ b/src/components/widgets/filesystem/FileSystemUploadDialog.vue
@@ -97,7 +97,7 @@ export default class FileSystemUploadDialog extends Mixins(StateMixin) {
 
       // Started uploading, but not complete.
       if (file.loaded > 0 && file.loaded < file.size) {
-        file.abortController.abort()
+        file.abortController?.abort()
       }
     }
   }

--- a/src/store/announcements/actions.ts
+++ b/src/store/announcements/actions.ts
@@ -30,19 +30,19 @@ export const actions = {
     }
   },
 
-  async onAnnouncementDismissed ({ commit }, payload) {
+  async onAnnouncementDismissed ({ commit }, payload: { entry_id: string }) {
     if (payload) {
       commit('setAnnouncementDismissed', { entry_id: payload.entry_id, dismissed: true })
     }
   },
 
-  async onAnnouncementWake ({ commit }, payload) {
+  async onAnnouncementWake ({ commit }, payload: { entry_id: string }) {
     if (payload) {
       commit('setAnnouncementDismissed', { entry_id: payload.entry_id, dismissed: false })
     }
   },
 
-  async dismiss (_, payload) {
+  async dismiss (_, payload: { entry_id: string; wake_time?: number }) {
     SocketActions.serverAnnouncementsDismiss(payload.entry_id, payload.wake_time)
   },
 

--- a/src/store/auth/actions.ts
+++ b/src/store/auth/actions.ts
@@ -1,5 +1,5 @@
 import type { ActionTree } from 'vuex'
-import type { AppUser, AuthState } from './types'
+import type { AppUser, AppUserWithPassword, AuthState } from './types'
 import type { RootState } from '../types'
 import { consola } from 'consola'
 import { SocketActions } from '@/api/socketActions'
@@ -117,8 +117,8 @@ export const actions = {
     await dispatch('logout', { invalidate: true })
   },
 
-  async addUser (_, user: AppUser) {
-    await SocketActions.accessPostUser(user.username, user.password ?? '')
+  async addUser (_, user: AppUserWithPassword) {
+    await SocketActions.accessPostUser(user.username, user.password)
 
     return user
   },

--- a/src/store/auth/actions.ts
+++ b/src/store/auth/actions.ts
@@ -1,5 +1,5 @@
 import type { ActionTree } from 'vuex'
-import type { AppUser, AppUserWithPassword, AuthState } from './types'
+import type { AuthState } from './types'
 import type { RootState } from '../types'
 import { consola } from 'consola'
 import { SocketActions } from '@/api/socketActions'
@@ -117,19 +117,7 @@ export const actions = {
     await dispatch('logout', { invalidate: true })
   },
 
-  async addUser (_, user: AppUserWithPassword) {
-    await SocketActions.accessPostUser(user.username, user.password)
-
-    return user
-  },
-
-  async removeUser (_, user: AppUser) {
-    await SocketActions.accessDeleteUser(user.username)
-
-    return user
-  },
-
-  async onUserCreated ({ commit }, user: { username: string; source?: string }) {
+  async onUserCreated ({ commit }, user: { username: string }) {
     commit('setAddUser', user)
   },
 

--- a/src/store/auth/actions.ts
+++ b/src/store/auth/actions.ts
@@ -1,5 +1,5 @@
 import type { ActionTree } from 'vuex'
-import type { AuthState } from './types'
+import type { AppUser, AuthState } from './types'
 import type { RootState } from '../types'
 import { consola } from 'consola'
 import { SocketActions } from '@/api/socketActions'
@@ -117,23 +117,23 @@ export const actions = {
     await dispatch('logout', { invalidate: true })
   },
 
-  async addUser (_, user) {
-    await SocketActions.accessPostUser(user.username, user.password)
+  async addUser (_, user: AppUser) {
+    await SocketActions.accessPostUser(user.username, user.password ?? '')
 
     return user
   },
 
-  async removeUser (_, user) {
+  async removeUser (_, user: AppUser) {
     await SocketActions.accessDeleteUser(user.username)
 
     return user
   },
 
-  async onUserCreated ({ commit }, user) {
+  async onUserCreated ({ commit }, user: { username: string; source?: string }) {
     commit('setAddUser', user)
   },
 
-  async onUserDeleted ({ commit }, user) {
+  async onUserDeleted ({ commit }, user: { username: string }) {
     commit('setRemoveUser', user)
   },
 

--- a/src/store/auth/mutations.ts
+++ b/src/store/auth/mutations.ts
@@ -18,8 +18,11 @@ export const mutations = {
     state.users = users
   },
 
-  setAddUser (state, user: { username: string; source?: string }) {
-    state.users.push({ source: 'moonraker', ...user })
+  setAddUser (state, user: { username: string }) {
+    state.users.push({
+      ...user,
+      source: 'moonraker',
+    })
   },
 
   setRemoveUser (state, user: { username: string }) {

--- a/src/store/auth/mutations.ts
+++ b/src/store/auth/mutations.ts
@@ -1,6 +1,6 @@
 import type { MutationTree } from 'vuex'
 import { defaultState } from './state'
-import type { AuthState } from './types'
+import type { AppUser, AuthState } from './types'
 
 export const mutations = {
   /**
@@ -10,24 +10,24 @@ export const mutations = {
     Object.assign(state, defaultState())
   },
 
-  setCurrentUser (state, user) {
+  setCurrentUser (state, user: AppUser | null) {
     state.currentUser = user
   },
 
-  setUsers (state, users) {
+  setUsers (state, users: AppUser[]) {
     state.users = users
   },
 
-  setAddUser (state, user) {
+  setAddUser (state, user: { username: string; source?: string }) {
     state.users.push({ source: 'moonraker', ...user })
   },
 
-  setRemoveUser (state, user) {
+  setRemoveUser (state, user: { username: string }) {
     const i = state.users.findIndex(u => u.username === user.username)
     if (i >= 0) state.users.splice(i, 1)
   },
 
-  setApiKey (state, key) {
+  setApiKey (state, key: string) {
     state.apiKey = key
   }
 } satisfies MutationTree<AuthState>

--- a/src/store/auth/types.ts
+++ b/src/store/auth/types.ts
@@ -6,7 +6,10 @@ export interface AuthState {
 
 export interface AppUser {
   username: string;
-  password?: string;
   source: string;
   created_on?: number;
+}
+
+export interface AppUserWithPassword extends AppUser {
+  password: string;
 }

--- a/src/store/auth/types.ts
+++ b/src/store/auth/types.ts
@@ -9,7 +9,3 @@ export interface AppUser {
   source: string;
   created_on?: number;
 }
-
-export interface AppUserWithPassword extends AppUser {
-  password: string;
-}

--- a/src/store/charts/actions.ts
+++ b/src/store/charts/actions.ts
@@ -1,7 +1,7 @@
 import type { ActionTree } from 'vuex'
 import { SocketActions } from '@/api/socketActions'
 import { Globals } from '@/globals'
-import type { ChartData, ChartState } from './types'
+import type { ChartData, ChartSelectedLegends, ChartState } from './types'
 import type { RootState } from '../types'
 import { isEqual } from 'lodash-es'
 
@@ -95,14 +95,14 @@ export const actions = {
   /**
    * Init the chart state from db
    */
-  initCharts ({ commit }, payload) {
+  initCharts ({ commit }, payload: Partial<ChartState>) {
     commit('setInitCharts', payload)
   },
 
   /**
    * Saves current state of selected legends to store and db
    */
-  saveSelectedLegends ({ commit, state }, payload) {
+  saveSelectedLegends ({ commit, state }, payload: ChartSelectedLegends) {
     // Only change the data if they require it
     if (!isEqual(state.selectedLegends, payload)) {
       commit('setSelectedLegends', payload)

--- a/src/store/charts/mutations.ts
+++ b/src/store/charts/mutations.ts
@@ -1,6 +1,6 @@
 import Vue from 'vue'
 import type { MutationTree } from 'vuex'
-import type { ChartData, ChartState } from './types'
+import type { ChartData, ChartSelectedLegends, ChartState } from './types'
 import { defaultState } from './state'
 
 export const mutations = {
@@ -29,7 +29,7 @@ export const mutations = {
   /**
    * Init the chart store from db
    */
-  setInitCharts (state, payload: ChartState) {
+  setInitCharts (state, payload: Partial<ChartState>) {
     if (payload) Object.assign(state, payload)
   },
 
@@ -55,7 +55,7 @@ export const mutations = {
     if (firstInRange > 0) state[payload.type].splice(0, firstInRange)
   },
 
-  setSelectedLegends (state, payload) {
+  setSelectedLegends (state, payload: ChartSelectedLegends) {
     state.selectedLegends = payload
   }
 } satisfies MutationTree<ChartState>

--- a/src/store/config/actions.ts
+++ b/src/store/config/actions.ts
@@ -1,6 +1,6 @@
 import vuetify from '@/plugins/vuetify'
 import type { ActionTree } from 'vuex'
-import type { ConfigState, SaveByPath, InitConfig, InstanceConfig, UiSettings, ThemeConfig, ConfiguredTableHeader } from './types'
+import type { ConfigState, SaveByPath, InitConfig, InstanceConfig, TemperaturePreset, UiSettings, ThemeConfig, ConfiguredTableHeader } from './types'
 import type { RootState } from '../types'
 import { SocketActions } from '@/api/socketActions'
 import { loadLocaleMessagesAsync, getStartingLocale } from '@/plugins/i18n'
@@ -134,7 +134,7 @@ export const actions = {
   /**
    * Add or update a given temp preset
    */
-  async updatePreset ({ commit, state }, payload) {
+  async updatePreset ({ commit, state }, payload: TemperaturePreset) {
     commit('setPreset', payload)
     SocketActions.serverDatabasePostItem('uiSettings.dashboard.tempPresets', state.uiSettings.dashboard.tempPresets)
   },
@@ -142,7 +142,7 @@ export const actions = {
   /**
    * Remove a temp preset
    */
-  async removePreset ({ commit, state }, payload) {
+  async removePreset ({ commit, state }, payload: TemperaturePreset) {
     commit('setRemovePreset', payload)
     SocketActions.serverDatabasePostItem('uiSettings.dashboard.tempPresets', state.uiSettings.dashboard.tempPresets)
   },

--- a/src/store/config/mutations.ts
+++ b/src/store/config/mutations.ts
@@ -1,6 +1,6 @@
 import Vue from 'vue'
 import type { MutationTree } from 'vuex'
-import type { ConfigState, UiSettings, SaveByPath, InstanceConfig, ConfiguredTableHeader, HostConfig, ApiConfig } from './types'
+import type { ConfigState, UiSettings, SaveByPath, InstanceConfig, TemperaturePreset, ConfiguredTableHeader, HostConfig, ApiConfig } from './types'
 import { defaultState } from './state'
 import { Globals } from '@/globals'
 import { cloneDeep, mergeWith, set } from 'lodash-es'
@@ -110,17 +110,17 @@ export const mutations = {
     state.instances = instances
   },
 
-  setUpdateInstanceName (state, payload) {
+  setUpdateInstanceName (state, payload: InstanceConfig) {
     const index = state.instances.findIndex(instance => instance.apiUrl === payload.apiUrl)
     if (index > -1) {
       const instance = state.instances[index]
       Vue.set(state.instances, index, { ...instance, ...payload })
+      localStorage.setItem(Globals.LOCAL_INSTANCES_STORAGE_KEY, JSON.stringify(state.instances))
     }
-    localStorage.setItem(Globals.LOCAL_INSTANCES_STORAGE_KEY, JSON.stringify(state.instances))
   },
 
-  setRemoveInstance (state, payload) {
-    const index = state.instances.findIndex((instance: InstanceConfig) => instance.apiUrl === payload.apiUrl)
+  setRemoveInstance (state, payload: InstanceConfig) {
+    const index = state.instances.findIndex(instance => instance.apiUrl === payload.apiUrl)
     if (index >= 0) {
       state.instances.splice(index, 1)
       localStorage.setItem(Globals.LOCAL_INSTANCES_STORAGE_KEY, JSON.stringify(state.instances))
@@ -138,7 +138,7 @@ export const mutations = {
   /**
    * Update / Add a temperature preset
    */
-  setPreset (state, payload) {
+  setPreset (state, payload: TemperaturePreset) {
     if (payload.id === -1) {
       payload.id = uuidv4()
       state.uiSettings.dashboard.tempPresets.push(payload)
@@ -153,7 +153,7 @@ export const mutations = {
   /**
    * Remove a preset
    */
-  setRemovePreset (state, payload) {
+  setRemovePreset (state, payload: TemperaturePreset) {
     const i = state.uiSettings.dashboard.tempPresets.findIndex(preset => preset.id === payload.id)
     state.uiSettings.dashboard.tempPresets.splice(i, 1)
   },

--- a/src/store/config/mutations.ts
+++ b/src/store/config/mutations.ts
@@ -155,7 +155,9 @@ export const mutations = {
    */
   setRemovePreset (state, payload: TemperaturePreset) {
     const i = state.uiSettings.dashboard.tempPresets.findIndex(preset => preset.id === payload.id)
-    state.uiSettings.dashboard.tempPresets.splice(i, 1)
+    if (i >= 0) {
+      state.uiSettings.dashboard.tempPresets.splice(i, 1)
+    }
   },
 
   /**

--- a/src/store/config/types.ts
+++ b/src/store/config/types.ts
@@ -233,7 +233,7 @@ export interface InstanceConfig extends ApiConfig {
 }
 
 export interface TemperaturePreset {
-  id: number;
+  id: number | string;
   name: string;
   values: Record<string, TemperaturePresetValue>;
   gcode?: string;

--- a/src/store/console/actions.ts
+++ b/src/store/console/actions.ts
@@ -17,14 +17,14 @@ export const actions = {
   /**
    * Inits known command history
    */
-  async initConsole ({ commit }, payload) {
+  async initConsole ({ commit }, payload: Partial<ConsoleState>) {
     commit('setInitConsole', payload)
   },
 
   /**
    * Add a command history item, and update server store.
    */
-  async onUpdateCommandHistory ({ state, commit }, payload) {
+  async onUpdateCommandHistory ({ state, commit }, payload: string[]) {
     commit('setUpdateCommandHistory', payload)
     SocketActions.serverDatabasePostItem(Globals.MOONRAKER_DB.fluidd.ROOTS.console.name + '.commandHistory', state.commandHistory)
   },
@@ -32,7 +32,7 @@ export const actions = {
   /**
    * The result of a specific gcode request.
    */
-  async onGcodeScript ({ dispatch }, payload) {
+  async onGcodeScript ({ dispatch }, payload: { result?: string }) {
     // If the response is not ok, pass it to the console.
     if (payload && payload.result && payload.result !== 'ok') {
       dispatch('onAddConsoleEntry', { message: Globals.CONSOLE_RECEIVE_PREFIX + payload.result })
@@ -171,7 +171,7 @@ export const actions = {
   /**
    * Updates auto scroll value
    */
-  async onUpdateAutoScroll ({ commit }, payload) {
+  async onUpdateAutoScroll ({ commit }, payload: boolean) {
     commit('setAutoScroll', payload)
     SocketActions.serverDatabasePostItem(Globals.MOONRAKER_DB.fluidd.ROOTS.console.name + '.autoScroll', payload)
   },

--- a/src/store/console/mutations.ts
+++ b/src/store/console/mutations.ts
@@ -81,7 +81,7 @@ export const mutations = {
   /**
    * Inits the console history from db
    */
-  setInitConsole (state, payload: ConsoleState) {
+  setInitConsole (state, payload: Partial<ConsoleState>) {
     if (payload) {
       if (payload.consoleFilters) {
         payload.consoleFiltersRegexp = payload.consoleFilters
@@ -120,7 +120,7 @@ export const mutations = {
   /**
    * Maintains the current console command
    */
-  setConsoleCommand (state, payload) {
+  setConsoleCommand (state, payload: string) {
     state.consoleCommand = payload
   },
 
@@ -131,7 +131,7 @@ export const mutations = {
   /**
    * Sets auto scroll
    */
-  setAutoScroll (state, payload) {
+  setAutoScroll (state, payload: boolean) {
     state.autoScroll = payload
   },
 

--- a/src/store/files/actions.ts
+++ b/src/store/files/actions.ts
@@ -1,5 +1,5 @@
 import type { ActionTree } from 'vuex'
-import type { FilesState, FilePaths } from './types'
+import type { FilesState, FilePaths, FileUpload, FileDownload } from './types'
 import type { RootState } from '../types'
 import getFilePaths from '@/util/get-file-paths'
 import { SocketActions } from '@/api/socketActions'
@@ -72,9 +72,9 @@ export const actions = {
    */
 
   // Old notifications for backwards compat
-  async notifyCopyItem ({ dispatch }, payload) { dispatch('notifyCreateFile', payload) },
-  async notifyMoveItem ({ dispatch }, payload) { dispatch('notifyMoveFile', payload) },
-  async notifyUploadFile ({ dispatch }, payload) { dispatch('notifyCreateFile', payload) },
+  async notifyCopyItem ({ dispatch }, payload: Moonraker.Files.ChangeResponse) { dispatch('notifyCreateFile', payload) },
+  async notifyMoveItem ({ dispatch }, payload: Moonraker.Files.ChangeResponse) { dispatch('notifyMoveFile', payload) },
+  async notifyUploadFile ({ dispatch }, payload: Moonraker.Files.ChangeResponse) { dispatch('notifyCreateFile', payload) },
 
   // New notifications
   async notifyRootUpdate ({ commit }, payload: Moonraker.Files.ChangeResponse) {
@@ -172,19 +172,19 @@ export const actions = {
   /**
    * Handles the state of current uploads and downloads.
    */
-  async updateFileUpload ({ commit }, payload) {
+  async updateFileUpload ({ commit }, payload: Partial<FileUpload> & { uid: string }) {
     commit('setUpdateFileUpload', payload)
   },
 
-  async removeFileUpload ({ commit }, payload) {
+  async removeFileUpload ({ commit }, payload: string) {
     commit('setRemoveFileUpload', payload)
   },
 
-  async updateFileDownload ({ commit }, payload) {
+  async updateFileDownload ({ commit }, payload: Partial<FileDownload> & { uid: string }) {
     commit('setUpdateFileDownload', payload)
   },
 
-  async removeFileDownload ({ commit }, payload) {
+  async removeFileDownload ({ commit }, payload: string) {
     commit('setRemoveFileDownload', payload)
   },
 

--- a/src/store/files/mutations.ts
+++ b/src/store/files/mutations.ts
@@ -138,7 +138,8 @@ export const mutations = {
         ...payload
       })
     } else {
-      // The first update for a given uid always carries the full FileUpload shape.
+      // The first update for a given uid always carries the full FileUpload shape
+      // (abortController is the only field that may not be set yet).
       state.uploads.push(payload as FileUpload)
     }
   },

--- a/src/store/files/mutations.ts
+++ b/src/store/files/mutations.ts
@@ -1,6 +1,6 @@
 import Vue from 'vue'
 import type { MutationTree } from 'vuex'
-import type { FilesState, MoonrakerPathContent, FilePaths } from './types'
+import type { FilesState, MoonrakerPathContent, FilePaths, FileUpload, FileDownload } from './types'
 import { defaultState } from './state'
 import { Globals } from '@/globals'
 
@@ -12,7 +12,7 @@ export const mutations = {
     Object.assign(state, defaultState())
   },
 
-  setResetRoot (state, root) {
+  setResetRoot (state, root: string) {
     const keysToDelete = Object.keys(state.pathContent)
       .filter(key => key === root || key.startsWith(`${root}/`))
 
@@ -129,7 +129,7 @@ export const mutations = {
     }
   },
 
-  setUpdateFileUpload (state, payload) {
+  setUpdateFileUpload (state, payload: Partial<FileUpload> & { uid: string }) {
     const uploadIndex = state.uploads.findIndex(upload => upload.uid === payload.uid)
 
     if (uploadIndex >= 0) {
@@ -138,7 +138,8 @@ export const mutations = {
         ...payload
       })
     } else {
-      state.uploads.push(payload)
+      // The first update for a given uid always carries the full FileUpload shape.
+      state.uploads.push(payload as FileUpload)
     }
   },
 
@@ -149,15 +150,16 @@ export const mutations = {
     }
   },
 
-  setUpdateFileDownload (state, payload) {
+  setUpdateFileDownload (state, payload: Partial<FileDownload> & { uid: string }) {
     if (
       state.download == null ||
       state.download.uid === payload.uid
     ) {
+      // The first update for a given uid always carries the full FileDownload shape.
       state.download = {
         ...state.download,
         ...payload
-      }
+      } as FileDownload
     }
   },
 

--- a/src/store/files/types.ts
+++ b/src/store/files/types.ts
@@ -68,9 +68,10 @@ export interface FileDownload {
   abortController: AbortController;
 }
 
-export interface FileUpload extends FileDownload {
+export interface FileUpload extends Omit<FileDownload, 'abortController'> {
   complete: boolean; // indicates moonraker is finished with the file.
   cancelled: boolean; // in a cancelled state, don't show - nor try to upload.
+  abortController?: AbortController; // not set until the upload of this entry starts.
 }
 
 export type FileFilterType = 'print_start_time' | 'hidden_files' | 'klipper_backup_files' | 'rolled_log_files' | 'moonraker_backup_files' | 'moonraker_temporary_upload_files' | 'crowsnest_backup_files'

--- a/src/store/history/actions.ts
+++ b/src/store/history/actions.ts
@@ -24,13 +24,13 @@ export const actions = {
     SocketActions.serverHistoryTotals()
   },
 
-  async updateHistory ({ commit }, payload) {
+  async updateHistory ({ commit }, payload: Moonraker.History.Job) {
     if (payload) {
       commit('setUpdateHistory', payload)
     }
   },
 
-  async clearHistoryThumbnails ({ commit }, payload) {
+  async clearHistoryThumbnails ({ commit }, payload: string) {
     if (payload) {
       commit('setClearHistoryThumbnails', payload)
     }

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -101,7 +101,7 @@ export const storeOptions = {
     /**
      * A void action. Some socket commands may not need processing.
      */
-    void (_, payload) {
+    void (_, payload: unknown) {
       consola.debug('void action', payload)
     }
   }

--- a/src/store/macros/actions.ts
+++ b/src/store/macros/actions.ts
@@ -15,7 +15,7 @@ export const actions = {
   /**
    * Init stored macros
    */
-  initMacros ({ commit }, payload) {
+  initMacros ({ commit }, payload: Partial<MacrosState>) {
     commit('initMacros', payload)
   },
 
@@ -43,7 +43,7 @@ export const actions = {
     SocketActions.serverDatabasePostItem(Globals.MOONRAKER_DB.fluidd.ROOTS.macros.name + '.stored', state.stored)
   },
 
-  saveAllOn ({ state, commit }, macros) {
+  saveAllOn ({ state, commit }, macros: Macro[]) {
     // Commit the change...
     commit('setUpdateAllVisible', { macros, visible: true })
 
@@ -51,7 +51,7 @@ export const actions = {
     SocketActions.serverDatabasePostItem(Globals.MOONRAKER_DB.fluidd.ROOTS.macros.name + '.stored', state.stored)
   },
 
-  saveAllOff ({ state, commit }, macros) {
+  saveAllOff ({ state, commit }, macros: Macro[]) {
     // Commit the change...
     commit('setUpdateAllVisible', { macros, visible: false })
 

--- a/src/store/macros/mutations.ts
+++ b/src/store/macros/mutations.ts
@@ -24,7 +24,7 @@ export const mutations = {
   },
 
   // Sets macro state from db
-  initMacros (state, payload: MacrosState) {
+  initMacros (state, payload: Partial<MacrosState>) {
     if (payload && payload.categories) {
       if (typeof payload.categories[0] === 'string') payload.categories = []
     }

--- a/src/store/mesh/actions.ts
+++ b/src/store/mesh/actions.ts
@@ -1,5 +1,5 @@
 import type { ActionTree } from 'vuex'
-import type { MeshState } from './types'
+import type { MatrixType, MeshState } from './types'
 import type { RootState } from '../types'
 
 export const actions = {
@@ -10,23 +10,23 @@ export const actions = {
     commit('setReset')
   },
 
-  async onMatrix ({ commit }, payload) {
+  async onMatrix ({ commit }, payload: MatrixType) {
     commit('setMatrix', payload)
   },
 
-  async onScale ({ commit }, payload) {
+  async onScale ({ commit }, payload: number) {
     commit('setScale', payload)
   },
 
-  async onBoxScale ({ commit }, payload) {
+  async onBoxScale ({ commit }, payload: number) {
     commit('setBoxScale', payload)
   },
 
-  async onWireframe ({ commit }, payload) {
+  async onWireframe ({ commit }, payload: boolean) {
     commit('setWireframe', payload)
   },
 
-  async onFlatSurface ({ commit }, payload) {
+  async onFlatSurface ({ commit }, payload: boolean) {
     commit('setFlatSurface', payload)
   }
 } satisfies ActionTree<MeshState, RootState>

--- a/src/store/mesh/mutations.ts
+++ b/src/store/mesh/mutations.ts
@@ -1,6 +1,6 @@
 import type { MutationTree } from 'vuex'
 import { defaultState } from './state'
-import type { MeshState } from './types'
+import type { MatrixType, MeshState } from './types'
 
 export const mutations = {
   /**
@@ -10,23 +10,23 @@ export const mutations = {
     Object.assign(state, defaultState())
   },
 
-  setMatrix (state, payload) {
+  setMatrix (state, payload: MatrixType) {
     state.matrix = payload
   },
 
-  setScale (state, payload) {
+  setScale (state, payload: number) {
     state.scale = payload
   },
 
-  setBoxScale (state, payload) {
+  setBoxScale (state, payload: number) {
     state.boxScale = payload
   },
 
-  setWireframe (state, payload) {
+  setWireframe (state, payload: boolean) {
     state.wireframe = payload
   },
 
-  setFlatSurface (state, payload) {
+  setFlatSurface (state, payload: boolean) {
     state.flatSurface = payload
   }
 } satisfies MutationTree<MeshState>

--- a/src/store/printer/actions.ts
+++ b/src/store/printer/actions.ts
@@ -1,5 +1,5 @@
 import type { ActionTree } from 'vuex'
-import type { KlippyApp, PrinterState } from './types'
+import type { KlippyApp, PrinterState, SocketNotifyPayload } from './types'
 import type { RootState } from '../types'
 import { handlePrintStateChange, handleCurrentFileChange, handleTrinamicDriversChange } from '../helpers'
 import { handleAddChartEntry, handleSystemStatsChange, handleMcuStatsChange } from '../chart_helpers'
@@ -149,7 +149,7 @@ export const actions = {
    * Print start confirmation.
    * Fires as a watch on a printer state change.
    */
-  async onPrintStart (_, payload) {
+  async onPrintStart (_, payload: Partial<Klipper.PrinterState>) {
     consola.debug('Print start detected', payload)
   },
 
@@ -157,7 +157,7 @@ export const actions = {
    * Print end confirmation.
    * Fires as a watch on a printer state change.
    */
-  async onPrintEnd (_, payload) {
+  async onPrintEnd (_, payload: Partial<Klipper.PrinterState>) {
     consola.debug('Print end detected', payload)
   },
 
@@ -268,7 +268,7 @@ export const actions = {
     }
   },
 
-  async onFastNotifyStatusUpdate ({ rootState, commit, dispatch }, payload) {
+  async onFastNotifyStatusUpdate ({ rootState, commit, dispatch }, payload: SocketNotifyPayload) {
     // Do NOT accept updates until our subscribe comes back.
     // This is because moonraker currently sends notification updates
     // prior to subscribing on browser refresh.

--- a/src/store/printer/types.ts
+++ b/src/store/printer/types.ts
@@ -18,6 +18,10 @@ export type PrinterStatus =
   | 'idle'
   | 'loading'
 
+export type SocketNotifyPayload = {
+  [K in keyof Klipper.PrinterState]: { key: K; payload: Klipper.PrinterState[K] }
+}[keyof Klipper.PrinterState]
+
 export interface KnownExtruder {
   name: string;
   key: Klipper.ExtruderKey;

--- a/src/store/socket/actions.ts
+++ b/src/store/socket/actions.ts
@@ -8,6 +8,7 @@ import { EventBus } from '@/eventBus'
 import { upperFirst, camelCase } from 'lodash-es'
 import { jwtDecode } from 'jwt-decode'
 import type { TokenKeys } from '../config/types'
+import type { HistoryItem } from '../history/types'
 import i18n from '@/plugins/i18n'
 
 const MODULES_TO_RESET_ON_DROP = [
@@ -338,11 +339,11 @@ export const actions = {
    * ==========================================================================
    */
 
-  async notifyStatusUpdate ({ dispatch }, payload) {
+  async notifyStatusUpdate ({ dispatch }, payload: Partial<Klipper.PrinterState>) {
     await dispatch('printer/onNotifyStatusUpdate', payload, { root: true })
   },
 
-  async notifyGcodeResponse ({ dispatch }, payload) {
+  async notifyGcodeResponse ({ dispatch }, payload: string) {
     dispatch('console/onAddConsoleEntry', { message: `${Globals.CONSOLE_RECEIVE_PREFIX}${payload}` }, { root: true })
   },
 
@@ -366,44 +367,44 @@ export const actions = {
     consola.debug('Klippy Ready')
   },
 
-  async notifyFilelistChanged ({ dispatch }, payload) {
+  async notifyFilelistChanged ({ dispatch }, payload: Moonraker.Files.ChangeResponse) {
     dispatch('files/notify' + upperFirst(camelCase(payload.action)), payload, { root: true })
   },
 
   // Next release, remove.
-  async notifyMetadataUpdate ({ dispatch }, payload) {
+  async notifyMetadataUpdate ({ dispatch }, payload: Moonraker.Files.FileWithMetaResponse) {
     dispatch('files/onFileMetaData', payload, { root: true })
   },
 
-  async notifyPowerChanged ({ dispatch }, payload) {
+  async notifyPowerChanged ({ dispatch }, payload: { device: string; status: Moonraker.Power.DeviceState }) {
     dispatch('power/onStatus', { [payload.device]: payload.status }, { root: true })
   },
 
-  async notifyUpdateResponse ({ dispatch }, payload) {
+  async notifyUpdateResponse ({ dispatch }, payload: Moonraker.UpdateManager.UpdateResponse) {
     dispatch('version/onUpdateResponse', payload, { root: true })
   },
 
-  async notifyUpdateRefreshed ({ dispatch }, payload) {
+  async notifyUpdateRefreshed ({ dispatch }, payload: Partial<Moonraker.UpdateManager.StatusResponse>) {
     dispatch('version/onUpdateStatus', payload, { root: true })
   },
 
-  async notifyHistoryChanged ({ dispatch }, payload) {
+  async notifyHistoryChanged ({ dispatch }, payload: { action: 'added' | 'finished'; job: HistoryItem }) {
     dispatch('history/onHistoryChange', payload, { root: true })
   },
 
-  async notifyCpuThrottled ({ dispatch }, payload) {
+  async notifyCpuThrottled ({ dispatch }, payload: Moonraker.ProcStats.ThrottledState) {
     dispatch('server/onMachineThrottledState', payload, { root: true })
   },
 
-  async notifyProcStatUpdate ({ dispatch }, payload) {
+  async notifyProcStatUpdate ({ dispatch }, payload: Moonraker.ProcStats.Response) {
     dispatch('server/onMachineProcStats', payload, { root: true })
   },
 
-  async notifyUserCreated ({ dispatch }, payload) {
+  async notifyUserCreated ({ dispatch }, payload: { username: string; source?: string }) {
     dispatch('auth/onUserCreated', payload, { root: true })
   },
 
-  async notifyUserDeleted ({ dispatch }, payload) {
+  async notifyUserDeleted ({ dispatch }, payload: { username: string }) {
     dispatch('auth/onUserDeleted', payload, { root: true })
   },
 
@@ -424,43 +425,43 @@ export const actions = {
     }
   },
 
-  async notifyServiceStateChanged ({ dispatch }, payload) {
+  async notifyServiceStateChanged ({ dispatch }, payload: Moonraker.Machine.ServiceState) {
     dispatch('server/onServiceStateChanged', payload, { root: true })
   },
 
-  async notifyTimelapseEvent ({ dispatch }, payload) {
+  async notifyTimelapseEvent ({ dispatch }, payload: Moonraker.Timelapse.Event) {
     dispatch('timelapse/onEvent', payload, { root: true })
   },
 
-  async notifyAnnouncementUpdate ({ dispatch }, payload) {
+  async notifyAnnouncementUpdate ({ dispatch }, payload: Moonraker.Announcements.ListResponse) {
     dispatch('announcements/onAnnouncementUpdate', payload, { root: true })
   },
 
-  async notifyAnnouncementDismissed ({ dispatch }, payload) {
+  async notifyAnnouncementDismissed ({ dispatch }, payload: { entry_id: string }) {
     dispatch('announcements/onAnnouncementDismissed', payload, { root: true })
   },
 
-  async notifyAnnouncementWake ({ dispatch }, payload) {
+  async notifyAnnouncementWake ({ dispatch }, payload: { entry_id: string }) {
     dispatch('announcements/onAnnouncementWake', payload, { root: true })
   },
 
-  async notifyWebcamsChanged ({ dispatch }, payload) {
+  async notifyWebcamsChanged ({ dispatch }, payload: Moonraker.Webcam.ListResponse) {
     dispatch('webcams/onWebcamsChanged', payload, { root: true })
   },
 
-  async notifySensorUpdate ({ dispatch }, payload) {
+  async notifySensorUpdate ({ dispatch }, payload: Record<string, Moonraker.Sensor.Values>) {
     dispatch('sensors/onSensorUpdate', payload, { root: true })
   },
 
-  async notifyJobQueueChanged ({ dispatch }, payload) {
+  async notifyJobQueueChanged ({ dispatch }, payload: { action: string, queue_state?: Moonraker.JobQueue.QueueState, updated_queue?: Moonraker.JobQueue.QueuedJob[] | null }) {
     dispatch('jobQueue/onJobQueueChanged', payload, { root: true })
   },
 
-  async notifyActiveSpoolSet ({ dispatch }, payload) {
+  async notifyActiveSpoolSet ({ dispatch }, payload: Moonraker.Spoolman.SpoolIdResponse) {
     dispatch('spoolman/onActiveSpool', payload, { root: true })
   },
 
-  async notifySpoolmanStatusChanged ({ dispatch }, payload) {
+  async notifySpoolmanStatusChanged ({ dispatch }, payload: { spoolman_connected: boolean }) {
     dispatch('spoolman/onStatusChanged', payload.spoolman_connected, { root: true })
   }
 } satisfies ActionTree<SocketState, RootState>

--- a/src/store/spoolman/actions.ts
+++ b/src/store/spoolman/actions.ts
@@ -66,7 +66,7 @@ export const actions = {
     SocketActions.serverSpoolmanProxyGetInfo()
   },
 
-  async onActiveSpool ({ commit }, payload) {
+  async onActiveSpool ({ commit }, payload: Moonraker.Spoolman.SpoolIdResponse) {
     commit('setActiveSpool', payload.spool_id)
   },
 

--- a/src/store/spoolman/mutations.ts
+++ b/src/store/spoolman/mutations.ts
@@ -35,7 +35,7 @@ export const mutations = {
     state.currency = payload.value.replace(/^"|"$/g, '')
   },
 
-  setConnected (state, payload) {
+  setConnected (state, payload: boolean) {
     state.connected = payload
   },
 

--- a/src/store/timelapse/actions.ts
+++ b/src/store/timelapse/actions.ts
@@ -30,7 +30,7 @@ export const actions = {
     commit('setLastFrame', payload)
   },
 
-  async onEvent ({ commit }, payload) {
+  async onEvent ({ commit }, payload: Moonraker.Timelapse.Event) {
     switch (payload.action) {
       case 'newframe': {
         if (payload.status === 'error') {

--- a/src/store/version/actions.ts
+++ b/src/store/version/actions.ts
@@ -43,41 +43,41 @@ export const actions = {
   /**
    * As updates happen, we get responses here.
    */
-  async onUpdateResponse ({ commit }, payload) {
+  async onUpdateResponse ({ commit }, payload: Moonraker.UpdateManager.UpdateResponse) {
     commit('setUpdateResponse', payload)
   },
 
   /**
    * Notifications of specific updates
    */
-  async onUpdatedMoonraker (_, payload) {
+  async onUpdatedMoonraker (_, payload: { result?: string }) {
     consola.debug('Finished updating moonraker', payload)
     SocketActions.machineUpdateStatus()
     // Moonraker is expected to restart; the socket will drop and naturally
     // cycle through connecting → identifying → ready via the state machine.
   },
 
-  async onUpdatedKlipper (_, payload) {
+  async onUpdatedKlipper (_, payload: { result?: string }) {
     consola.debug('Finished updating klipper', payload)
     SocketActions.machineUpdateStatus()
   },
 
-  async onUpdatedClient (_, payload) {
+  async onUpdatedClient (_, payload: { result?: string }) {
     consola.debug('Finished updating a client', payload)
     SocketActions.machineUpdateStatus()
   },
 
-  async onUpdatedFluidd (_, payload) {
+  async onUpdatedFluidd (_, payload: { result?: string }) {
     consola.debug('Finished updating fluidd, reloading', payload)
     window.location.reload()
   },
 
-  async onUpdatedSystem (_, payload) {
+  async onUpdatedSystem (_, payload: { result?: string }) {
     consola.debug('Finished updating system', payload)
     SocketActions.machineUpdateStatus()
   },
 
-  async onUpdatedAll (_, payload) {
+  async onUpdatedAll (_, payload: { result?: string }) {
     consola.debug('Finished updating all services', payload)
     window.location.reload()
   }

--- a/src/store/version/mutations.ts
+++ b/src/store/version/mutations.ts
@@ -17,7 +17,7 @@ export const mutations = {
     }
   },
 
-  setUpdateResponse (state, payload) {
+  setUpdateResponse (state, payload: Moonraker.UpdateManager.UpdateResponse) {
     // If we get a complete === true, then assume the update is complete
     // and set busy to false also.
     if (payload.complete) {

--- a/src/store/wait/actions.ts
+++ b/src/store/wait/actions.ts
@@ -13,14 +13,14 @@ export const actions = {
   /**
    * Add's a wait to the list of waits.
    */
-  async addWait ({ commit }, wait) {
+  async addWait ({ commit }, wait: string) {
     commit('setAddWait', wait)
   },
 
   /**
    * Removes a wait from the list of waits.
    */
-  async removeWait ({ commit }, wait) {
+  async removeWait ({ commit }, wait: string) {
     commit('setRemoveWait', wait)
   }
 } satisfies ActionTree<WaitState, RootState>

--- a/src/store/wait/mutations.ts
+++ b/src/store/wait/mutations.ts
@@ -13,7 +13,7 @@ export const mutations = {
   /**
    * Add a wait, ensuring we don't add dupes.
    */
-  setAddWait (state, payload) {
+  setAddWait (state, payload: string) {
     const i = state.waits.indexOf(payload)
     if (i === -1) state.waits.push(payload)
   },
@@ -21,7 +21,7 @@ export const mutations = {
   /**
    * Remove a wait, if found.
    */
-  setRemoveWait (state, payload) {
+  setRemoveWait (state, payload: string) {
     const i = state.waits.indexOf(payload)
     if (i !== -1) state.waits.splice(i, 1)
   }

--- a/src/store/webcams/actions.ts
+++ b/src/store/webcams/actions.ts
@@ -26,7 +26,7 @@ export const actions = {
     SocketActions.serverWebcamsList()
   },
 
-  async initWebcams ({ commit }, payload) {
+  async initWebcams ({ commit }, payload: { activeWebcam?: string }) {
     commit('setInitWebcams', payload)
   },
 

--- a/src/typings/moonraker.klippy_apis.d.ts
+++ b/src/typings/moonraker.klippy_apis.d.ts
@@ -25,7 +25,7 @@ declare namespace Moonraker.KlippyApis {
   }
 
   export interface ObjectsSubscribeResponse {
-    status: Klipper.PrinterState;
+    status: Partial<Klipper.PrinterState>;
   }
 
   export interface GcodeHelpResponse extends Record<string, string> {

--- a/src/typings/moonraker.timelapse.d.ts
+++ b/src/typings/moonraker.timelapse.d.ts
@@ -102,4 +102,13 @@ declare namespace Moonraker.Timelapse {
     crf: number;
     pixelformat: string;
   }
+
+  export interface NewFrameResponse {
+    action: 'newframe';
+    status?: 'error';
+    frame: string;
+    framefile: string;
+  }
+
+  export type Event = NewFrameResponse | RenderResponse
 }

--- a/src/typings/moonraker.update_manager.d.ts
+++ b/src/typings/moonraker.update_manager.d.ts
@@ -101,4 +101,10 @@ declare namespace Moonraker.UpdateManager {
     info_tags: string[];
   }
 
+  export interface UpdateResponse {
+    application: string;
+    proc_id: number;
+    message: string;
+    complete?: boolean;
+  }
 }


### PR DESCRIPTION
Annotates every action/mutation handler payload that previously fell back to Vuex's implicit `any`, so `$typedDispatch`/`$typedCommit` no longer leak `any` through inferred `RootActionsType`/`RootMutationsType`.

Also tightens a few latent mismatches surfaced along the way (e.g. `TemperaturePreset.id`, console/charts/macros init payloads, file upload/download progress updates, and timelapse/update-manager notification shapes).