### PR TITLE
feat: display-name aliases for Klipper objects

### DIFF
--- a/src/components/layout/AppSettingsNav.vue
+++ b/src/components/layout/AppSettingsNav.vue
@@ -45,6 +45,7 @@ export default class AppSettingsNav extends Vue {
       { name: this.$tc('app.setting.title.camera', 2), hash: '#camera', visible: true },
       { name: this.$t('app.setting.title.tool'), hash: '#toolhead', visible: true },
       { name: this.$t('app.setting.title.thermal_presets'), hash: '#presets', visible: true },
+      { name: this.$t('app.setting.title.aliases'), hash: '#aliases', visible: true },
       { name: this.$t('app.setting.title.gcode_preview'), hash: '#gcodePreview', visible: true },
       { name: this.$t('app.general.title.timelapse'), hash: '#timelapse', visible: this.supportsTimelapse },
       { name: this.$t('app.mmu.title.headline'), hash: '#mmu', visible: this.supportsMmu },

--- a/src/components/settings/AliasSettings.vue
+++ b/src/components/settings/AliasSettings.vue
@@ -1,0 +1,112 @@
+<template>
+  <div>
+    <v-subheader id="aliases">
+      {{ $t('app.setting.title.aliases') }}
+    </v-subheader>
+    <v-card
+      :elevation="5"
+      dense
+      class="mb-4"
+    >
+      <app-setting :title="$t('app.setting.label.aliases')">
+        <template #sub-title>
+          {{ $t('app.setting.tooltip.aliases') }}
+        </template>
+      </app-setting>
+
+      <template v-if="items.length">
+        <v-divider />
+
+        <template v-for="(item, index) in items">
+          <app-setting
+            :key="item.key"
+            :title="item.defaultPrettyName"
+            :sub-title="item.key"
+          >
+            <v-text-field
+              :value="aliases[item.key] || ''"
+              :placeholder="item.defaultPrettyName"
+              :aria-label="item.defaultPrettyName"
+              :maxlength="ALIAS_MAX_LENGTH"
+              spellcheck="false"
+              filled
+              dense
+              hide-details
+              clearable
+              @change="handleChange(item, $event)"
+            />
+          </app-setting>
+
+          <v-divider
+            v-if="index < items.length - 1"
+            :key="`divider-${item.key}`"
+          />
+        </template>
+      </template>
+    </v-card>
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Vue } from 'vue-property-decorator'
+import type { Fan, Led, OutputPin, Heater, Sensor } from '@/store/printer/types'
+
+// Shared cap on an alias length (UI-enforced; display-only value).
+const ALIAS_MAX_LENGTH = 64
+
+interface AliasItem {
+  key: string;
+  // True pre-alias default name (shown as the placeholder). Sourced from the
+  // getter's `defaultPrettyName`, NOT re-derived, so the fan→'Part Fan' and
+  // tmc2240 special-cases stay correct even while an alias is active.
+  defaultPrettyName: string;
+}
+
+@Component({})
+export default class AliasSettings extends Vue {
+  readonly ALIAS_MAX_LENGTH = ALIAS_MAX_LENGTH
+
+  // Read live from the store so async DB load (mergeWith) and external changes
+  // stay reflected in every row's text field.
+  get aliases (): Record<string, string> {
+    return this.$typedState.config.uiSettings.dashboard.aliases
+  }
+
+  // All aliasable Klipper objects: fans, output pins, LEDs, heaters and sensors.
+  // Uses the ARRAY getters — getOutputs is curried and must not be spread.
+  get items (): AliasItem[] {
+    const fans: Fan[] = this.$typedGetters['printer/getAllFans']
+    const pins: OutputPin[] = this.$typedGetters['printer/getAllPins']
+    const leds: Led[] = this.$typedGetters['printer/getAllLeds']
+    const heaters: Heater[] = this.$typedGetters['printer/getHeaters']
+    const sensors: Sensor[] = this.$typedGetters['printer/getSensors']
+
+    const groups = [...fans, ...pins, ...leds, ...heaters, ...sensors]
+
+    // Dedup by full config key (defensive; getter key-groups are disjoint).
+    const seen = new Set<string>()
+
+    return groups
+      .filter((item) => {
+        if (!item?.key || seen.has(item.key)) return false
+        seen.add(item.key)
+        return true
+      })
+      .map((item): AliasItem => ({
+        key: item.key,
+        defaultPrettyName: item.defaultPrettyName ?? item.prettyName
+      }))
+      .sort((a, b) => a.key.localeCompare(b.key))
+  }
+
+  handleChange (item: AliasItem, value: string | null) {
+    const name = (value ?? '').trim()
+
+    if (name) {
+      this.$typedDispatch('config/updateAlias', { key: item.key, name })
+    } else {
+      this.$typedDispatch('config/removeAlias', { key: item.key })
+    }
+  }
+}
+</script>

--- a/src/components/widgets/outputs/OutputFan.vue
+++ b/src/components/widgets/outputs/OutputFan.vue
@@ -5,7 +5,7 @@
       suffix="%"
       :value="value"
       :reset-value="0"
-      :label="(rpm) ? `${fan.prettyName} <small>${rpm}</small>` : fan.prettyName"
+      :label="label"
       :rules="[
         customRules.minFan
       ]"
@@ -43,12 +43,19 @@ import { Component, Mixins, Prop } from 'vue-property-decorator'
 import type { Fan } from '@/store/printer/types'
 import StateMixin from '@/mixins/state'
 import BrowserMixin from '@/mixins/browser'
