### PR TITLE
feat: optional trailing-average smoothing for power/speed chart series

### DIFF
--- a/src/components/settings/GeneralSettings.vue
+++ b/src/components/settings/GeneralSettings.vue
@@ -66,19 +66,6 @@
 
       <v-divider />
 
-      <app-setting :title="$t('app.setting.label.chart_smoothing')">
-        <v-select
-          v-model="chartSmoothingWindow"
-          filled
-          dense
-          single-line
-          hide-details="auto"
-          :items="availableChartSmoothingWindows"
-        />
-      </app-setting>
-
-      <v-divider />
-
       <app-setting
         :title="$t('app.setting.label.keyboard_shortcuts')"
         :sub-title="$t('app.setting.tooltip.keyboard_shortcuts')"
@@ -239,6 +226,19 @@
 
       <v-divider />
 
+      <app-setting :title="$t('app.setting.label.thermal_chart_smoothing')">
+        <v-select
+          v-model="chartSmoothingWindow"
+          filled
+          dense
+          single-line
+          hide-details="auto"
+          :items="availableChartSmoothingWindows"
+        />
+      </app-setting>
+
+      <v-divider />
+
       <app-setting
         :title="$t('app.setting.label.enable_diagnostics')"
         :sub-title="$t('app.setting.tooltip.diagnostics_performance')"
@@ -384,10 +384,14 @@ export default class GeneralSettings extends Mixins(StateMixin, BrowserMixin) {
   }
 
   get availableChartSmoothingWindows () {
+    const nf = new Intl.NumberFormat(getAllLocales(), { style: 'unit', unit: 'second', unitDisplay: 'short' })
+
     return [0, 1, 3, 5, 10, 15, 30]
       .map(value => ({
         value,
-        text: this.$tc('app.setting.label.chart_smoothing_seconds', value)
+        text: value === 0
+          ? this.$t('app.setting.label.none').toString()
+          : nf.format(value)
       }))
   }
 

--- a/src/components/settings/GeneralSettings.vue
+++ b/src/components/settings/GeneralSettings.vue
@@ -388,7 +388,10 @@ export default class GeneralSettings extends Mixins(StateMixin, BrowserMixin) {
       { value: 0, text: this.$t('app.setting.label.chart_smoothing_none') },
       { value: 1, text: this.$t('app.setting.label.chart_smoothing_seconds', { count: 1 }) },
       { value: 3, text: this.$t('app.setting.label.chart_smoothing_seconds', { count: 3 }) },
-      { value: 5, text: this.$t('app.setting.label.chart_smoothing_seconds', { count: 5 }) }
+      { value: 5, text: this.$t('app.setting.label.chart_smoothing_seconds', { count: 5 }) },
+      { value: 10, text: this.$t('app.setting.label.chart_smoothing_seconds', { count: 10 }) },
+      { value: 15, text: this.$t('app.setting.label.chart_smoothing_seconds', { count: 15 }) },
+      { value: 30, text: this.$t('app.setting.label.chart_smoothing_seconds', { count: 30 }) }
     ]
   }
 

--- a/src/components/settings/GeneralSettings.vue
+++ b/src/components/settings/GeneralSettings.vue
@@ -66,6 +66,19 @@
 
       <v-divider />
 
+      <app-setting :title="$t('app.setting.label.chart_smoothing')">
+        <v-select
+          v-model="chartSmoothingWindow"
+          filled
+          dense
+          single-line
+          hide-details="auto"
+          :items="availableChartSmoothingWindows"
+        />
+      </app-setting>
+
+      <v-divider />
+
       <app-setting
         :title="$t('app.setting.label.keyboard_shortcuts')"
         :sub-title="$t('app.setting.tooltip.keyboard_shortcuts')"
@@ -356,6 +369,27 @@ export default class GeneralSettings extends Mixins(StateMixin, BrowserMixin) {
         value: key,
         text: `${date.toLocaleTimeString(entry.locales ?? getAllLocales(), entry.options)}${entry.suffix ?? ''}`
       }))
