### PR TITLE
fix: split update check from notifications

### DIFF
--- a/src/components/layout/AppBar.vue
+++ b/src/components/layout/AppBar.vue
@@ -272,10 +272,6 @@ export default class AppBar extends Mixins(StateMixin, ServicesMixin, FilesMixin
     return this.$typedState.config.uiSettings.general.instanceName
   }
 
-  get hasUpdates (): boolean {
-    return this.$typedGetters['version/hasUpdates']
-  }
-
   get saveConfigPending (): boolean {
     return this.$typedGetters['printer/getSaveConfigPending']
   }

--- a/src/components/settings/VersionSettings.vue
+++ b/src/components/settings/VersionSettings.vue
@@ -198,16 +198,15 @@ export default class VersionSettings extends Mixins(StateMixin) {
     return this.$typedGetters['version/getVisibleComponents']
   }
 
-  get isRefreshing () {
+  get isRefreshing (): boolean {
     return this.hasWait(this.$waits.onVersionRefresh)
   }
 
-  get hasUpdates () {
-    const d = this.$typedGetters['version/hasUpdates']
-    return d
+  get hasUpdates (): boolean {
+    return this.$typedGetters['version/hasUpdates']
   }
 
-  get hasInvalidComponent () {
+  get hasInvalidComponent (): boolean {
     return this.components
       .some(component => !this.isValid(component))
   }
@@ -232,18 +231,18 @@ export default class VersionSettings extends Mixins(StateMixin) {
     return component.name
   }
 
-  hasUpdate (component: string) {
+  hasUpdate (component: string): boolean {
     return this.$typedGetters['version/hasUpdate'](component)
   }
 
-  isDirty (component: VersionInfo) {
+  isDirty (component: VersionInfo): boolean {
     return (
       'is_dirty' in component &&
       component.is_dirty
     )
   }
 
-  isValid (component: VersionInfo) {
+  isValid (component: VersionInfo): boolean {
     return (
       !('is_valid' in component) ||
       component.is_valid

--- a/src/store/version/actions.ts
+++ b/src/store/version/actions.ts
@@ -23,10 +23,13 @@ export const actions = {
   /**
    * Inits any file config we may have.
    */
-  async onUpdateStatus ({ commit, dispatch, getters }, payload: Partial<Moonraker.UpdateManager.StatusResponse>) {
+  async onUpdateStatus ({ commit, dispatch, getters, rootState }, payload: Partial<Moonraker.UpdateManager.StatusResponse>) {
     commit('setUpdateStatus', payload)
 
-    if (getters.hasUpdates) {
+    if (
+      rootState.config.uiSettings.general.enableVersionNotifications &&
+      getters.hasUpdates
+    ) {
       dispatch('notifications/pushNotification', {
         id: 'updates-available',
         title: i18n.t('app.version.label.updates_available'),

--- a/src/store/version/getters.ts
+++ b/src/store/version/getters.ts
@@ -39,11 +39,8 @@ export const getters = {
   /**
    * Returns an object indicating if any component (but system) has an update.
    */
-  hasUpdates: (state, getters, rootState) => {
-    const enableNotifications = rootState.config.uiSettings.general.enableVersionNotifications
-
+  hasUpdates: (state, getters) => {
     return (
-      enableNotifications &&
       state.status?.version_info != null &&
       Object.keys(state.status.version_info)
         .filter(name => name !== 'system')

--- a/src/typings/moonraker.update_manager.d.ts
+++ b/src/typings/moonraker.update_manager.d.ts
@@ -39,6 +39,7 @@ declare namespace Moonraker.UpdateManager {
     owner: string;
     branch: string;
     repo_name: string;
+    repo_detected?: boolean;
     is_dirty: boolean;
     corrupt: boolean;
     pristine: boolean;


### PR DESCRIPTION
The update status of the components was linked to having the notifications enabled, so they would not be shown as updatable if the notification was disabled.

This fixes the problem by splitting these two settings and only checking where necessary.

Fixes #1886