### PR TITLE
feat: moonraker sensor graphs

### DIFF
--- a/src/components/widgets/sensors/Sensors.vue
+++ b/src/components/widgets/sensors/Sensors.vue
@@ -5,16 +5,53 @@
       :key="sensor.id"
     >
       <v-col>
-        {{ $filters.prettyCase(sensor.friendly_name) }}
+        <v-simple-table class="sensor-table">
+          <thead>
+            <tr>
+              <th width="100%">
+                {{ $t('app.chart.label.item') }}
+              </th>
+              <th
+                v-for="key in getValueKeys(sensor)"
+                :key="`${sensor.id}-${key}`"
+              >
+                {{ $filters.prettyCase(key) }}
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td class="sensor-name">
+                {{ $filters.prettyCase(sensor.friendly_name) }}
+              </td>
+              <td
+                v-for="key in getValueKeys(sensor)"
+                :key="`${sensor.id}-${key}-value`"
+                class="sensor-value"
+              >
+                <span
+                  :class="{ 'active': isLegendSelected(sensor, key), 'toggle': isChartableValue(sensor, key) }"
+                  class="legend-item"
+                  @click="handleLegendClick(sensor, key)"
+                >
+                  {{ getFormattedValue(sensor, key, sensor.values[key]) }}
+                </span>
+              </td>
+            </tr>
+          </tbody>
+        </v-simple-table>
 
-        <v-chip
-          v-for="(value, key) in sensor.values"
-          :key="`${sensor.id}-${key}`"
-          small
-          class="ml-2"
-        >
-          {{ $filters.prettyCase(key.toString()) }}: {{ getFormattedValue(sensor, key.toString(), value) }}
-        </v-chip>
+        <template v-if="hasChart(sensor)">
+          <v-divider />
+
+          <app-chart
+            class="sensor-chart"
+            :data="getChartData(sensor)"
+            :dimensions="getChartDimensions(sensor)"
+            height="260px"
+            :options="getChartOptions(sensor)"
+          />
+        </template>
       </v-col>
     </v-row>
   </v-container>