+  }
+
+  get chartSmoothingWindow (): number {
+    return this.$typedState.config.uiSettings.general.chartSmoothingWindow
+  }
+
+  set chartSmoothingWindow (value: number) {
+    this.$typedDispatch('config/saveByPath', {
+      path: 'uiSettings.general.chartSmoothingWindow',
+      value,
+      server: true
+    })
+  }
+
+  get availableChartSmoothingWindows () {
+    return [
+      { value: 0, text: this.$t('app.setting.label.chart_smoothing_none') },
+      { value: 1, text: this.$t('app.setting.label.chart_smoothing_seconds', { count: 1 }) },
+      { value: 3, text: this.$t('app.setting.label.chart_smoothing_seconds', { count: 3 }) },
+      { value: 5, text: this.$t('app.setting.label.chart_smoothing_seconds', { count: 5 }) }
+    ]
   }
 
   get enableKeyboardShortcuts (): boolean {

--- a/src/components/settings/GeneralSettings.vue
+++ b/src/components/settings/GeneralSettings.vue
@@ -384,15 +384,11 @@ export default class GeneralSettings extends Mixins(StateMixin, BrowserMixin) {
   }
 
   get availableChartSmoothingWindows () {
-    return [
-      { value: 0, text: this.$t('app.setting.label.chart_smoothing_none') },
-      { value: 1, text: this.$t('app.setting.label.chart_smoothing_seconds', { count: 1 }) },
-      { value: 3, text: this.$t('app.setting.label.chart_smoothing_seconds', { count: 3 }) },
-      { value: 5, text: this.$t('app.setting.label.chart_smoothing_seconds', { count: 5 }) },
-      { value: 10, text: this.$t('app.setting.label.chart_smoothing_seconds', { count: 10 }) },
-      { value: 15, text: this.$t('app.setting.label.chart_smoothing_seconds', { count: 15 }) },
-      { value: 30, text: this.$t('app.setting.label.chart_smoothing_seconds', { count: 30 }) }
-    ]
+    return [0, 1, 3, 5, 10, 15, 30]
+      .map(value => ({
+        value,
+        text: this.$tc('app.setting.label.chart_smoothing_seconds', value)
+      }))
   }
 
   get enableKeyboardShortcuts (): boolean {

--- a/src/components/settings/ToolheadSettings.vue
+++ b/src/components/settings/ToolheadSettings.vue
@@ -726,12 +726,13 @@ export default class ToolHeadSettings extends Mixins(ToolheadMixin) {
   }
 
   handleReset () {
-    const { instanceName, chartVisible, hideTempWaits }: GeneralConfig = this.$typedState.config.uiSettings.general
+    const { instanceName, chartVisible, chartSmoothingWindow, hideTempWaits }: GeneralConfig = this.$typedState.config.uiSettings.general
 
     const value: GeneralConfig = {
       ...defaultState().uiSettings.general,
       instanceName,
       chartVisible,
+      chartSmoothingWindow,
       hideTempWaits
     }
 

--- a/src/components/widgets/thermals/ThermalChart.vue
+++ b/src/components/widgets/thermals/ThermalChart.vue
@@ -97,14 +97,20 @@ export default class ThermalChart extends Mixins(BrowserMixin) {
     return this.$typedState.config.uiSettings.general.chartSmoothingWindow
   }
 
+  get smoothableKeys (): string[] {
+    return this.series
+      .map(series => series.name as string)
+      .filter(name => (
+        name.endsWith('#power') ||
+        name.endsWith('#speed')
+      ))
+  }
+
   get smoothedChartData (): Readonly<ChartData>[] {
     return smoothChartData(
       this.chartData,
-      this.chartSmoothingWindow,
-      key => (
-        key.endsWith('#power') ||
-        key.endsWith('#speed')
-      )
+      this.smoothableKeys,
+      this.chartSmoothingWindow
     )
   }
 

--- a/src/components/widgets/thermals/ThermalChart.vue
+++ b/src/components/widgets/thermals/ThermalChart.vue
@@ -42,7 +42,7 @@ import { markRaw } from 'vue'
 import { Component, Watch, Prop, Ref, Mixins } from 'vue-property-decorator'
 import type { ECharts, EChartsInitOpts, EChartsOption, LineSeriesOption } from 'echarts'
 import getKlipperType from '@/util/get-klipper-type'
-import { isPowerOrSpeed, smoothChartData } from '@/util/chart-smoothing'
+import { smoothChartData } from '@/util/chart-smoothing'
 import BrowserMixin from '@/mixins/browser'
 import type { ChartData, ChartSelectedLegends } from '@/store/charts/types'
 
@@ -97,10 +97,15 @@ export default class ThermalChart extends Mixins(BrowserMixin) {
     return this.$typedState.config.uiSettings.general.chartSmoothingWindow
   }
 
-  // Raw data with a trailing moving average applied to power/speed series only.
-  // A window of 0 returns chartData untouched.
   get smoothedChartData (): Readonly<ChartData>[] {
-    return smoothChartData(this.chartData, this.chartSmoothingWindow, isPowerOrSpeed)
+    return smoothChartData(
+      this.chartData,
+      this.chartSmoothingWindow,
+      key => (
+        key.endsWith('#power') ||
+        key.endsWith('#speed')
+      )
+    )
   }
 
   get chartableSensors (): string[] {
@@ -130,9 +135,9 @@ export default class ThermalChart extends Mixins(BrowserMixin) {
     this.chart.setOption({ series: this.series })
   }
 
-  // Watch the smoothed data so both new samples and a smoothing-window change
-  // re-render the chart live.
-  @Watch('smoothedChartData')
+  // Watch the raw inputs so the paused check below can skip smoothing work.
+  @Watch('chartData')
+  @Watch('chartSmoothingWindow')
   onDataChange () {
     if (!this.chart || this.paused) return
 

--- a/src/components/widgets/thermals/ThermalChart.vue
+++ b/src/components/widgets/thermals/ThermalChart.vue
@@ -42,6 +42,7 @@ import { markRaw } from 'vue'
 import { Component, Watch, Prop, Ref, Mixins } from 'vue-property-decorator'
 import type { ECharts, EChartsInitOpts, EChartsOption, LineSeriesOption } from 'echarts'
 import getKlipperType from '@/util/get-klipper-type'
+import { isPowerOrSpeed, smoothChartData } from '@/util/chart-smoothing'
 import BrowserMixin from '@/mixins/browser'
 import type { ChartData, ChartSelectedLegends } from '@/store/charts/types'
 
@@ -65,7 +66,7 @@ export default class ThermalChart extends Mixins(BrowserMixin) {
     this.paused = !this.paused
 
     if (!this.paused) {
-      this.onDataChange(this.chartData)
+      this.onDataChange()
     }
   }
 
@@ -90,6 +91,16 @@ export default class ThermalChart extends Mixins(BrowserMixin) {
 
   get chartData (): Readonly<ChartData>[] {
     return this.$typedState.charts.chart
+  }
+
+  get chartSmoothingWindow (): number {
+    return this.$typedState.config.uiSettings.general.chartSmoothingWindow
+  }
+
+  // Raw data with a trailing moving average applied to power/speed series only.
+  // A window of 0 returns chartData untouched.
+  get smoothedChartData (): Readonly<ChartData>[] {
+    return smoothChartData(this.chartData, this.chartSmoothingWindow, isPowerOrSpeed)
   }
 
   get chartableSensors (): string[] {
@@ -119,8 +130,10 @@ export default class ThermalChart extends Mixins(BrowserMixin) {
     this.chart.setOption({ series: this.series })
   }
 
-  @Watch('chartData')
-  onDataChange (data: any) {
+  // Watch the smoothed data so both new samples and a smoothing-window change
+  // re-render the chart live.
+  @Watch('smoothedChartData')
+  onDataChange () {
     if (!this.chart || this.paused) return
 
     // Series deferred at creation (empty store): build now and re-apply.
@@ -132,7 +145,7 @@ export default class ThermalChart extends Mixins(BrowserMixin) {
 
     this.chart.setOption({
       dataset: {
-        source: data
+        source: this.smoothedChartData
       }
     })
   }
@@ -185,7 +198,7 @@ export default class ThermalChart extends Mixins(BrowserMixin) {
     this.chart.setOption({
       ...this.options,
       dataset: {
-        source: this.chartData
+        source: this.smoothedChartData
       }
     }, { notMerge: true })
   }

--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -877,8 +877,7 @@ app:
       z_adjust_values: Z Adjust values
       date_format: Date format
       time_format: Time format
-      chart_smoothing: Chart smoothing
-      chart_smoothing_seconds: 'None | {count} sec'
+      thermal_chart_smoothing: Thermal chart smoothing
       text_sort_order: Text sort order
       drag_and_drop_functionality_for_files_and_folders: Drag-and-drop
         functionality for files and folders

--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -878,8 +878,7 @@ app:
       date_format: Date format
       time_format: Time format
       chart_smoothing: Chart smoothing
-      chart_smoothing_none: None
-      chart_smoothing_seconds: '{count} sec'
+      chart_smoothing_seconds: 'None | {count} sec'
       text_sort_order: Text sort order
       drag_and_drop_functionality_for_files_and_folders: Drag-and-drop
         functionality for files and folders

--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -877,6 +877,9 @@ app:
       z_adjust_values: Z Adjust values
       date_format: Date format
       time_format: Time format
+      chart_smoothing: Chart smoothing
+      chart_smoothing_none: None
+      chart_smoothing_seconds: '{count} sec'
       text_sort_order: Text sort order
       drag_and_drop_functionality_for_files_and_folders: Drag-and-drop
         functionality for files and folders

--- a/src/store/config/state.ts
+++ b/src/store/config/state.ts
@@ -19,6 +19,7 @@ export const defaultState = (): ConfigState => {
         instanceName: Globals.APP_NAME,
         locale: 'en',
         chartVisible: true,
+        chartSmoothingWindow: 0,
         hideTempWaits: true,
         axis: {
           x: { inverted: false },

--- a/src/store/config/types.ts
+++ b/src/store/config/types.ts
@@ -101,6 +101,7 @@ export interface GeneralConfig {
   instanceName: string;
   locale: string;
   chartVisible: boolean;
+  chartSmoothingWindow: number;
   hideTempWaits: boolean;
   axis: Axis;
   defaultExtrudeLength: number;

--- a/src/util/__tests__/chart-smoothing.spec.ts
+++ b/src/util/__tests__/chart-smoothing.spec.ts
@@ -1,0 +1,75 @@
+import { isPowerOrSpeed, smoothChartData } from '../chart-smoothing'
+import type { ChartData } from '@/store/charts/types'
+
+// Build a series of 1Hz samples starting at epoch t=0s.
+// Each entry maps a base value -> { date, [key]: value, extruder: <temp> }.
+const buildSeries = (
+  key: string,
+  values: (number | null)[],
+  temps?: number[]
+): ChartData[] =>
+  values.map((value, i) => {
+    const sample: ChartData = { date: new Date(i * 1000) }
+    if (value !== null) sample[key] = value
+    if (temps) sample.extruder = temps[i]
+    return sample
+  })
+
+describe('isPowerOrSpeed', () => {
+  it('matches #power and #speed keys only', () => {
+    expect(isPowerOrSpeed('extruder#power')).toBe(true)
+    expect(isPowerOrSpeed('fan#speed')).toBe(true)
+    expect(isPowerOrSpeed('extruder')).toBe(false)
+    expect(isPowerOrSpeed('extruder#target')).toBe(false)
+    expect(isPowerOrSpeed('date')).toBe(false)
+  })
+})
+
+describe('smoothChartData', () => {
+  it('returns input unchanged when window is 0', () => {
+    const data = buildSeries('extruder#power', [0, 100, 0, 100])
+    expect(smoothChartData(data, 0, isPowerOrSpeed)).toBe(data)
+  })
+
+  it('applies a trailing moving average to a square wave (window=3s, 1Hz)', () => {
+    const data = buildSeries('extruder#power', [0, 100, 0, 100, 0, 100])
+    const out = smoothChartData(data, 3, isPowerOrSpeed)
+    const got = out.map(s => s['extruder#power'] as number)
+
+    expect(got[0]).toBeCloseTo(0, 5) // {0}
+    expect(got[1]).toBeCloseTo(50, 5) // {0,100}
+    expect(got[2]).toBeCloseTo(100 / 3, 5) // {0,100,0}
+    expect(got[3]).toBeCloseTo(200 / 3, 5) // {100,0,100}
+    expect(got[4]).toBeCloseTo(100 / 3, 5) // {0,100,0}
+    expect(got[5]).toBeCloseTo(200 / 3, 5) // {100,0,100}
+  })
+
+  it('leaves non-smoothable keys (temps) and date untouched', () => {
+    const data = buildSeries('extruder#power', [0, 100, 0, 100], [200, 201, 202, 203])
+    const out = smoothChartData(data, 3, isPowerOrSpeed)
+
+    out.forEach((s, i) => {
+      expect(s.extruder).toBe(data[i].extruder) // temps raw
+      expect(s.date).toBe(data[i].date) // same Date reference
+    })
+  })
+
+  it('skips null/missing values in the window mean', () => {
+    // index 2 has no power value at all
+    const data = buildSeries('extruder#power', [0, 100, null, 100])
+    const out = smoothChartData(data, 3, isPowerOrSpeed)
+
+    expect(out[1]['extruder#power']).toBeCloseTo(50, 5) // {0,100}
+    // window at i=3 is {100 (i1), <gap>, 100 (i3)} -> mean of the two present = 100
+    expect(out[3]['extruder#power']).toBeCloseTo(100, 5)
+    // a sample with no value stays without a value (not invented)
+    expect(out[2]['extruder#power']).toBeUndefined()
+  })
+
+  it('does not mutate the input array or its samples', () => {
+    const data = buildSeries('extruder#power', [0, 100, 0, 100])
+    const snapshot = JSON.stringify(data)
+    smoothChartData(data, 3, isPowerOrSpeed)
+    expect(JSON.stringify(data)).toBe(snapshot)
+  })
+})

--- a/src/util/__tests__/chart-smoothing.spec.ts
+++ b/src/util/__tests__/chart-smoothing.spec.ts
@@ -1,4 +1,4 @@
-import { isPowerOrSpeed, smoothChartData } from '../chart-smoothing'
+import { smoothChartData } from '../chart-smoothing'
 import type { ChartData } from '@/store/charts/types'
 
 // Build a series of 1Hz samples starting at epoch t=0s.
@@ -15,20 +15,30 @@ const buildSeries = (
     return sample
   })
 
-describe('isPowerOrSpeed', () => {
-  it('matches #power and #speed keys only', () => {
-    expect(isPowerOrSpeed('extruder#power')).toBe(true)
-    expect(isPowerOrSpeed('fan#speed')).toBe(true)
-    expect(isPowerOrSpeed('extruder')).toBe(false)
-    expect(isPowerOrSpeed('extruder#target')).toBe(false)
-    expect(isPowerOrSpeed('date')).toBe(false)
-  })
-})
+// Stand-in for the real ThermalChart.vue predicate: smoothChartData is generic
+// over any isSmoothable callback, so a matching key suffix is all these tests need.
+const isPowerOrSpeed = (key: string): boolean =>
+  key.endsWith('#power') || key.endsWith('#speed')
 
 describe('smoothChartData', () => {
   it('returns input unchanged when window is 0', () => {
     const data = buildSeries('extruder#power', [0, 100, 0, 100])
     expect(smoothChartData(data, 0, isPowerOrSpeed)).toBe(data)
+  })
+
+  it('returns input unchanged for non-finite or negative windows', () => {
+    const data = buildSeries('extruder#power', [0, 100, 0, 100])
+    expect(smoothChartData(data, Number.NaN, isPowerOrSpeed)).toBe(data)
+    expect(smoothChartData(data, Number.POSITIVE_INFINITY, isPowerOrSpeed)).toBe(data)
+    expect(smoothChartData(data, -3, isPowerOrSpeed)).toBe(data)
+  })
+
+  it('averages all preceding values once the trailing window spans them', () => {
+    const data = buildSeries('extruder#power', [0, 100, 0, 100, 0, 100])
+    const out = smoothChartData(data, 1000, isPowerOrSpeed)
+    const mean = (0 + 100 + 0 + 100 + 0 + 100) / 6
+
+    expect(out[out.length - 1]['extruder#power']).toBeCloseTo(mean, 5)
   })
 
   it('applies a trailing moving average to a square wave (window=3s, 1Hz)', () => {

--- a/src/util/__tests__/chart-smoothing.spec.ts
+++ b/src/util/__tests__/chart-smoothing.spec.ts
@@ -15,27 +15,32 @@ const buildSeries = (
     return sample
   })
 
-// Stand-in for the real ThermalChart.vue predicate: smoothChartData is generic
-// over any isSmoothable callback, so a matching key suffix is all these tests need.
-const isPowerOrSpeed = (key: string): boolean =>
-  key.endsWith('#power') || key.endsWith('#speed')
-
 describe('smoothChartData', () => {
   it('returns input unchanged when window is 0', () => {
     const data = buildSeries('extruder#power', [0, 100, 0, 100])
-    expect(smoothChartData(data, 0, isPowerOrSpeed)).toBe(data)
+    expect(smoothChartData(data, ['extruder#power'], 0)).toBe(data)
   })
 
-  it('returns input unchanged for non-finite or negative windows', () => {
+  it('returns input unchanged for a negative window', () => {
     const data = buildSeries('extruder#power', [0, 100, 0, 100])
-    expect(smoothChartData(data, Number.NaN, isPowerOrSpeed)).toBe(data)
-    expect(smoothChartData(data, Number.POSITIVE_INFINITY, isPowerOrSpeed)).toBe(data)
-    expect(smoothChartData(data, -3, isPowerOrSpeed)).toBe(data)
+    expect(smoothChartData(data, ['extruder#power'], -3)).toBe(data)
+  })
+
+  it('returns input unchanged when keys is empty', () => {
+    const data = buildSeries('extruder#power', [0, 100, 0, 100])
+    expect(smoothChartData(data, [], 3)).toBe(data)
+  })
+
+  it('ignores a key no sample carries', () => {
+    const data = buildSeries('extruder#power', [0, 100, 0, 100])
+    const out = smoothChartData(data, ['bed#power'], 3)
+
+    out.forEach((s, i) => expect(s).toEqual(data[i]))
   })
 
   it('averages all preceding values once the trailing window spans them', () => {
     const data = buildSeries('extruder#power', [0, 100, 0, 100, 0, 100])
-    const out = smoothChartData(data, 1000, isPowerOrSpeed)
+    const out = smoothChartData(data, ['extruder#power'], 1000)
     const mean = (0 + 100 + 0 + 100 + 0 + 100) / 6
 
     expect(out[out.length - 1]['extruder#power']).toBeCloseTo(mean, 5)
@@ -43,7 +48,7 @@ describe('smoothChartData', () => {
 
   it('applies a trailing moving average to a square wave (window=3s, 1Hz)', () => {
     const data = buildSeries('extruder#power', [0, 100, 0, 100, 0, 100])
-    const out = smoothChartData(data, 3, isPowerOrSpeed)
+    const out = smoothChartData(data, ['extruder#power'], 3)
     const got = out.map(s => s['extruder#power'] as number)
 
     expect(got[0]).toBeCloseTo(0, 5) // {0}
@@ -54,9 +59,9 @@ describe('smoothChartData', () => {
     expect(got[5]).toBeCloseTo(200 / 3, 5) // {100,0,100}
   })
 
-  it('leaves non-smoothable keys (temps) and date untouched', () => {
+  it('leaves keys absent from the keys list (temps) and date untouched', () => {
     const data = buildSeries('extruder#power', [0, 100, 0, 100], [200, 201, 202, 203])
-    const out = smoothChartData(data, 3, isPowerOrSpeed)
+    const out = smoothChartData(data, ['extruder#power'], 3)
 
     out.forEach((s, i) => {
       expect(s.extruder).toBe(data[i].extruder) // temps raw
@@ -67,7 +72,7 @@ describe('smoothChartData', () => {
   it('skips null/missing values in the window mean', () => {
     // index 2 has no power value at all
     const data = buildSeries('extruder#power', [0, 100, null, 100])
-    const out = smoothChartData(data, 3, isPowerOrSpeed)
+    const out = smoothChartData(data, ['extruder#power'], 3)
 
     expect(out[1]['extruder#power']).toBeCloseTo(50, 5) // {0,100}
     // window at i=3 is {100 (i1), <gap>, 100 (i3)} -> mean of the two present = 100
@@ -79,7 +84,7 @@ describe('smoothChartData', () => {
   it('does not mutate the input array or its samples', () => {
     const data = buildSeries('extruder#power', [0, 100, 0, 100])
     const snapshot = JSON.stringify(data)
-    smoothChartData(data, 3, isPowerOrSpeed)
+    smoothChartData(data, ['extruder#power'], 3)
     expect(JSON.stringify(data)).toBe(snapshot)
   })
 })

--- a/src/util/chart-smoothing.ts
+++ b/src/util/chart-smoothing.ts
@@ -1,38 +1,26 @@
 import type { ChartData } from '@/store/charts/types'
 
 /**
- * Applies a trailing time-window moving average to every smoothable key,
- * returning a new dataset. The input is never mutated.
- *
- * `windowSeconds` is the width of the trailing window in seconds; Moonraker's
- * store is ~1 sample/second, so a 3s window averages roughly the last 3
- * samples. A window of 0 (or no smoothable keys) is a no-op and returns the
- * original array reference unchanged.
- *
- * Samples missing a numeric value for a key are skipped in the mean, and a
- * sample that has no value for a key keeps it absent (a value is never
- * invented).
+ * Applies a trailing moving average (window in seconds) to each key in
+ * `keys`, returning a new dataset — the input is never mutated. A window of
+ * 0 (or an empty `keys` list) is a no-op returning the original reference.
+ * Samples missing a numeric value are skipped in the mean and left absent.
  */
 export const smoothChartData = (
   data: ChartData[],
-  windowSeconds: number,
-  isSmoothable: (key: string) => boolean
+  keys: readonly string[],
+  windowSeconds: number
 ): ChartData[] => {
-  if (!Number.isFinite(windowSeconds) || windowSeconds <= 0 || data.length === 0) return data
+  if (
+    windowSeconds <= 0 ||
+    data.length === 0 ||
+    keys.length === 0
+  ) return data
 
   const windowMs = windowSeconds * 1000
-
-  // The smoothable keys present anywhere in the dataset.
-  const keys = new Set<string>()
-  for (const sample of data) {
-    for (const key of Object.keys(sample)) {
-      if (key !== 'date' && isSmoothable(key)) keys.add(key)
-    }
-  }
-  if (keys.size === 0) return data
-
-  const times = data.map(sample => sample.date.getTime())
-  const result: ChartData[] = [...data]
+  const times = data
+    .map(sample => sample.date.getTime())
+  const result = [...data]
 
   // Two-pointer trailing window per key.
   for (const key of keys) {
@@ -40,26 +28,34 @@ export const smoothChartData = (
     let sum = 0
     let count = 0
 
-    for (let i = 0; i < data.length; i++) {
-      const value = data[i][key]
+    for (let index = 0; index < data.length; index++) {
+      const value = data[index][key]
+
       if (typeof value === 'number') {
         sum += value
         count++
       }
 
-      while (times[i] - times[left] >= windowMs) {
+      while (times[index] - times[left] >= windowMs) {
         const leftValue = data[left][key]
+
         if (typeof leftValue === 'number') {
           sum -= leftValue
           count--
         }
+
         left++
       }
 
       // Only smooth samples that actually carry a numeric value for this key.
       if (typeof value === 'number' && count > 0) {
-        if (result[i] === data[i]) result[i] = { ...data[i] }
-        result[i][key] = sum / count
+        if (result[index] === data[index]) {
+          result[index] = {
+            ...data[index]
+          }
+        }
+
+        result[index][key] = sum / count
       }
     }
   }

--- a/src/util/chart-smoothing.ts
+++ b/src/util/chart-smoothing.ts
@@ -1,14 +1,6 @@
 import type { ChartData } from '@/store/charts/types'
 
 /**
- * Matches the spiky PWM-driven series (heater power, fan speed). These are the
- * only series we visually smooth — temperatures are left raw so real thermal
- * lag stays visible.
- */
-export const isPowerOrSpeed = (key: string): boolean =>
-  key.endsWith('#power') || key.endsWith('#speed')
-
-/**
  * Applies a trailing time-window moving average to every smoothable key,
  * returning a new dataset. The input is never mutated.
  *
@@ -26,7 +18,7 @@ export const smoothChartData = (
   windowSeconds: number,
   isSmoothable: (key: string) => boolean
 ): ChartData[] => {
-  if (windowSeconds <= 0 || data.length === 0) return data
+  if (!Number.isFinite(windowSeconds) || windowSeconds <= 0 || data.length === 0) return data
 
   const windowMs = windowSeconds * 1000
 
@@ -39,28 +31,38 @@ export const smoothChartData = (
   }
   if (keys.size === 0) return data
 
-  return data.map((sample, i) => {
-    const result: ChartData = { ...sample }
-    const time = sample.date.getTime()
+  const times = data.map(sample => sample.date.getTime())
+  const result: ChartData[] = [...data]
 
-    for (const key of keys) {
-      // Only smooth samples that actually carry a numeric value for this key.
-      if (typeof sample[key] !== 'number') continue
+  // Two-pointer trailing window per key.
+  for (const key of keys) {
+    let left = 0
+    let sum = 0
+    let count = 0
 
-      let sum = 0
-      let count = 0
-      for (let j = i; j >= 0; j--) {
-        if (time - data[j].date.getTime() >= windowMs) break
-        const value = data[j][key]
-        if (typeof value === 'number') {
-          sum += value
-          count++
-        }
+    for (let i = 0; i < data.length; i++) {
+      const value = data[i][key]
+      if (typeof value === 'number') {
+        sum += value
+        count++
       }
 
-      if (count > 0) result[key] = sum / count
-    }
+      while (times[i] - times[left] >= windowMs) {
+        const leftValue = data[left][key]
+        if (typeof leftValue === 'number') {
+          sum -= leftValue
+          count--
+        }
+        left++
+      }
 
-    return result
-  })
+      // Only smooth samples that actually carry a numeric value for this key.
+      if (typeof value === 'number' && count > 0) {
+        if (result[i] === data[i]) result[i] = { ...data[i] }
+        result[i][key] = sum / count
+      }
+    }
+  }
+
+  return result
 }

--- a/src/util/chart-smoothing.ts
+++ b/src/util/chart-smoothing.ts
@@ -1,0 +1,66 @@
+import type { ChartData } from '@/store/charts/types'
+
+/**
+ * Matches the spiky PWM-driven series (heater power, fan speed). These are the
+ * only series we visually smooth — temperatures are left raw so real thermal
+ * lag stays visible.
+ */
+export const isPowerOrSpeed = (key: string): boolean =>
+  key.endsWith('#power') || key.endsWith('#speed')
+
+/**
+ * Applies a trailing time-window moving average to every smoothable key,
+ * returning a new dataset. The input is never mutated.
+ *
+ * `windowSeconds` is the width of the trailing window in seconds; Moonraker's
+ * store is ~1 sample/second, so a 3s window averages roughly the last 3
+ * samples. A window of 0 (or no smoothable keys) is a no-op and returns the
+ * original array reference unchanged.
+ *
+ * Samples missing a numeric value for a key are skipped in the mean, and a
+ * sample that has no value for a key keeps it absent (a value is never
+ * invented).
+ */
+export const smoothChartData = (
+  data: ChartData[],
+  windowSeconds: number,
+  isSmoothable: (key: string) => boolean
+): ChartData[] => {
+  if (windowSeconds <= 0 || data.length === 0) return data
+
+  const windowMs = windowSeconds * 1000
+
+  // The smoothable keys present anywhere in the dataset.
+  const keys = new Set<string>()
+  for (const sample of data) {
+    for (const key of Object.keys(sample)) {
+      if (key !== 'date' && isSmoothable(key)) keys.add(key)
+    }
+  }
+  if (keys.size === 0) return data
+
+  return data.map((sample, i) => {
+    const result: ChartData = { ...sample }
+    const time = sample.date.getTime()
+
+    for (const key of keys) {
+      // Only smooth samples that actually carry a numeric value for this key.
+      if (typeof sample[key] !== 'number') continue
+
+      let sum = 0
+      let count = 0
+      for (let j = i; j >= 0; j--) {
+        if (time - data[j].date.getTime() >= windowMs) break
+        const value = data[j][key]
+        if (typeof value === 'number') {
+          sum += value
+          count++
+        }
+      }
+
+      if (count > 0) result[key] = sum / count
+    }
+
+    return result
+  })
+}


### PR DESCRIPTION
Closes #1896

## Summary

Adds an **opt-in** General setting that applies a trailing moving-average to the thermal chart's power/speed series only. Temperatures are left raw — real thermal lag stays visible.

- Default is `None` — no behavior change unless a user turns it on.
- Window presets: `None / 1 / 3 / 5 / 10 / 15 / 30 s`.
- Smoothing is a pure, unit-tested util (`smoothChartData`) applied between the chart store and the ECharts dataset; the window is stored in `uiSettings.general.chartSmoothingWindow` (seconds, `0` = none) and changes re-render the chart live.

I posted this as a feature request three weeks ago (#1896) and offered to open a PR if there was interest, but haven't heard back — I understand maintainer time is limited, so I'm going ahead and opening this as a concrete, working reference per the offer in that issue. Very happy to adjust the design (global setting vs. per-chart, different presets, or close this out entirely) based on your take — no pressure either way.

## Test plan

- [x] `pnpm run lint` — clean
- [x] `pnpm run type-check` — clean
- [x] `pnpm run test` — 330/330 passing (includes new `chart-smoothing.spec.ts` covering the util at every window size)
- [x] `pnpm run circular-check` — clean
- [x] `pnpm run build` — production build succeeds
- [x] Manually verified on my own printer (Creality K1) — screenshot in #1896 shows the same power trace with smoothing off vs. 3s

Signed-off-by: Daniel Vystrcil <dvystrcil@gmail.com>