### PR TITLE
refactor: drop redundant console sanitize

### DIFF
--- a/src/store/console/actions.ts
+++ b/src/store/console/actions.ts
@@ -3,7 +3,6 @@ import { Globals } from '@/globals'
 import type { ConsoleEntry, ConsoleFilter, ConsoleState, PromptDialogButton, PromptDialogItemButton, PromptDialogItemText } from './types'
 import type { RootState } from '../types'
 import { SocketActions } from '@/api/socketActions'
-import DOMPurify from 'dompurify'
 import { takeRightWhile } from 'lodash-es'
 
 export const actions = {
@@ -43,13 +42,17 @@ export const actions = {
    * Add a console entry
    */
   async onAddConsoleEntry ({ commit, dispatch }, payload: Omit<ConsoleEntry, 'id'>) {
-    payload.message = DOMPurify.sanitize(payload.message).replace(/\r\n|\r|\n/g, '<br />')
+    payload.message = payload.message
+      .replace(/\r\n|\r|\n/g, '<br />')
+
     if (!payload.time || payload.time <= 0) {
       payload.time = Date.now() / 1000 | 0
     }
+
     if (!payload.type) {
       payload.type = 'response'
     }
+
     if (payload.type === 'response' && payload.message.startsWith('// action:')) {
       payload.type = 'action'
     }
@@ -66,8 +69,7 @@ export const actions = {
     if (payload && payload.gcode_store) {
       const entries = payload.gcode_store
         .map((entry, index): ConsoleEntry => {
-          const rawMessage = Globals.CONSOLE_RECEIVE_PREFIX + entry.message
-          const message = DOMPurify.sanitize(rawMessage)
+          const message = Globals.CONSOLE_RECEIVE_PREFIX + entry.message
             .replace(/\r\n|\r|\n/g, '<br />')
 
           const type = (


### PR DESCRIPTION
Console messages are already sanitized at render via `v-safe-html` (DOMPurify), and `ConsoleItem` injects further HTML after the store, so the store-side `DOMPurify.sanitize` never protected the rendered output.