@@ -22,9 +59,17 @@
 
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator'
+import type { EChartsOption, LineSeriesOption } from 'echarts'
+import type { ChartData } from '@/store/charts/types'
+
+interface SensorSeries extends LineSeriesOption {
+  unit?: string
+}
 
 @Component({})
 export default class Sensors extends Vue {
+  selectedLegends: Record<string, boolean> = {}
+
   get sensors (): Moonraker.Sensor.Entry[] {
     return this.$typedGetters['sensors/getSensors']
   }
@@ -45,5 +90,325 @@ export default class Sensors extends Vue {
 
     return `${value}${units}`
   }
+
+  getValueKeys (sensor: Moonraker.Sensor.Entry): string[] {
+    return Object.keys(sensor.values)
+  }
+
+  hasChart (sensor: Moonraker.Sensor.Entry): boolean {
+    return this.getChartData(sensor).length > 0 && this.getChartDimensions(sensor).length > 1
+  }
+
+  isChartableValue (sensor: Moonraker.Sensor.Entry, key: string): boolean {
+    return typeof sensor.values[key] === 'number'
+  }
+
+  isLegendSelected (sensor: Moonraker.Sensor.Entry, key: string): boolean {
+    return this.selectedLegends[this.getLegendKey(sensor, key)] ?? true
+  }
+
+  handleLegendClick (sensor: Moonraker.Sensor.Entry, key: string) {
+    if (!this.isChartableValue(sensor, key)) {
+      return
+    }
+
+    this.$set(
+      this.selectedLegends,
+      this.getLegendKey(sensor, key),
+      !this.isLegendSelected(sensor, key)
+    )
+  }
+
+  getChartData (sensor: Moonraker.Sensor.Entry): Readonly<ChartData>[] {
+    return this.$typedState.charts[this.getChartKey(sensor)] ?? []
+  }
+
+  getChartDimensions (sensor: Moonraker.Sensor.Entry): string[] {
+    return [
+      'date',
+      ...Object.entries(sensor.values)
+        .filter((entry): entry is [string, number] => typeof entry[1] === 'number')
+        .map(([key]) => key)
+    ]
+  }
+
+  getChartOptions (sensor: Moonraker.Sensor.Entry): EChartsOption {
+    const isDark: boolean = this.$typedState.config.uiSettings.theme.isDark
+    const fontColor = isDark ? 'rgba(255,255,255,0.65)' : 'rgba(0,0,0,0.45)'
+    const lineColor = isDark ? '#ffffff' : '#000000'
+    const lineStyle = {
+      color: lineColor,
+      opacity: 0.05
+    }
+    const pointerStyle = {
+      color: lineColor,
+      opacity: 0.5
+    }
+
+    const series = this.getChartSeries(sensor)
+    const axisUnit = this.getPrimaryUnit(sensor)
+    const axisName = axisUnit
+      ? `${this.$filters.prettyCase(this.getPrimaryDimension(sensor) ?? '')} ${axisUnit}`
+      : this.$filters.prettyCase(sensor.friendly_name)
+
+    return {
+      dataset: {
+        dimensions: this.getChartDimensions(sensor),
+        source: this.getChartData(sensor)
+      },
+      grid: {
+        top: 16,
+        left: 16,
+        right: 16,
+        bottom: 16,
+        outerBoundsMode: 'same',
+        outerBoundsContain: 'auto'
+      },
+      textStyle: {
+        fontFamily: 'Roboto'
+      },
+      legend: {
+        show: false
+      },
+      tooltip: {
+        trigger: 'axis',
+        backgroundColor: isDark ? 'rgba(15,15,15,0.75)' : 'rgba(255,255,255,0.75)',
+        borderColor: isDark ? 'rgba(0,0,0,0.85)' : 'rgba(255,255,255,0.85)',
+        textStyle: {
+          color: fontColor,
+          fontFamily: 'Roboto',
+          fontSize: 13
+        },
+        axisPointer: {
+          type: 'line',
+          lineStyle: pointerStyle,
+          label: {
+            color: fontColor,
+            fontSize: 14,
+            backgroundColor: isDark ? 'rgba(15,15,15,0.75)' : 'rgba(255,255,255,0.75)'
+          }
+        },
+        position: (pos, params, el, elRect, size) => {
+          const obj: Record<string, number> = { top: -10 }
+          obj[['left', 'right'][+(pos[0] < size.viewSize[0] / 2)]] = 10
+          return obj
+        },
+        formatter: (params) => this.formatTooltip(params, series)
+      },
+      xAxis: {
+        type: 'time',
+        max: 'dataMax',
+        min: (value: { max: number }) => {
+          const retention: number = this.$typedGetters['charts/getChartRetention']
+          return value.max - (retention * 1000)
+        },
+        axisTick: {
+          show: false
+        },
+        splitLine: {
+          show: true,
+          lineStyle
+        },
+        axisLabel: {
+          margin: 14,
+          color: fontColor,
+          fontSize: 14,
+          formatter: '{H}:{mm}',
+          rotate: 0
+        },
+        axisPointer: {
+          label: {
+            show: true,
+            margin: 9,
+            formatter: (params) => this.$filters.formatTimeWithSeconds(params.value)
+          }
+        }
+      },
+      yAxis: {
+        name: axisName,
+        nameTextStyle: {
+          fontSize: 14,
+          color: fontColor,
+          align: 'left'
+        },
+        nameGap: 8,
+        show: true,
+        type: 'value',
+        position: 'left',
+        scale: true,
+        splitLine: {
+          show: true,
+          lineStyle
+        },
+        axisLabel: {
+          margin: 8,
+          fontSize: 14,
+          color: fontColor
+        },
+        boundaryGap: [0, '100%']
+      },
+      dataZoom: [{
+        type: 'inside',
+        zoomOnMouseWheel: 'shift'
+      }],
+      series
+    }
+  }
+
+  getChartSeries (sensor: Moonraker.Sensor.Entry): SensorSeries[] {
+    return this.getChartDimensions(sensor)
+      .filter(key => key !== 'date')
+      .filter(key => this.isLegendSelected(sensor, key))
+      .map(key => ({
+        name: this.$filters.prettyCase(key),
+        unit: sensor.parameter_info?.find(x => x.name === key)?.units ?? '',
+        type: 'line',
+        showSymbol: false,
+        animation: false,
+        emphasis: {
+          focus: 'series'
+        },
+        lineStyle: {
+          width: 1.5,
+          opacity: 1
+        },
+        areaStyle: {
+          opacity: key === this.getPrimaryDimension(sensor) ? 0.05 : 0
+        },
+        encode: {
+          x: 'date',
+          y: key
+        }
+      }))
+  }
+
+  getChartKey (sensor: Moonraker.Sensor.Entry): string {
+    return `sensor:${sensor.id}`
+  }
+
+  getLegendKey (sensor: Moonraker.Sensor.Entry, key: string): string {
+    return `${sensor.id}:${key}`
+  }
+
+  getPrimaryDimension (sensor: Moonraker.Sensor.Entry): string | undefined {
+    const dimensions = this.getChartDimensions(sensor)
+      .filter(key => key !== 'date')
+
+    return dimensions.includes('power')
+      ? 'power'
+      : dimensions[0]
+  }
+
+  getPrimaryUnit (sensor: Moonraker.Sensor.Entry): string {
+    const primaryDimension = this.getPrimaryDimension(sensor)
+
+    return primaryDimension
+      ? sensor.parameter_info?.find(x => x.name === primaryDimension)?.units ?? ''
+      : ''
+  }
+
+  formatTooltip (params: unknown, series: SensorSeries[]): string {
+    if (!Array.isArray(params)) {
+      return ''
+    }
+
+    return params
+      .map((param) => {
+        if (
+          param == null ||
+          typeof param !== 'object' ||
+          !('seriesIndex' in param) ||
+          !('data' in param) ||
+          !('marker' in param)
+        ) {
+          return ''
+        }
+
+        const seriesIndex = Number(param.seriesIndex)
+        const item = series[seriesIndex]
+        const key = item?.encode?.y
+
+        if (typeof key !== 'string' || item == null) {
+          return ''
+        }
+
+        const data = param.data as Record<string, unknown>
+        const value = data[key]
+        const formattedValue = typeof value === 'number'
+          ? Math.round(value * 1000) / 1000
+          : '-'
+
+        return `
+          <div>
+            ${String(param.marker)}
+            <span>${this.sanitize(String(item.name))}:</span>
+            <strong style="float:right;margin-left:20px">
+              ${this.sanitize(String(formattedValue))} ${this.sanitize(item.unit ?? '')}
+            </strong>
+            <div style="clear:both"></div>
+          </div>`
+      })
+      .join('')
+  }
+
+  sanitize (value: string): string {
+    return value.replace(/[^\w .-]/g, (char: string) => `&#${char.charCodeAt(0)};`)
+  }
 }
 </script>