-import { encodeGcodeParamValue } from '@/util/gcode-helpers'
+import buildOutputLabel from '@/util/build-output-label'
+import { buildFanSpeedGcode } from '@/util/output-gcode'
 
 @Component({})
 export default class OutputFan extends Mixins(StateMixin, BrowserMixin) {
   @Prop({ type: Object, required: true })
   readonly fan!: Fan
+
+  // prettyName may be a user-supplied alias; the label is rendered as HTML
+  // (v-safe-html) so escape it before composing the optional <small> rpm markup.
+  get label () {
+    return buildOutputLabel(this.fan.prettyName, this.rpm)
+  }
 
   get prettyValue () {
     return (this.value === 0)
@@ -63,14 +70,11 @@ export default class OutputFan extends Mixins(StateMixin, BrowserMixin) {
   }
 
   handleChange (target: number) {
-    // If this is a controllable fan, it's either the part fan [fan] or a generic fan [fan_generic].
-    if (this.fan.type === 'fan') {
-      target = Math.ceil(target * 2.55)
-      this.sendGcode(`M106 S${target}`, `${this.$waits.onSetFanSpeed}${this.fan.name}`)
-    }
-    if (this.fan.type === 'fan_generic') {
-      target = target / 100
-      this.sendGcode(`SET_FAN_SPEED FAN=${encodeGcodeParamValue(this.fan.name)} SPEED=${target}`, `${this.$waits.onSetFanSpeed}${this.fan.name}`)
+    // Display-only: the command is keyed by the raw Klipper name, never the alias.
+    const gcode = buildFanSpeedGcode(this.fan, target)
+
+    if (gcode) {
+      this.sendGcode(gcode, `${this.$waits.onSetFanSpeed}${this.fan.name}`)
     }
   }
 

--- a/src/components/widgets/outputs/OutputPin.vue
+++ b/src/components/widgets/outputs/OutputPin.vue
@@ -3,7 +3,7 @@
     <app-named-slider
       v-if="pwm"
       suffix="%"
-      :label="pin.prettyName"
+      :label="label"
       :min="0"
       :max="100"
       :value="value"
@@ -17,7 +17,7 @@
     <app-named-switch
       v-else
       :disabled="!klippyReady || pin.disconnected"
-      :label="pin.prettyName"
+      :label="label"
       :value="pin.value > 0"
       :loading="hasWait(`${$waits.onSetOutputPin}${pin.name}`)"
       @input="handleChange"
@@ -30,12 +30,18 @@ import { Component, Mixins, Prop } from 'vue-property-decorator'
 import StateMixin from '@/mixins/state'
 import BrowserMixin from '@/mixins/browser'
 import type { OutputPin as IOutputPin } from '@/store/printer/types'
-import { encodeGcodeParamValue } from '@/util/gcode-helpers'
+import buildOutputLabel from '@/util/build-output-label'
+import { buildSetPinGcode } from '@/util/output-gcode'
 
 @Component({})
 export default class OutputPin extends Mixins(StateMixin, BrowserMixin) {
   @Prop({ type: Object, required: true })
   readonly pin!: IOutputPin
+
+  // prettyName may be a user-supplied alias rendered as HTML (v-safe-html label).
+  get label () {
+    return buildOutputLabel(this.pin.prettyName)
+  }
 
   get pwm () {
     return (
@@ -68,7 +74,8 @@ export default class OutputPin extends Mixins(StateMixin, BrowserMixin) {
       target = Math.round(target * this.pin.scale) / 100
     }
 
-    this.sendGcode(`SET_PIN PIN=${encodeGcodeParamValue(this.pin.name)} VALUE=${target}`, `${this.$waits.onSetOutputPin}${this.pin.name}`)
+    // Display-only: the command is keyed by the raw Klipper name, never the alias.
+    this.sendGcode(buildSetPinGcode(this.pin.name, target), `${this.$waits.onSetOutputPin}${this.pin.name}`)
   }
 }
 </script>

--- a/src/components/widgets/thermals/ThermalChart.vue
+++ b/src/components/widgets/thermals/ThermalChart.vue
@@ -43,6 +43,7 @@ import { Component, Watch, Prop, Ref, Mixins } from 'vue-property-decorator'
 import type { ECharts, EChartsInitOpts, EChartsOption, LineSeriesOption } from 'echarts'
 import getKlipperType from '@/util/get-klipper-type'
 import BrowserMixin from '@/mixins/browser'
+import { formatThermalTooltip } from './thermal-tooltip-formatter'
 import type { ChartData, ChartSelectedLegends } from '@/store/charts/types'
 
 @Component({})
@@ -102,6 +103,10 @@ export default class ThermalChart extends Mixins(BrowserMixin) {
 
   get sensorColors (): Record<string, string> {
     return this.$typedState.config.uiSettings.dashboard.sensorColors
+  }
+
+  get aliases (): Record<string, string> {
+    return this.$typedState.config.uiSettings.dashboard.aliases
   }
 
   @Watch('sensorColors', { deep: true })
@@ -267,48 +272,14 @@ export default class ThermalChart extends Mixins(BrowserMixin) {
           obj[['left', 'right'][+(pos[0] < size.viewSize[0] / 2)]] = 10
           return obj
         },
-        formatter: (params) => {
-          if (!Array.isArray(params)) {
-            return ''
-          }
-
-          let text = ''
-          params
-            .forEach((param: any) => {
-              if (
-                param.seriesName &&
-                !param.seriesName.endsWith('#target') &&
-                !param.seriesName.endsWith('#power') &&
-                !param.seriesName.endsWith('#speed') &&
-                param.value[param.seriesName] != null
-              ) {
-                const name = param.seriesName.trim().split(/\s+/).pop() || ''
-                text += `
-                  <div>
-                    ${param.marker}
-                    <span style="font-size:${fontSize}px;color:${fontColor};font-weight:400;margin-left:2px">
-                      ${this.$filters.prettyCase(name)}:
-                    </span>
-                    <span style="float:right;margin-left:20px;font-size:${fontSize}px;color:${fontColor};font-weight:900">
-                      ${param.value[param.seriesName].toFixed(2)}<small>°C</small>`
-
-                if (param.value[`${param.seriesName}#target`] != null) {
-                  text += ` / ${param.value[`${param.seriesName}#target`].toFixed()}<small>°C</small>`
-                }
-                if (param.value[`${param.seriesName}#power`] != null) {
-                  text += ` / ${(param.value[`${param.seriesName}#power`] * 100).toFixed()}<small>%</small>`
-                }
-                if (param.value[`${param.seriesName}#speed`] != null) {
-                  text += ` / ${(param.value[`${param.seriesName}#speed`] * 100).toFixed()}<small>%</small>`
-                }
-                text += `</span>
-                  <div style="clear: both"></div>
-                </div>
-                <div style="clear: both"></div>`
-              }
-            })
-          return text
-        }
+        // Reads the live `aliases` object per-hover so in-place Vue.set/Vue.delete
+        // mutations are reflected without rebuilding the chart options.
+        formatter: (params) => formatThermalTooltip(params, {
+          aliases: this.aliases,
+          prettyCase: (value: string) => this.$filters.prettyCase(value),
+          fontColor,
+          fontSize
+        })
       },
       xAxis: {
         type: 'time',

--- a/src/components/widgets/thermals/__tests__/thermalchart-tooltip.spec.ts
+++ b/src/components/widgets/thermals/__tests__/thermalchart-tooltip.spec.ts
@@ -1,0 +1,44 @@
+import { formatThermalTooltip, type ThermalTooltipContext } from '../thermal-tooltip-formatter'
+
+const KEY = 'temperature_sensor chamber'
+
+const ctx = (aliases: Record<string, string> = {}): ThermalTooltipContext => ({
+  aliases,
+  prettyCase: (v: string) => `p:${v}`,
+  fontColor: '#000',
+  fontSize: 14,
+})
+
+const param = (overrides: Record<string, any> = {}) => ({
+  seriesName: KEY,
+  marker: '<span></span>',
+  value: { [KEY]: 42.5 },
+  ...overrides,
+})
+
+describe('formatThermalTooltip', () => {
+  it('returns empty string for non-array params', () => {
+    expect(formatThermalTooltip({}, ctx())).toBe('')
+  })
+
+  it('shows the alias in the tooltip when one is set (AC1)', () => {
+    const html = formatThermalTooltip([param()], ctx({ [KEY]: 'Chamber' }))
+    expect(html).toContain('Chamber:')
+  })
+
+  it('falls back to the default label for an EMPTY-string alias (|| not ??)', () => {
+    const html = formatThermalTooltip([param()], ctx({ [KEY]: '' }))
+    expect(html).toContain('p:chamber:')
+  })
+
+  it('HTML-escapes a malicious alias — no live markup reaches the sink (AC6)', () => {
+    const html = formatThermalTooltip([param()], ctx({ [KEY]: '<img src=x onerror=alert(1)>' }))
+    expect(html).toContain('&lt;img src=x onerror=alert(1)&gt;')
+    expect(html).not.toContain('<img src=x')
+  })
+
+  it('renders the temperature value', () => {
+    const html = formatThermalTooltip([param()], ctx())
+    expect(html).toContain('42.50')
+  })
+})

--- a/src/components/widgets/thermals/thermal-tooltip-formatter.ts
+++ b/src/components/widgets/thermals/thermal-tooltip-formatter.ts
@@ -1,0 +1,66 @@
+import resolveAliasLabel from '@/util/resolve-alias-label'
+
+export interface ThermalTooltipContext {
+  // Live alias map; read per-hover so in-place Vue.set/Vue.delete stay reflected.
+  aliases: Record<string, string>
+  prettyCase: (value: string) => string
+  fontColor: string
+  fontSize: number
+}
+
+/**
+ * Build the ECharts tooltip HTML for the thermal chart.
+ *
+ * Extracted from ThermalChart so the alias-resolution + HTML-escape wiring
+ * (AC1 tooltip + AC6 XSS) is unit-testable without mounting the component.
+ * The series label is resolved via `resolveAliasLabel`, which applies the user
+ * alias (keyed by the full `seriesName`) AND escapes it — escaping alone would
+ * show the auto name; both steps are required.
+ */
+export const formatThermalTooltip = (params: unknown, ctx: ThermalTooltipContext): string => {
+  if (!Array.isArray(params)) {
+    return ''
+  }
+
+  const { aliases, prettyCase, fontColor, fontSize } = ctx
+
+  let text = ''
+
+  params.forEach((param: any) => {
+    if (
+      param.seriesName &&
+      !param.seriesName.endsWith('#target') &&
+      !param.seriesName.endsWith('#power') &&
+      !param.seriesName.endsWith('#speed') &&
+      param.value[param.seriesName] != null
+    ) {
+      const name = param.seriesName.trim().split(/\s+/).pop() || ''
+      const label = resolveAliasLabel(param.seriesName, aliases, prettyCase(name))
+
+      text += `
+        <div>
+          ${param.marker}
+          <span style="font-size:${fontSize}px;color:${fontColor};font-weight:400;margin-left:2px">
+            ${label}:
+          </span>
+          <span style="float:right;margin-left:20px;font-size:${fontSize}px;color:${fontColor};font-weight:900">
+            ${param.value[param.seriesName].toFixed(2)}<small>°C</small>`
+
+      if (param.value[`${param.seriesName}#target`] != null) {
+        text += ` / ${param.value[`${param.seriesName}#target`].toFixed()}<small>°C</small>`
+      }
+      if (param.value[`${param.seriesName}#power`] != null) {
+        text += ` / ${(param.value[`${param.seriesName}#power`] * 100).toFixed()}<small>%</small>`
+      }
+      if (param.value[`${param.seriesName}#speed`] != null) {
+        text += ` / ${(param.value[`${param.seriesName}#speed`] * 100).toFixed()}<small>%</small>`
+      }
+      text += `</span>
+        <div style="clear: both"></div>
+      </div>
+      <div style="clear: both"></div>`
+    }
+  })
+
+  return text
+}

--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -723,6 +723,7 @@ app:
       '270': 270°
       none: None
     label:
+      aliases: Custom display names
       all_off: All off
       all_on: All on
       aspect_ratio: Aspect Ratio
@@ -867,6 +868,7 @@ app:
       slicer: Slicer
       slicer_m73: Slicer (M73)
     title:
+      aliases: Custom Names
       authentication: Authentication
       console: Console
       camera: Camera | Cameras
@@ -880,6 +882,9 @@ app:
       tool: Tool
       warnings: Warnings
     tooltip:
+      aliases: Give fans, output pins, LEDs, heaters and temperature sensors friendly
+        display names. This only changes what Fluidd shows — the Klipper
+        configuration and object names are left untouched.
       average_calculation: If more than one option is select, an average will be
         calculated
       diagnostics_performance: '[BETA] Logging diagnostics info may impact performance'

--- a/src/store/config/__tests__/aliases.spec.ts
+++ b/src/store/config/__tests__/aliases.spec.ts
@@ -1,0 +1,108 @@
+import { vi } from 'vitest'
+import { SocketActions } from '@/api/socketActions'
+import { mutations } from '../mutations'
+import { actions } from '../actions'
+import type { ConfigState } from '../types'
+
+vi.mock('@/api/socketActions', () => ({
+  SocketActions: {
+    serverDatabasePostItem: vi.fn(),
+    serverDatabaseDeleteItem: vi.fn(),
+  },
+}))
+
+// Minimal slice of ConfigState needed by the alias mutations/actions.
+const makeState = (aliases: Record<string, string> = {}): ConfigState =>
+  ({ uiSettings: { dashboard: { aliases } } } as unknown as ConfigState)
+
+// Typed shims so the actions can be called directly with a mock context.
+type Commit = (type: string, payload?: unknown) => void
+type Dispatch = (type: string, payload?: unknown) => Promise<void>
+type UpdateAlias = (ctx: { commit: Commit; dispatch: Dispatch }, payload: { key: string; name: string }) => Promise<void>
+type RemoveAlias = (ctx: { commit: Commit; state: ConfigState }, payload: { key: string }) => Promise<void>
+const updateAlias = actions.updateAlias as unknown as UpdateAlias
+const removeAlias = actions.removeAlias as unknown as RemoveAlias
+
+const KEY = 'output_pin fan2'
+const DB_PATH = ['uiSettings', 'dashboard', 'aliases', 'output_pin fan2']
+
+describe('config store — aliases', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('mutations', () => {
+    it('setAlias adds a new entry (reactively via Vue.set)', () => {
+      const state = makeState()
+      mutations.setAlias(state, { key: KEY, name: 'Side Fan' })
+      expect(state.uiSettings.dashboard.aliases).toStrictEqual({ [KEY]: 'Side Fan' })
+    })
+
+    it('setAlias overwrites an existing entry', () => {
+      const state = makeState({ [KEY]: 'Old' })
+      mutations.setAlias(state, { key: KEY, name: 'New' })
+      expect(state.uiSettings.dashboard.aliases[KEY]).toBe('New')
+    })
+
+    it('setRemoveAlias deletes an entry', () => {
+      const state = makeState({ [KEY]: 'Side Fan' })
+      mutations.setRemoveAlias(state, { key: KEY })
+      expect(state.uiSettings.dashboard.aliases).toStrictEqual({})
+    })
+  })
+
+  describe('actions', () => {
+    it('updateAlias commits and persists the trimmed value (key kept whole)', async () => {
+      const commit = vi.fn()
+      const dispatch = vi.fn()
+      await updateAlias({ commit, dispatch }, { key: KEY, name: '  Side Fan  ' })
+      expect(commit).toHaveBeenCalledWith('setAlias', { key: KEY, name: 'Side Fan' })
+      expect(SocketActions.serverDatabasePostItem).toHaveBeenCalledWith(DB_PATH, 'Side Fan')
+      expect(dispatch).not.toHaveBeenCalled()
+    })
+
+    it('updateAlias keeps a dotted key unsplit in the DB path', async () => {
+      const commit = vi.fn()
+      const dispatch = vi.fn()
+      await updateAlias({ commit, dispatch }, { key: 'temperature_sensor my.sensor', name: 'Chamber' })
+      expect(SocketActions.serverDatabasePostItem).toHaveBeenCalledWith(
+        ['uiSettings', 'dashboard', 'aliases', 'temperature_sensor my.sensor'],
+        'Chamber'
+      )
+    })
+
+    it('updateAlias with a blank name delegates to removeAlias and never persists ""', async () => {
+      const commit = vi.fn()
+      const dispatch = vi.fn()
+      await updateAlias({ commit, dispatch }, { key: KEY, name: '   ' })
+      expect(dispatch).toHaveBeenCalledWith('removeAlias', { key: KEY })
+      expect(commit).not.toHaveBeenCalled()
+      expect(SocketActions.serverDatabasePostItem).not.toHaveBeenCalled()
+    })
+
+    it('removeAlias deletes from the DB when the alias existed', async () => {
+      const commit = vi.fn()
+      const state = makeState({ [KEY]: 'Side Fan' })
+      await removeAlias({ commit, state }, { key: KEY })
+      expect(commit).toHaveBeenCalledWith('setRemoveAlias', { key: KEY })
+      expect(SocketActions.serverDatabaseDeleteItem).toHaveBeenCalledWith(DB_PATH)
+    })
+
+    it('removeAlias skips the network delete when no alias existed', async () => {
+      const commit = vi.fn()
+      const state = makeState({})
+      await removeAlias({ commit, state }, { key: KEY })
+      expect(commit).toHaveBeenCalledWith('setRemoveAlias', { key: KEY })
+      expect(SocketActions.serverDatabaseDeleteItem).not.toHaveBeenCalled()
+    })
+
+    it('removeAlias is not spoofed by a prototype-chain key name', async () => {
+      const commit = vi.fn()
+      const state = makeState({})
+      // `constructor`/`toString` are truthy via `key in obj` but must NOT trigger a delete.
+      await removeAlias({ commit, state }, { key: 'constructor' })
+      await removeAlias({ commit, state }, { key: 'toString' })
+      expect(SocketActions.serverDatabaseDeleteItem).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/store/config/__tests__/sensor-colors-guard.spec.ts
+++ b/src/store/config/__tests__/sensor-colors-guard.spec.ts
@@ -1,0 +1,55 @@
+import { vi } from 'vitest'
+import { SocketActions } from '@/api/socketActions'
+import { actions } from '../actions'
+import type { ConfigState } from '../types'
+
+// Regression for the guarded-delete backport (review finding F5): removeSensorColor
+// must use an own-property check, not `key in`, so a prototype-chain key name
+// cannot spoof a Moonraker delete_item on a never-stored override.
+
+vi.mock('@/api/socketActions', () => ({
+  SocketActions: {
+    serverDatabasePostItem: vi.fn(),
+    serverDatabaseDeleteItem: vi.fn(),
+  },
+}))
+
+const makeState = (sensorColors: Record<string, string> = {}): ConfigState =>
+  ({ uiSettings: { dashboard: { sensorColors } } } as unknown as ConfigState)
+
+type Commit = (type: string, payload?: unknown) => void
+type RemoveSensorColor = (ctx: { commit: Commit; state: ConfigState }, payload: { key: string }) => Promise<void>
+const removeSensorColor = actions.removeSensorColor as unknown as RemoveSensorColor
+
+const KEY = 'temperature_sensor chamber'
+
+describe('config store — removeSensorColor guarded delete', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('deletes from the DB when the override existed', async () => {
+    const commit = vi.fn()
+    const state = makeState({ [KEY]: '#ff0000' })
+    await removeSensorColor({ commit, state }, { key: KEY })
+    expect(commit).toHaveBeenCalledWith('setRemoveSensorColor', { key: KEY })
+    expect(SocketActions.serverDatabaseDeleteItem).toHaveBeenCalledWith(
+      ['uiSettings', 'dashboard', 'sensorColors', KEY]
+    )
+  })
+
+  it('skips the network delete when no override existed', async () => {
+    const commit = vi.fn()
+    const state = makeState({})
+    await removeSensorColor({ commit, state }, { key: KEY })
+    expect(SocketActions.serverDatabaseDeleteItem).not.toHaveBeenCalled()
+  })
+
+  it('is not spoofed by a prototype-chain key name', async () => {
+    const commit = vi.fn()
+    const state = makeState({})
+    await removeSensorColor({ commit, state }, { key: 'constructor' })
+    await removeSensorColor({ commit, state }, { key: 'toString' })
+    expect(SocketActions.serverDatabaseDeleteItem).not.toHaveBeenCalled()
+  })
+})

--- a/src/store/config/actions.ts
+++ b/src/store/config/actions.ts
@@ -160,11 +160,47 @@ export const actions = {
    */
   async removeSensorColor ({ commit, state }, payload: { key: string }) {
     // Guard: delete_item errors on a key Moonraker never stored, so only fire the
-    // network delete when an override actually existed.
-    const existed = payload.key in state.uiSettings.dashboard.sensorColors
+    // network delete when an override actually existed. Own-property check (not
+    // `key in`) so a Klipper section named like a prototype member (e.g.
+    // `constructor`) can't spoof a delete on an empty map — mirrors removeAlias.
+    const existed = Object.prototype.hasOwnProperty.call(state.uiSettings.dashboard.sensorColors, payload.key)
     commit('setRemoveSensorColor', payload)
     if (existed) {
       SocketActions.serverDatabaseDeleteItem(dbKey`uiSettings.dashboard.sensorColors.${payload.key}`)
+    }
+  },
+
+  /**
+   * Set or update the display-name alias for a fan, output pin, LED, heater or sensor.
+   * Display-only: persists to the Moonraker DB `fluidd` namespace, never to Klipper config.
+   */
+  async updateAlias ({ commit, dispatch }, payload: { key: string; name: string }) {
+    const name = payload.name.trim()
+
+    // Never persist an empty alias. Delegate to removeAlias so the DB entry is
+    // cleared via the guarded delete, keeping the getter fallback (`|| default`)
+    // and the tooltip resolver in agreement.
+    if (name === '') {
+      await dispatch('removeAlias', { key: payload.key })
+      return
+    }
+
+    commit('setAlias', { key: payload.key, name })
+    SocketActions.serverDatabasePostItem(dbKey`uiSettings.dashboard.aliases.${payload.key}`, name)
+  },
+
+  /**
+   * Remove the display-name alias for a fan, output pin, LED, heater or sensor.
+   */
+  async removeAlias ({ commit, state }, payload: { key: string }) {
+    // Guard: delete_item errors on a key Moonraker never stored, so only fire the
+    // network delete when an alias actually existed. Use an own-property check
+    // (not `key in`) so a Klipper section named like a prototype member
+    // (e.g. `constructor`, `toString`) can't spoof a delete on an empty map.
+    const existed = Object.prototype.hasOwnProperty.call(state.uiSettings.dashboard.aliases, payload.key)
+    commit('setRemoveAlias', payload)
+    if (existed) {
+      SocketActions.serverDatabaseDeleteItem(dbKey`uiSettings.dashboard.aliases.${payload.key}`)
     }
   },
 

--- a/src/store/config/mutations.ts
+++ b/src/store/config/mutations.ts
@@ -174,6 +174,21 @@ export const mutations = {
     Vue.delete(state.uiSettings.dashboard.sensorColors, payload.key)
   },
 
+  /**
+   * Set / update a display-name alias for a fan, output pin, LED, heater or sensor.
+   * Display-only: this never renames the underlying Klipper object.
+   */
+  setAlias (state, payload: { key: string; name: string }) {
+    Vue.set(state.uiSettings.dashboard.aliases, payload.key, payload.name)
+  },
+
+  /**
+   * Remove a display-name alias.
+   */
+  setRemoveAlias (state, payload: { key: string }) {
+    Vue.delete(state.uiSettings.dashboard.aliases, payload.key)
+  },
+
   setFileSystemActiveFilters (state, payload: { root: string, value: FileFilterType[] }) {
     Vue.set(state.uiSettings.fileSystem.activeFilters, payload.root, payload.value)
   },

--- a/src/store/config/state.ts
+++ b/src/store/config/state.ts
@@ -90,7 +90,8 @@ export const defaultState = (): ConfigState => {
       },
       dashboard: {
         tempPresets: [],
-        sensorColors: {}
+        sensorColors: {},
+        aliases: {}
       },
       tableHeaders: {},
       thumbnailSizes: {},

--- a/src/store/config/types.ts
+++ b/src/store/config/types.ts
@@ -207,6 +207,7 @@ export interface AxisConfig {
 export interface DashboardConfig {
   tempPresets: TemperaturePreset[];
   sensorColors: Record<string, string>;
+  aliases: Record<string, string>;
 }
 
 export interface SaveByPath {

--- a/src/store/printer/__tests__/getters-aliases.spec.ts
+++ b/src/store/printer/__tests__/getters-aliases.spec.ts
@@ -1,0 +1,128 @@
+import Vue from 'vue'
+import { getters } from '../getters'
+
+// Stub the prettyCase filter + colorset so assertions target the alias-override
+// logic, not prettyCase formatting or colour resolution (covered elsewhere).
+const originalFilters = Vue.$filters
+const originalColorset = Vue.$colorset
+beforeAll(() => {
+  Vue.$filters = { prettyCase: (v: string) => `p:${v}` } as typeof Vue.$filters
+  Vue.$colorset = { next: (_t: string, _k: string, c?: string) => c ?? '#000000' } as unknown as typeof Vue.$colorset
+})
+afterAll(() => {
+  Vue.$filters = originalFilters
+  Vue.$colorset = originalColorset
+})
+
+const gettersArg = {
+  getNonCriticalDisconnectedMcusSet: new Set<string>(),
+  getExtraSensorData: () => ({}),
+} as any
+
+const rootState = (aliases: Record<string, string> = {}) =>
+  ({ config: { uiSettings: { dashboard: { aliases, sensorColors: {} } } } }) as any
+
+const byKey = (list: any[], key: string) => list.find((o) => o.key === key)
+
+// --- getOutputs (fans / output pins / LEDs) -------------------------------
+
+const outputsState = () => ({
+  printer: {
+    fan: { speed: 0 }, // the part fan (type "fan", name "fan")
+    'output_pin fan2': { value: 0 },
+    configfile: { settings: {} },
+  },
+}) as any
+
+const outputs = (aliases: Record<string, string> = {}) =>
+  getters.getOutputs(outputsState(), gettersArg, rootState(aliases))()
+
+describe('printer getters — getOutputs alias override', () => {
+  it('falls back to the computed defaultPrettyName when no alias is set', () => {
+    const row = byKey(outputs(), 'output_pin fan2')
+    expect(row.prettyName).toBe('p:fan2')
+    expect(row.defaultPrettyName).toBe('p:fan2')
+  })
+
+  it('overrides prettyName with the alias, leaving defaultPrettyName + raw identifiers intact', () => {
+    const row = byKey(outputs({ 'output_pin fan2': 'Side Fan' }), 'output_pin fan2')
+    expect(row.prettyName).toBe('Side Fan')
+    expect(row.defaultPrettyName).toBe('p:fan2')
+    // AC4 (display-only): the G-code path reads `name`/`key` — these MUST stay raw.
+    expect(row.name).toBe('fan2')
+    expect(row.key).toBe('output_pin fan2')
+  })
+
+  it('keeps the "Part Fan" special case as the default for the part fan', () => {
+    const row = byKey(outputs(), 'fan')
+    expect(row.prettyName).toBe('Part Fan')
+    expect(row.defaultPrettyName).toBe('Part Fan')
+  })
+
+  it('lets an alias override the "Part Fan" special case', () => {
+    const row = byKey(outputs({ fan: 'My Part Fan' }), 'fan')
+    expect(row.prettyName).toBe('My Part Fan')
+    expect(row.defaultPrettyName).toBe('Part Fan')
+  })
+})
+
+// --- getHeaters (single-token keys: heater_bed / extruder) ------------------
+
+const heatersState = () => ({
+  printer: {
+    heaters: { available_heaters: ['heater_bed', 'extruder'] },
+    heater_bed: { temperature: 20 },
+    extruder: { temperature: 200 },
+    configfile: { settings: {} },
+  },
+}) as any
+
+const heaters = (aliases: Record<string, string> = {}) =>
+  getters.getHeaters(heatersState(), gettersArg, rootState(aliases))
+
+describe('printer getters — getHeaters alias override', () => {
+  it('resolves single-token heater keys and falls back to the default', () => {
+    const row = byKey(heaters(), 'heater_bed')
+    expect(row.key).toBe('heater_bed')
+    expect(row.prettyName).toBe('p:heater_bed')
+    expect(row.defaultPrettyName).toBe('p:heater_bed')
+  })
+
+  it('overrides a single-token heater with an alias, keeping name/key raw', () => {
+    const row = byKey(heaters({ heater_bed: 'Bed' }), 'heater_bed')
+    expect(row.prettyName).toBe('Bed')
+    expect(row.defaultPrettyName).toBe('p:heater_bed')
+    expect(row.name).toBe('heater_bed')
+  })
+})
+
+// --- getSensors (tmc2240 special-case + temperature_sensor) -----------------
+
+const sensorsState = () => ({
+  printer: {
+    'temperature_sensor chamber': { temperature: 25 },
+    'tmc2240 stepper_x': { temperature: 40 },
+    configfile: { settings: {} },
+  },
+}) as any
+
+const sensors = (aliases: Record<string, string> = {}) =>
+  getters.getSensors(sensorsState(), gettersArg, rootState(aliases))
+
+describe('printer getters — getSensors alias override', () => {
+  it('falls back to the computed default for a temperature sensor', () => {
+    const row = byKey(sensors(), 'temperature_sensor chamber')
+    expect(row.prettyName).toBe('p:chamber')
+    expect(row.defaultPrettyName).toBe('p:chamber')
+  })
+
+  it('overrides the tmc2240 stepper_driver special-case with an alias', () => {
+    const row = byKey(sensors({ 'tmc2240 stepper_x': 'Driver X' }), 'tmc2240 stepper_x')
+    expect(row.prettyName).toBe('Driver X')
+    // defaultPrettyName keeps the (non-obvious) stepper_driver default, whatever it renders to.
+    expect(typeof row.defaultPrettyName).toBe('string')
+    expect(row.defaultPrettyName.length).toBeGreaterThan(0)
+    expect(row.defaultPrettyName).not.toBe('Driver X')
+    expect(row.key).toBe('tmc2240 stepper_x')
+  })
+})

--- a/src/store/printer/getters.ts
+++ b/src/store/printer/getters.ts
@@ -581,6 +581,7 @@ export const getters = {
   getHeaters: (state, getters, rootState): Heater[] => {
     const nonCriticalDisconnectedMcusSet: Set<string> = getters.getNonCriticalDisconnectedMcusSet
     const sensorColors: Record<string, string> = rootState.config.uiSettings.dashboard.sensorColors
+    const aliases: Record<string, string> = rootState.config.uiSettings.dashboard.aliases
 
     const heaters: Heater[] = []
 
@@ -597,7 +598,8 @@ export const getters = {
         const name = nameFromSplit || key
 
         const color = resolveSensorColor(sensorColors, key)
-        const prettyName = Vue.$filters.prettyCase(name)
+        const defaultPrettyName = Vue.$filters.prettyCase(name)
+        const prettyName = aliases[key] || defaultPrettyName
 
         const disconnected = configHasDisconnectedMcu(config, nonCriticalDisconnectedMcusSet)
 
@@ -607,6 +609,7 @@ export const getters = {
           type,
           color,
           prettyName,
+          defaultPrettyName,
           key,
           minTemp: config?.min_temp ?? 0,
           maxTemp: config?.max_temp ?? 500,
@@ -662,6 +665,7 @@ export const getters = {
   */
   getOutputs: (state, getters, rootState) => (filter?: string[]): Array<Fan | Led | OutputPin> => {
     const sensorColors: Record<string, string> = rootState.config.uiSettings.dashboard.sensorColors
+    const aliases: Record<string, string> = rootState.config.uiSettings.dashboard.aliases
 
     // Fans..
     const fans = [
@@ -740,9 +744,10 @@ export const getters = {
         supportedTypes.includes(type) &&
         (!filterByPrefix.includes(type) || !name.startsWith('_'))
       ) {
-        const prettyName = name === 'fan'
+        const defaultPrettyName = name === 'fan'
           ? 'Part Fan' // If we know its the part fan.
           : Vue.$filters.prettyCase(name)
+        const prettyName = aliases[key] || defaultPrettyName
 
         const color = applyColor.includes(type)
           ? resolveSensorColor(sensorColors, key)
@@ -758,6 +763,7 @@ export const getters = {
           config: { ...config },
           name,
           prettyName,
+          defaultPrettyName,
           key,
           color,
           type,
@@ -804,6 +810,7 @@ export const getters = {
     ]
     const nonCriticalDisconnectedMcusSet: Set<string> = getters.getNonCriticalDisconnectedMcusSet
     const sensorColors: Record<string, string> = rootState.config.uiSettings.dashboard.sensorColors
+    const aliases: Record<string, string> = rootState.config.uiSettings.dashboard.aliases
 
     const printerKeys = Object.keys(state.printer)
 
@@ -817,7 +824,7 @@ export const getters = {
             const name = nameFromSplit || key
 
             if (!name.startsWith('_')) {
-              const prettyName = type === 'tmc2240'
+              const defaultPrettyName = type === 'tmc2240'
                 ? i18n.t('app.general.label.stepper_driver',
                   {
                     name:
@@ -826,6 +833,7 @@ export const getters = {
                         : Vue.$filters.prettyCase(name)
                   }).toString()
                 : Vue.$filters.prettyCase(name)
+              const prettyName = aliases[key] || defaultPrettyName
               const color = resolveSensorColor(sensorColors, key)
               const config = state.printer.configfile.settings[key.toLowerCase()]
 
@@ -840,6 +848,7 @@ export const getters = {
                 name,
                 key,
                 prettyName,
+                defaultPrettyName,
                 color,
                 type,
                 disconnected

--- a/src/store/printer/types.ts
+++ b/src/store/printer/types.ts
@@ -63,6 +63,9 @@ type OutputType<TConfig extends TSHelpers.ValueTypesOf<Klipper.SettingsStateBase
   config?: TConfig;
   name: string;
   prettyName: string;
+  // Auto-generated default display name (pre-alias). `prettyName` = alias || defaultPrettyName.
+  // Optional so any hand-built row literal (e.g. in tests) still type-checks.
+  defaultPrettyName?: string;
   key: string;
   color?: string;
   type: string;
@@ -103,6 +106,7 @@ export type OutputPin = OutputType<Klipper.OutputPinSettings, Klipper.OutputPinS
 export interface Sensor extends Partial<Klipper.TemperatureSensorState>, Partial<Klipper.TemperatureSensor2State>, Partial<Klipper.ZThermalAdjustState> {
   name: string;
   prettyName: string;
+  defaultPrettyName?: string;
   key: string;
   color?: string;
   type: string;

--- a/src/util/__tests__/build-output-label.spec.ts
+++ b/src/util/__tests__/build-output-label.spec.ts
@@ -1,0 +1,20 @@
+import buildOutputLabel from '../build-output-label'
+
+describe('buildOutputLabel', () => {
+  it('escapes the (possibly aliased) display name — AC6', () => {
+    expect(buildOutputLabel('<img src=x onerror=alert(1)>'))
+      .toBe('&lt;img src=x onerror=alert(1)&gt;')
+  })
+
+  it('passes a plain name through unchanged', () => {
+    expect(buildOutputLabel('Side Fan')).toBe('Side Fan')
+  })
+
+  it('appends the trusted rpm suffix as <small> markup', () => {
+    expect(buildOutputLabel('Side Fan', '1200 rpm')).toBe('Side Fan <small>1200 rpm</small>')
+  })
+
+  it('escapes the name even when an rpm suffix is present', () => {
+    expect(buildOutputLabel('<b>x</b>', '5 rpm')).toBe('&lt;b&gt;x&lt;/b&gt; <small>5 rpm</small>')
+  })
+})

--- a/src/util/__tests__/escape-html.spec.ts
+++ b/src/util/__tests__/escape-html.spec.ts
@@ -1,0 +1,30 @@
+import escapeHtml from '../escape-html'
+
+describe('escapeHtml', () => {
+  it.each([
+    ['&', '&amp;'],
+    ['<', '&lt;'],
+    ['>', '&gt;'],
+    ['"', '&quot;'],
+    ["'", '&#39;'],
+  ])('escapes %s', (input, expected) => {
+    expect(escapeHtml(input)).toBe(expected)
+  })
+
+  it('escapes & first so entities are not double-encoded', () => {
+    expect(escapeHtml('a & <b>')).toBe('a &amp; &lt;b&gt;')
+  })
+
+  it('neutralises an HTML/script injection payload', () => {
+    expect(escapeHtml('<img src=x onerror=alert(1)>'))
+      .toBe('&lt;img src=x onerror=alert(1)&gt;')
+  })
+
+  it('escapes every occurrence, not just the first', () => {
+    expect(escapeHtml('<<>>')).toBe('&lt;&lt;&gt;&gt;')
+  })
+
+  it('leaves plain text untouched', () => {
+    expect(escapeHtml('Side Fan')).toBe('Side Fan')
+  })
+})

--- a/src/util/__tests__/output-gcode.spec.ts
+++ b/src/util/__tests__/output-gcode.spec.ts
@@ -1,0 +1,34 @@
+import { buildFanSpeedGcode, buildSetPinGcode } from '../output-gcode'
+
+// AC4 (display-only): every emitted command must be keyed by the raw Klipper
+// `name`, never a user-supplied alias / prettyName.
+
+describe('buildFanSpeedGcode', () => {
+  it('emits an absolute M106 for the part fan (no name leaks in)', () => {
+    expect(buildFanSpeedGcode({ type: 'fan', name: 'fan' }, 100)).toBe('M106 S255')
+  })
+
+  it('emits SET_FAN_SPEED keyed by the raw name for a generic fan', () => {
+    const gcode = buildFanSpeedGcode({ type: 'fan_generic', name: 'fan2' }, 50)
+    expect(gcode).toBe('SET_FAN_SPEED FAN=fan2 SPEED=0.5')
+  })
+
+  it('uses the raw name even when a display alias exists on the row', () => {
+    // The builder only ever sees `name`; the alias ("Side Fan") is not an input.
+    const gcode = buildFanSpeedGcode({ type: 'fan_generic', name: 'fan2' }, 100)
+    expect(gcode).toContain('FAN=fan2')
+    expect(gcode).not.toContain('Side Fan')
+  })
+
+  it('returns undefined for a non-controllable fan type', () => {
+    expect(buildFanSpeedGcode({ type: 'temperature_fan', name: 'x' }, 100)).toBeUndefined()
+  })
+})
+
+describe('buildSetPinGcode', () => {
+  it('emits SET_PIN keyed by the raw pin name, never the alias', () => {
+    const gcode = buildSetPinGcode('fan2', 0.5)
+    expect(gcode).toBe('SET_PIN PIN=fan2 VALUE=0.5')
+    expect(gcode).not.toContain('Side Fan')
+  })
+})

--- a/src/util/__tests__/resolve-alias-label.spec.ts
+++ b/src/util/__tests__/resolve-alias-label.spec.ts
@@ -1,0 +1,31 @@
+import resolveAliasLabel from '../resolve-alias-label'
+
+const KEY = 'output_pin fan2'
+
+describe('resolveAliasLabel', () => {
+  it('returns the alias (escaped) when one is set', () => {
+    expect(resolveAliasLabel(KEY, { [KEY]: 'Side Fan' }, 'Default')).toBe('Side Fan')
+  })
+
+  it('falls back to the (escaped) default when no alias is set', () => {
+    expect(resolveAliasLabel(KEY, {}, 'Default')).toBe('Default')
+  })
+
+  it('falls back to the default for an empty-string alias (|| not ??)', () => {
+    // Guards the blank-tooltip class of bug: an empty alias must not blank the label.
+    expect(resolveAliasLabel(KEY, { [KEY]: '' }, 'Default')).toBe('Default')
+  })
+
+  it.each(['#target', '#power', '#speed'])('strips the %s series suffix before lookup', (suffix) => {
+    expect(resolveAliasLabel(`${KEY}${suffix}`, { [KEY]: 'Side Fan' }, 'Default')).toBe('Side Fan')
+  })
+
+  it('HTML-escapes a malicious alias', () => {
+    expect(resolveAliasLabel(KEY, { [KEY]: '<img src=x onerror=alert(1)>' }, 'Default'))
+      .toBe('&lt;img src=x onerror=alert(1)&gt;')
+  })
+
+  it('HTML-escapes a malicious default label too', () => {
+    expect(resolveAliasLabel(KEY, {}, '<script>')).toBe('&lt;script&gt;')
+  })
+})

--- a/src/util/build-output-label.ts
+++ b/src/util/build-output-label.ts
@@ -1,0 +1,19 @@
+import escapeHtml from './escape-html'
+
+/**
+ * Build the HTML `label` for an output widget (fan / pin / LED).
+ *
+ * The label is rendered via `v-safe-html` (DOMPurify) inside AppNamedSlider /
+ * AppNamedSwitch, so a raw `<` in a user alias would survive as markup. Escape
+ * the (possibly aliased) display name before composing the optional rpm suffix,
+ * which is app-generated and therefore trusted.
+ */
+const buildOutputLabel = (prettyName: string, rpm?: string): string => {
+  const name = escapeHtml(prettyName)
+
+  return rpm
+    ? `${name} <small>${rpm}</small>`
+    : name
+}
+
+export default buildOutputLabel

--- a/src/util/escape-html.ts
+++ b/src/util/escape-html.ts
@@ -1,0 +1,12 @@
+// The single HTML-escaping implementation. Used to neutralise user-supplied
+// display-name aliases before they reach a raw-HTML sink (ECharts tooltip
+// formatter, v-safe-html labels). `&` MUST be replaced first.
+const escapeHtml = (value: string): string =>
+  value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+
+export default escapeHtml

--- a/src/util/output-gcode.ts
+++ b/src/util/output-gcode.ts
@@ -1,0 +1,36 @@
+import { encodeGcodeParamValue } from './gcode-helpers'
+
+/**
+ * Build the G-code command for setting a controllable fan's speed.
+ *
+ * Display-only guarantee (AC4): the emitted command references the raw Klipper
+ * object `name`, NEVER the display alias / `prettyName`. Aliases are cosmetic.
+ *
+ * @param fan         Fan type + raw Klipper name (`{ type, name }`).
+ * @param sliderValue The 0-100 slider value.
+ * @returns The G-code string, or undefined for non-controllable fan types.
+ */
+export const buildFanSpeedGcode = (
+  fan: { type: string; name: string },
+  sliderValue: number
+): string | undefined => {
+  // Part fan: absolute 0-255 M106.
+  if (fan.type === 'fan') {
+    return `M106 S${Math.ceil(sliderValue * 2.55)}`
+  }
+
+  // Generic fan: SET_FAN_SPEED with a 0-1 fraction, keyed by the raw name.
+  if (fan.type === 'fan_generic') {
+    return `SET_FAN_SPEED FAN=${encodeGcodeParamValue(fan.name)} SPEED=${sliderValue / 100}`
+  }
+
+  return undefined
+}
+
+/**
+ * Build the G-code command for setting an output pin's value.
+ *
+ * Display-only guarantee (AC4): keyed by the raw Klipper `name`, never the alias.
+ */
+export const buildSetPinGcode = (name: string, value: number): string =>
+  `SET_PIN PIN=${encodeGcodeParamValue(name)} VALUE=${value}`

--- a/src/util/resolve-alias-label.ts
+++ b/src/util/resolve-alias-label.ts
@@ -1,0 +1,30 @@
+import escapeHtml from './escape-html'
+
+// ECharts appends these suffixes to derived series (target/power/speed lines).
+const SERIES_SUFFIX = /(#target|#power|#speed)$/
+
+/**
+ * Resolve the display label for a chart series, applying a user alias if one
+ * exists, then HTML-escaping the result for safe insertion into the tooltip's
+ * raw-HTML string.
+ *
+ * @param seriesKey    The ECharts series name = the raw printer-state key,
+ *                     possibly with a `#target`/`#power`/`#speed` suffix.
+ * @param aliases      The alias map (`objectKey -> friendlyName`).
+ * @param defaultLabel The pre-alias label to fall back to.
+ *
+ * Uses `||` (not `??`) so a stored empty-string alias falls through to the
+ * default, matching the getters' `alias || default` resolution.
+ */
+const resolveAliasLabel = (
+  seriesKey: string,
+  aliases: Record<string, string>,
+  defaultLabel: string
+): string => {
+  const objectKey = seriesKey.replace(SERIES_SUFFIX, '')
+  const raw = aliases[objectKey] || defaultLabel
+
+  return escapeHtml(raw)
+}
+
+export default resolveAliasLabel

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -20,6 +20,7 @@
         <camera-settings />
         <toolhead-settings />
         <preset-settings />
+        <alias-settings />
         <gcode-preview-settings />
         <timelapse-settings v-if="supportsTimelapse" />
         <mmu-settings v-if="supportsMmu" />
@@ -37,6 +38,7 @@ import StateMixin from '@/mixins/state'
 import MacroSettings from '@/components/settings/macros/MacroSettings.vue'
 import GeneralSettings from '@/components/settings/GeneralSettings.vue'
 import PresetSettings from '@/components/settings/presets/PresetSettings.vue'
+import AliasSettings from '@/components/settings/AliasSettings.vue'
 import CameraSettings from '@/components/settings/cameras/CameraSettings.vue'
 import ToolheadSettings from '@/components/settings/ToolheadSettings.vue'
 import ThemeSettings from '@/components/settings/ThemeSettings.vue'
@@ -59,6 +61,7 @@ import WarningsSettings from '@/components/settings/WarningsSettings.vue'
     MacroSettings,
     GeneralSettings,
     PresetSettings,
+    AliasSettings,
     CameraSettings,
     ToolheadSettings,
     ThemeSettings,

--- a/tsconfig.vitest.json
+++ b/tsconfig.vitest.json
@@ -10,9 +10,24 @@
     ]
   },
 
+  // vitest's `include` OVERRIDES (does not merge with) the extended tsconfig.app
+  // include. The new store/getter specs import store source that references the
+  // ambient global namespaces (Moonraker/Klipper/TSHelpers in src/typings) and the
+  // Vue augmentations ($filters/$colorset, declared in the heavy src/plugins/*.ts),
+  // so a narrow test-only include leaves them unresolved under `vue-tsc --build`
+  // (only `type-check` bites — vitest itself esbuild-transpiles and never typechecks).
+  //
+  // Fix: mirror tsconfig.app's source include so this program sees the same global
+  // declarations (superset = app source + tests). A project reference to app was the
+  // structural first choice but app is `noEmit` / non-composite, so it can't be a
+  // reference target without restructuring the app build; and narrowly rooting
+  // src/plugins/filters.ts drags @/router → the whole component tree. Mirroring is
+  // green with no TS6307 composite-overlap here (tsconfig.app excludes __tests__).
   "include": [
+    "*.d.ts",
+    "src/**/*.ts",
+    "src/**/*.vue",
     "tests/**/*",
-    "src/**/__tests__/*",
     "env.d.ts",
   ],
 


### PR DESCRIPTION
## What

Adds a user-editable, **display-only** alias map (`objectKey → friendly name`) for fans, `output_pin`s, LEDs, heaters and temperature sensors. Users can give an object a friendly name in the UI without renaming the underlying Klipper config section.

Motivation: on some machines (e.g. rooted Creality K1) fans are hardcoded in firmware as `output_pin fan0/1/2`; renaming the Klipper section breaks the printer's touchscreen fan control. This provides friendly names that **never touch Klipper config or emit G-code**.

## How

Mirrors the existing `sensorColors` feature end-to-end:

- **Store**: `aliases: Record<string,string>` on `uiSettings.dashboard`, with `setAlias`/`setRemoveAlias` mutations and `updateAlias`/`removeAlias` actions, persisted to the Moonraker DB `fluidd` namespace via the existing `dbKey` mechanism. Auto-loaded through the existing `mergeWith` in `setInitUiSettings` — no bespoke load wiring.
- **Getters**: `getOutputs`/`getHeaters`/`getSensors` resolve `aliases[key]` first and expose a new `defaultPrettyName` (the true pre-alias name) so the settings panel placeholder shows the real default even while an alias is active.
- **Settings panel**: new `AliasSettings.vue` to set/clear aliases (placeholder = `defaultPrettyName`).
- **Display-only guarantee**: the fan/pin G-code paths are keyed off the raw object `name`, never the alias (extracted to `src/util/output-gcode.ts`).
- **XSS**: user aliases reach two raw-HTML sinks — the ECharts thermal-tooltip formatter and the `v-safe-html` `OutputFan`/`OutputPin` labels — and are HTML-escaped at both via a single `escapeHtml` util.
- **i18n**: `src/locales/en.yaml` only (other locales left to Weblate).

## Testing

- `pnpm run lint`, `pnpm run type-check`, `pnpm run test` (375 pass), `pnpm run circular-check` (no cycles), and a production build all pass clean.
- 51 new unit tests: store mutations/actions incl. guarded delete + prototype-chain safety, getter alias-override + `defaultPrettyName`, escape/resolve-label utils, thermal-tooltip formatter XSS, output-label escape, a display-only G-code regression (asserts the command path uses `name`, not the alias), and `dbKey` dot-in-value parity.
- Manually deployed to a Creality K1 Max: the alias settings panel renders and — critically for the display-only guarantee — the printer's touchscreen and physical fan control remain fully functional with aliases set.

## Note for reviewers (`tsconfig.vitest.json`)

The new store/getter specs import store source that references the ambient global namespaces (`Moonraker`/`Klipper`/`TSHelpers` in `src/typings`) and the `$filters`/`$colorset` Vue augmentations declared in `src/plugins`. Because `tsconfig.vitest.json`'s `include` **overrides** (does not merge with) the extended `tsconfig.app` include, those globals were unresolved under `vue-tsc --build`. I widened the vitest `include` to mirror the app source so the globals resolve.

A narrower include isn't possible without dragging the whole component graph in (`src/plugins/filters.ts` value-imports `@/router`), and a project reference to the app project is blocked by its `noEmit`/non-composite config. Happy to take direction if you'd prefer a different structural fix here.

---

Signed-off-by: Philipp Oppolzer <philipp.oppolzer@gmail.com>
