### PR TITLE
fix: add rel=noopener to target=_blank links

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,6 +179,7 @@ src/
 - ESLint enforced: `neostandard` + `pluginVue.configs['flat/vue2-recommended']` + `pluginRegexp` + `@vue/eslint-config-typescript`
 - `.editorconfig` rules: 2 spaces, LF line endings, UTF-8, trim trailing whitespace, max line 100 (code)
 - camelCase for variables/methods, PascalCase for components
+- Any link opening a new tab (`target="_blank"`) **must** also set `rel="noopener noreferrer"` — applies to `<a>`, `<v-btn>`/`<app-btn>` with `:href`, and any HTML strings rendered via `v-safe-html` (e.g. `src/util/link-external-urls.ts`)
 - Use `consola` for logging, not `console.log` (configured in `src/setupConsola.ts` — warn in prod, verbose in dev)
 - Type imports: `import type { ... }` for types only (`verbatimModuleSyntax: true`)
 - `satisfies` keyword for store module type checking

--- a/src/components/common/Login.vue
+++ b/src/components/common/Login.vue
@@ -84,6 +84,7 @@
               class="custom-transform-class text-none"
               :href="$globals.DOCS_AUTH_LOST_PASSWORD"
               target="_blank"
+              rel="noopener noreferrer"
             >
               {{ $t('app.general.btn.forgot_password') }}
             </app-btn>
@@ -93,6 +94,7 @@
               class="custom-transform-class text-none"
               :href="$globals.DOCS_AUTH"
               target="_blank"
+              rel="noopener noreferrer"
             >
               {{ $t('app.general.btn.auth_unsure') }}
             </app-btn>

--- a/src/components/layout/AppNotificationMenu.vue
+++ b/src/components/layout/AppNotificationMenu.vue
@@ -109,6 +109,7 @@
                   x-small
                   :href="n.to"
                   target="_blank"
+                  rel="noopener noreferrer"
                   class="mr-1"
                   @click="menu = false"
                 />

--- a/src/components/settings/VersionInformationDialog.vue
+++ b/src/components/settings/VersionInformationDialog.vue
@@ -48,6 +48,7 @@
                       class="secondary--text"
                       :href="`${baseUrl}/commits/${component.branch}`"
                       target="_blank"
+                      rel="noopener noreferrer"
                     >
                       <strong>{{ commit.author }}</strong>
                     </a>
@@ -71,6 +72,7 @@
                     color="secondary"
                     :href="`${baseUrl}/commit/${commit.sha}`"
                     target="_blank"
+                    rel="noopener noreferrer"
                   >
                     <span class="primary--text">{{ commit.sha.substring(0, 7) }}</span>
                   </app-btn>

--- a/src/components/settings/VersionSettings.vue
+++ b/src/components/settings/VersionSettings.vue
@@ -68,6 +68,7 @@
                   v-bind="attrs"
                   :href="component.remote_url"
                   target="_blank"
+                  rel="noopener noreferrer"
                   v-on="on"
                 >
                   <v-icon

--- a/src/components/widgets/afc/dialogs/AfcSettingsDialog.vue
+++ b/src/components/widgets/afc/dialogs/AfcSettingsDialog.vue
@@ -12,6 +12,7 @@
         tile
         href="https://www.armoredturtle.xyz/docs/afc-klipper-add-on/toolhead/calculation.html"
         target="_blank"
+        rel="noopener noreferrer"
         class="me-1"
       >
         <v-icon left>

--- a/src/components/widgets/camera/CameraItem.vue
+++ b/src/components/widgets/camera/CameraItem.vue
@@ -103,6 +103,7 @@
       <a
         :href="rawCameraUrl"
         target="_blank"
+        rel="noopener noreferrer"
       >
         <v-icon>$openInNew</v-icon>
       </a>

--- a/src/components/widgets/filesystem/FileEditorDialog.vue
+++ b/src/components/widgets/filesystem/FileEditorDialog.vue
@@ -76,6 +76,7 @@
             v-if="!printerPrinting && configMap?.link"
             :href="configMap.link"
             target="_blank"
+            rel="noopener noreferrer"
           >
             <v-icon
               small

--- a/src/components/widgets/filesystem/FilePreviewDialog.vue
+++ b/src/components/widgets/filesystem/FilePreviewDialog.vue
@@ -145,7 +145,7 @@ export default class FilePreviewDialog extends Mixins(StateMixin) {
         link (args: Tokens.Link) {
           const html = this.constructor.prototype.link.call(this, args)
 
-          return html.replace(/^<a /, '<a target="_blank" ')
+          return html.replace(/^<a /, '<a target="_blank" rel="noopener noreferrer" ')
         }
       }
     }

--- a/src/components/widgets/spoolman/SpoolSelectionDialog.vue
+++ b/src/components/widgets/spoolman/SpoolSelectionDialog.vue
@@ -269,6 +269,7 @@
         v-if="spoolmanURL"
         :href="spoolmanURL"
         target="_blank"
+        rel="noopener noreferrer"
         color="primary"
         text
         type="button"


### PR DESCRIPTION
Adds `rel="noopener noreferrer"` to all `target="_blank"` links across the app, preventing reverse-tabnabbing and blocking new tabs from accessing `window.opener`.

Follow-up to the same fix made for `linkExternalUrls` in #1879