+
+<style lang="scss" scoped>
+  @import 'vuetify/src/styles/styles.sass';
+
+  .theme--light :deep(.v-data-table.sensor-table > .v-data-table__wrapper > table) {
+    color: rgba(map-get($material-light, 'text-color'), 1);
+  }
+
+  .theme--dark :deep(.v-data-table.sensor-table > .v-data-table__wrapper > table) {
+    color: rgba(map-get($material-dark, 'text-color'), 1);
+  }
+
+  :deep(.v-data-table.sensor-table > .v-data-table__wrapper > table) {
+    > thead > tr > th {
+      height: 40px;
+      white-space: nowrap;
+    }
+
+    > thead > tr > th:first-child,
+    > tbody > tr > td:first-child {
+      padding-left: 16px;
+    }
+
+    > thead > tr > th:not(:first-child),
+    > tbody > tr > td:not(:first-child) {
+      text-align: right;
+    }
+  }
+
+  .sensor-name {
+    font-size: 1rem;
+  }
+
+  .sensor-chart {
+    width: 100%;
+  }
+
+  .sensor-value {
+    font-weight: 300;
+    font-size: 1.125rem;
+    white-space: nowrap;
+  }
+
+  .legend-item {
+    display: inline-block;
+    opacity: 0.45;
+  }
+
+  .legend-item.toggle {
+    cursor: pointer;
+  }
+
+  .legend-item.active {
+    opacity: 1;
+  }
+</style>

--- a/src/store/sensors/actions.ts
+++ b/src/store/sensors/actions.ts
@@ -1,7 +1,42 @@
-import type { ActionTree } from 'vuex'
+import type { ActionTree, Commit } from 'vuex'
+import type { ChartData } from '../charts/types'
 import type { MoonrakerSensorsState } from './types'
 import type { RootState } from '../types'
 import { SocketActions } from '@/api/socketActions'
