### PR TITLE
feat: adds support for Moonraker file roots details

### DIFF
--- a/src/api/socketActions.ts
+++ b/src/api/socketActions.ts
@@ -738,6 +738,17 @@ export const SocketActions = {
     )
   },
 
+  serverFilesRoots (options?: NotifyOptions) {
+    return baseEmit<Moonraker.Files.RootsResponse>(
+      'server.files.roots',
+      {
+        dispatch: 'files/onServerFilesRoots',
+        wait: Waits.onFileSystemRoots,
+        ...options
+      }
+    )
+  },
+
   serverFilesList (root: string, options?: NotifyOptions) {
     return baseEmit<Moonraker.Files.ListRootResponse>(
       'server.files.list',

--- a/src/globals.ts
+++ b/src/globals.ts
@@ -624,6 +624,7 @@ export const Waits = Object.freeze({
   onExtruderChange: 'onExtruderChange',
   onLoadLanguage: 'onLoadLanguage',
   onFileSystem: 'onFileSystem',
+  onFileSystemRoots: 'onFileSystemRoots',
   onJobQueue: 'onJobQueue',
   onTimelapseSaveFrame: 'onTimelapseSaveFrame',
   onManualProbe: 'onManualProbe',

--- a/src/store/files/actions.ts
+++ b/src/store/files/actions.ts
@@ -45,7 +45,7 @@ export const actions = {
   },
 
   async onServerFilesRoots ({ commit }, payload: Moonraker.Files.RootsResponse) {
-    commit('setServerFilesRoots', payload)
+    commit('setServerFilesRoots', [...payload])
   },
 
   async onServerFilesListRoot ({ commit }, payload: ObjectWithRequest<Moonraker.Files.ListRootResponse>) {

--- a/src/store/files/actions.ts
+++ b/src/store/files/actions.ts
@@ -44,6 +44,10 @@ export const actions = {
     commit('setServerFilesGetDirectory', { path, content: { files, dirs: filteredDirs } })
   },
 
+  async onServerFilesRoots ({ commit }, payload: Moonraker.Files.RootsResponse) {
+    commit('setServerFilesRoots', payload)
+  },
+
   async onServerFilesListRoot ({ commit }, payload: ObjectWithRequest<Moonraker.Files.ListRootResponse>) {
     const { root } = payload.__request__.params ?? {}
 

--- a/src/store/files/getters.ts
+++ b/src/store/files/getters.ts
@@ -227,6 +227,10 @@ export const getters = {
     return state.currentPaths[root] ?? ''
   },
 
+  getRootDetails: (state) => (root: string): Moonraker.Files.RootInfoWithPath | undefined => {
+    return state.roots?.find(rootInfo => rootInfo.name === root)
+  },
+
   getDiskUsage: (state) => (root: string): AppDiskUsage | undefined => {
     const diskUsage = state.diskUsage[root]
 

--- a/src/store/files/mutations.ts
+++ b/src/store/files/mutations.ts
@@ -31,6 +31,10 @@ export const mutations = {
     Vue.set(state.pathContent, path, content)
   },
 
+  setServerFilesRoots (state, payload: Moonraker.Files.RootsResponse) {
+    state.roots = payload
+  },
+
   setServerFilesListRoot (state, payload: { root: string, files: Moonraker.Files.RootFile[] }) {
     const { root, files } = payload
 

--- a/src/store/files/mutations.ts
+++ b/src/store/files/mutations.ts
@@ -31,7 +31,7 @@ export const mutations = {
     Vue.set(state.pathContent, path, content)
   },
 
-  setServerFilesRoots (state, payload: Moonraker.Files.RootsResponse) {
+  setServerFilesRoots (state, payload: Moonraker.Files.RootInfoWithPath[]) {
     state.roots = payload
   },
 

--- a/src/store/files/state.ts
+++ b/src/store/files/state.ts
@@ -4,6 +4,7 @@ export const defaultState = (): FilesState => {
   return {
     uploads: [],
     download: null,
+    roots: null,
     currentPaths: {},
     diskUsage: {},
     rootFiles: {},

--- a/src/store/files/types.ts
+++ b/src/store/files/types.ts
@@ -6,7 +6,8 @@ export type { AppFileMeta }
 export interface FilesState {
   uploads: FileUpload[];
   download: FileDownload | null;
-  currentPaths: Record<string, string>;
+  roots: Moonraker.Files.RootInfoWithPath[] | null;
+  currentPaths: Record<string, string | undefined>;
   diskUsage: Record<string, Moonraker.Files.DiskUsage | undefined>;
   rootFiles: Record<string, Moonraker.Files.RootFile[] | undefined>;
   pathContent: Record<string, MoonrakerPathContent | undefined>;

--- a/src/typings/moonraker.file_manager.d.ts
+++ b/src/typings/moonraker.file_manager.d.ts
@@ -1,4 +1,7 @@
 declare namespace Moonraker.Files {
+  export interface RootsResponse extends Array<RootInfoWithPath> {
+  }
+
   export interface ListRootResponse extends Array<RootFile> {
   }
 
@@ -37,6 +40,10 @@ declare namespace Moonraker.Files {
   export interface RootInfo {
     name: string;
     permissions?: Moonraker.Files.FilePermissions;
+  }
+
+  export interface RootInfoWithPath extends RootInfo {
+    path: string;
   }
 
   export type FilePermissions = '' | 'r' | 'rw'


### PR DESCRIPTION
Adds support for Moonraker's `server.files.roots` service call.

This code is not currently in use but serves as a base for future improvements.