### PR TITLE
fix(AFC): Not defaulting to black in Print Dialog if lane not loaded

### DIFF
--- a/src/mixins/afc.ts
+++ b/src/mixins/afc.ts
@@ -159,7 +159,7 @@ export default class AfcMixin extends Vue {
     } else if (spool?.filament?.color_hex) {
       color = `#${spool.filament.color_hex.replace(/^#/, '')}`
     } else {
-      color = laneObj?.color || '#000000'
+      color = laneObj?.color || ''
     }
 
     const material = spool?.filament?.material || laneObj?.material || ''


### PR DESCRIPTION
Minor fix, not defaulting to black in AFC Print Dialog if lane is not loaded
- Updated to not default to black color in AFC Print Dialog if lane is not loaded. It was confusing to see a color even if filament was not loaded into the lanes.

AFC Print Screen Dialog before:
<img width="628" height="788" alt="image" src="https://github.com/user-attachments/assets/3364ae1c-81d0-48ed-9364-c2971c43755e" />

AFC Print Screen Dialog after fix:
<img width="718" height="821" alt="image" src="https://github.com/user-attachments/assets/85c195d4-8b52-4ace-bd00-95cb6ce6aacf" />

<!---
Thank you for contributing to Fluidd.  Before creating your pull request please review the [contributing guidelines](https://github.com/fluidd-core/fluidd/blob/master/CONTRIBUTING.md).

Be sure that every commit in it contains a footer with your real name and a reachable email address.

Alternatively, please add your real name and a reachable email address in the footer of this Pull Request.

Your signature acknowledges that you accept the [developer certificate of origin](https://github.com/fluidd-core/fluidd/blob/master/developer-certificate-of-origin).
--->