+
+const getSensorChartKey = (sensorId: string): string => `sensor:${sensorId}`
+
+const getNumericSensorValues = (values: Moonraker.Sensor.Values): Record<string, number> => {
+  return Object.fromEntries(
+    Object.entries(values)
+      .filter((entry): entry is [string, number] => typeof entry[1] === 'number')
+  )
+}
+
+const addSensorChartEntries = (
+  sensors: Record<string, Moonraker.Sensor.Values>,
+  commit: Commit,
+  retention: number
+) => {
+  for (const [sensorId, values] of Object.entries(sensors)) {
+    const sensorValues = getNumericSensorValues(values)
+
+    if (Object.keys(sensorValues).length === 0) {
+      continue
+    }
+
+    const data: ChartData = {
+      date: new Date(),
+      ...sensorValues
+    }
+
+    commit('charts/setChartEntry', {
+      type: getSensorChartKey(sensorId),
+      retention,
+      data
+    }, { root: true })
+  }
+}
 
 export const actions = {
   async reset ({ commit }) {
@@ -12,15 +47,31 @@ export const actions = {
     SocketActions.serverSensorsList()
   },
 
-  async onSensorsList ({ commit }, payload: Moonraker.Sensor.ListResponse) {
+  async onSensorsList ({ commit, rootGetters }, payload: Moonraker.Sensor.ListResponse) {
     if (payload) {
       commit('setSensorsList', payload)
+      addSensorChartEntries(
+        Object.fromEntries(
+          Object.entries(payload.sensors)
+            .map(([sensorId, sensor]) => [sensorId, sensor.values])
+        ),
+        commit,
+        rootGetters['charts/getChartRetention']
+      )
     }
   },
 
-  async onSensorUpdate ({ commit }, payload: Record<string, Moonraker.Sensor.Values>) {
+  async onSensorUpdate ({ commit, rootGetters, state }, payload: Record<string, Moonraker.Sensor.Values>) {
     if (payload) {
       commit('setSensorUpdate', payload)
+      addSensorChartEntries(
+        Object.fromEntries(
+          Object.keys(payload)
+            .map(sensorId => [sensorId, state.sensors[sensorId]?.values ?? payload[sensorId]])
+        ),
+        commit,
+        rootGetters['charts/getChartRetention']
+      )
     }
   }
 } satisfies ActionTree<MoonrakerSensorsState, RootState>

--- a/src/store/sensors/actions.ts
+++ b/src/store/sensors/actions.ts
@@ -4,6 +4,7 @@ import type { MoonrakerSensorsState } from './types'
 import type { RootState } from '../types'
 import { SocketActions } from '@/api/socketActions'
 
+const SENSOR_CHART_STORAGE_KEY = 'fluidd:sensorCharts'
 const getSensorChartKey = (sensorId: string): string => `sensor:${sensorId}`
 
 const getNumericSensorValues = (values: Moonraker.Sensor.Values): Record<string, number> => {
@@ -11,6 +12,97 @@ const getNumericSensorValues = (values: Moonraker.Sensor.Values): Record<string,
     Object.entries(values)
       .filter((entry): entry is [string, number] => typeof entry[1] === 'number')
   )
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> => (
+  value != null &&
+  typeof value === 'object' &&
+  !Array.isArray(value)
+)
+
+const getSensorChartCache = (): Record<string, ChartData[]> => {
+  try {
+    const item = localStorage.getItem(SENSOR_CHART_STORAGE_KEY)
+    const parsed: unknown = item != null ? JSON.parse(item) : {}
+
+    if (!isRecord(parsed)) {
+      return {}
+    }
+
+    return Object.fromEntries(
+      Object.entries(parsed)
+        .filter((entry): entry is [string, unknown[]] => Array.isArray(entry[1]))
+        .map(([key, entries]) => [
+          key,
+          entries
+            .filter(isRecord)
+            .map((entry) => {
+              const date = new Date(entry.date as string | number | Date)
+
+              return Object.fromEntries(
+                Object.entries(entry)
+                  .filter(([entryKey, value]) => entryKey === 'date' || typeof value === 'number')
+                  .map(([entryKey, value]) => [
+                    entryKey,
+                    entryKey === 'date' ? date : value
+                  ])
+              ) as ChartData
+            })
+            .filter(entry => !Number.isNaN(entry.date.valueOf()))
+        ])
+    )
+  } catch {
+    return {}
+  }
+}
+
+const setSensorChartCache = (cache: Record<string, ChartData[]>) => {
+  try {
+    localStorage.setItem(SENSOR_CHART_STORAGE_KEY, JSON.stringify(cache))
+  } catch {
+    // Ignore storage failures; live charting should keep working without persistence.
+  }
+}
+
+const saveSensorChartEntry = (key: string, data: ChartData, retention: number) => {
+  const cache = getSensorChartCache()
+  const entries = [
+    ...(cache[key] ?? []),
+    data
+  ]
+    .filter(entry => (Date.now() - entry.date.valueOf()) / 1000 < retention)
+
+  setSensorChartCache({
+    ...cache,
+    [key]: entries
+  })
+}
+
+const restoreSensorChartEntries = (sensorIds: string[], commit: Commit, retention: number) => {
+  const cache = getSensorChartCache()
+  const sensorChartKeys = sensorIds.map(getSensorChartKey)
+  const nextCache: Record<string, ChartData[]> = {}
+
+  for (const [key, entries] of Object.entries(cache)) {
+    if (!sensorChartKeys.includes(key)) {
+      continue
+    }
+
+    const retainedEntries = entries
+      .filter(entry => (Date.now() - entry.date.valueOf()) / 1000 < retention)
+
+    nextCache[key] = retainedEntries
+
+    for (const entry of retainedEntries) {
+      commit('charts/setChartEntry', {
+        type: key,
+        retention,
+        data: entry
+      }, { root: true })
+    }
+  }
+
+  setSensorChartCache(nextCache)
 }
 
 const addSensorChartEntries = (
@@ -35,6 +127,8 @@ const addSensorChartEntries = (
       retention,
       data
     }, { root: true })
+
+    saveSensorChartEntry(getSensorChartKey(sensorId), data, retention)
   }
 }
 
@@ -50,6 +144,11 @@ export const actions = {
   async onSensorsList ({ commit, rootGetters }, payload: Moonraker.Sensor.ListResponse) {
     if (payload) {
       commit('setSensorsList', payload)
+      restoreSensorChartEntries(
+        Object.keys(payload.sensors),
+        commit,
+        rootGetters['charts/getChartRetention']
+      )
       addSensorChartEntries(
         Object.fromEntries(
           Object.entries(payload.sensors)

--- a/src/store/sensors/mutations.ts
+++ b/src/store/sensors/mutations.ts
@@ -25,7 +25,12 @@ export const mutations = {
 
   setSensorUpdate (state, payload: Record<string, Moonraker.Sensor.Values>) {
     for (const sensorKey in payload) {
-      state.sensors[sensorKey].values = Object.freeze(payload[sensorKey])
+      if (state.sensors[sensorKey] != null) {
+        state.sensors[sensorKey].values = Object.freeze({
+          ...state.sensors[sensorKey].values,
+          ...payload[sensorKey]
+        })
+      }
     }
   }
 } satisfies MutationTree<MoonrakerSensorsState>


### PR DESCRIPTION
## AI-Warning
This fluidd-addon is vibecoded and hardcoded using Codex! i have no knowledge over vue. 

## Summary

Adds live graphs for numeric Moonraker sensor values in the Fluidd Sensors card.

This makes MQTT sensors such as Tasmota power monitors easier to inspect directly in Fluidd, with values like power, voltage, current, and energy shown in a Thermals-style layout.

## Changes

- Record numeric Moonraker sensor values in the existing chart store
- Merge partial sensor updates so values stay visible between updates
- Display sensor values in a table layout similar to Thermals
- Add a chart below sensors with numeric values
- Allow clicking numeric values to toggle chart lines

## Tested

Tested locally with a Moonraker MQTT sensor exposing:

- `power` in W
- `voltage` in V
- `current` in A
- `energy` in kWh

## Checks

- `pnpm run type-check`
- ESLint on changed files

Signed-off-by: Mike00107 <mike00107@gmail.com> 

<img width="873" height="410" alt="image" src="https://github.com/user-attachments/assets/a32dd14f-247c-43a6-8ed2-6238bf45c0bc" />