### PR TITLE
fix(GcodePreview): toolhead position, extrusion modes and bounds

### DIFF
--- a/src/workers/parseGcode.ts
+++ b/src/workers/parseGcode.ts
@@ -1,5 +1,4 @@
 import type { ArcMove, ArcPlane, BBox, Layer, LinearMove, Move, Part, PositioningMode } from '@/store/gcodePreview/types'
-import isKeyOf from '@/util/is-key-of'
 import { pick } from 'lodash-es'
 import { split } from 'shlex'
 
@@ -71,6 +70,17 @@ const decimalRound = (a: number) => {
   return Math.round(a * 10000) / 10000
 }
 
+const createBounds = (): BBox => ({
+  x: {
+    min: Number.POSITIVE_INFINITY,
+    max: Number.NEGATIVE_INFINITY
+  },
+  y: {
+    min: Number.POSITIVE_INFINITY,
+    max: Number.NEGATIVE_INFINITY
+  }
+})
+
 const utf8ByteLength = (str: string) => {
   let bytes = 0
 
@@ -122,7 +132,7 @@ const parseGcode = async (
   const tools = new Set<number>()
 
   let newLayerForNextMove = false
-  let extrusionMode: PositioningMode = 'relative'
+  let extrusionMode: PositioningMode = 'absolute'
   let positioningMode: PositioningMode = 'absolute'
   let plane: ArcPlane = 'xy'
   const toolhead = {
@@ -133,16 +143,8 @@ const parseGcode = async (
   }
   let tool = 0
   let filePosition = 0
-  const bounds: BBox = {
-    x: {
-      min: Number.POSITIVE_INFINITY,
-      max: Number.NEGATIVE_INFINITY
-    },
-    y: {
-      min: Number.POSITIVE_INFINITY,
-      max: Number.NEGATIVE_INFINITY
-    }
-  }
+  let bounds = createBounds()
+  let lastBounds: BBox | null = null
 
   // todo get from firmware
   // store path: printer.printer.configFile.settings.firmware_retraction
@@ -157,6 +159,7 @@ const parseGcode = async (
     const { type, command, args } = parseLine(line) ?? {}
 
     let move: Move | null = null
+    let isSynthesizedMove = false
 
     if (type === 'macro') {
       switch (command) {
@@ -230,6 +233,8 @@ const parseGcode = async (
           plane = 'yz'
           break
         case 'G10':
+          isSynthesizedMove = true
+
           move = {
             e: -fwretraction.length,
             tool,
@@ -241,6 +246,8 @@ const parseGcode = async (
           }
           break
         case 'G11':
+          isSynthesizedMove = true
+
           move = {
             e: decimalRound(fwretraction.length + fwretraction.extrudeExtra),
             tool,
@@ -252,6 +259,8 @@ const parseGcode = async (
           }
           break
         case 'G28': {
+          isSynthesizedMove = true
+
           const hasX = 'x' in args
           const hasY = 'y' in args
           const hasZ = 'z' in args
@@ -286,9 +295,7 @@ const parseGcode = async (
           extrusionMode = 'relative'
           break
         case 'G92':
-          if (extrusionMode === 'absolute') {
-            toolhead.e = args.e ?? toolhead.e
-          }
+          toolhead.e = args.e ?? toolhead.e
 
           if (positioningMode === 'absolute') {
             toolhead.x = args.x ?? toolhead.x
@@ -314,14 +321,18 @@ const parseGcode = async (
       }
 
       if (move) {
-        if (extrusionMode === 'absolute' && move.e !== undefined) {
-          const extrusionLength = decimalRound(move.e - toolhead.e)
+        if (move.e !== undefined) {
+          if (positioningMode === 'absolute' && extrusionMode === 'absolute' && !isSynthesizedMove) {
+            const extrusionLength = decimalRound(move.e - toolhead.e)
 
-          toolhead.e = move.e
-          move.e = extrusionLength
+            toolhead.e = move.e
+            move.e = extrusionLength
+          } else {
+            toolhead.e = decimalRound(toolhead.e + move.e)
+          }
         }
 
-        if (positioningMode === 'relative') {
+        if (positioningMode === 'relative' && !isSynthesizedMove) {
           if (move.x !== undefined) {
             move.x = decimalRound(move.x + toolhead.x)
           }
@@ -336,8 +347,23 @@ const parseGcode = async (
         }
 
         if (newLayerForNextMove && move.e && move.e > 0) {
-          const m = move
-          if (['x', 'y', 'i', 'j'].some(x => isKeyOf(x, m) && m[x] !== 0)) {
+          if (
+            ('x' in move && move.x !== toolhead.x) ||
+            ('y' in move && move.y !== toolhead.y) ||
+            ('i' in move && move.i !== 0) ||
+            ('j' in move && move.j !== 0)
+          ) {
+            if (layers.length > 0) {
+              lastBounds = {
+                x: { ...bounds.x },
+                y: { ...bounds.y }
+              }
+
+              if (layers.length === 1) {
+                bounds = createBounds()
+              }
+            }
+
             const layer: Layer = {
               z: toolhead.z,
               move: moves.length - 1,
@@ -421,7 +447,7 @@ const parseGcode = async (
     layers,
     parts,
     bounds: layers.length > 0
-      ? bounds
+      ? lastBounds ?? bounds
       : null,
     tools: [...tools]
       .sort((a, b) => a - b)


### PR DESCRIPTION
Several fixes to the G-code preview parser worker (`src/workers/parseGcode.ts`), where its emulation of Klipper's coordinate semantics diverged from what Klipper actually does. Each item below was verified against Klipper source.

### Toolhead position

- **`G28` now ignores `G90`/`G91`.** Klipper's `cmd_G28` never consults `absolute_coord` — homing always lands at an absolute position derived from `position_endstop`/`homing_position` (`klippy/extras/homing.py`, `klippy/extras/gcode_move.py::_handle_home_rails_end`). The parser was adding the current toolhead position to it when a file was in relative mode.
- **`G10`/`G11` z-hop no longer double-offsets.** These synthesize `move.z` from the already-absolute `toolhead.z`, so they must skip the relative→absolute conversion too.

Both are handled by a single `isSynthesizedMove` flag set where the move is constructed, rather than testing command names downstream.

### Extrusion

- **`E` is absolute only when *both* `G90` and `M82` are active.** Per `cmd_G1` (`klippy/extras/gcode_move.py`), `absolute_coord` gates E as well:

  ```python
  absolute_coord = self.absolute_coord
  if axis == 'E':
      if not self.absolute_extrude:
          absolute_coord = False
  ```

  The parser only checked the extrusion mode, so a file in `G91` + `M82` had its E values misread as absolute targets.

- **`G10`/`G11` extrusion values are always deltas.** Klipper's `firmware_retraction.py` wraps the synthesized move in `G91`, so the value is relative regardless of `M82`/`M83`. Previously, a `G11` under `M82` with `toolhead.e = 100` produced `move.e = -99` — an unretract rendered as a retraction — and corrupted every subsequent delta.

- **`toolhead.e` now tracks relative-E moves.** Klipper's `last_position[3]` advances on these; the parser left it stale, so any `M83` → `M82` transition produced a wrong first delta.

- **`G92 E` is applied unconditionally**, matching `cmd_G92`, which has no mode check. Fixes `M83 … G92 E0 … M82 … G1 E5`.

- **Default extrusion mode is now absolute**, matching Klipper's `absolute_coord = absolute_extrude = True` initialisation. Only affects files that extrude before emitting `M82`/`M83`.

### Layer detection

The "did the toolhead actually move" test compared already-converted **absolute** X/Y coordinates against `0`, so a layer starting at X0 or Y0 was missed. It now compares X/Y against the current toolhead position, while I/J (arc-centre offsets, still relative) keep the `!= 0` test.

### Bounds

Reported bounds now exclude the first layer (priming/skirt) and the last layer, matching the intent already documented in the `getBounds` fallback getter in `src/store/gcodePreview/getters.ts`. Previously the worker accumulated through end-of-file, so end-G-code park/home moves stretched the bounding box and the preview auto-zoomed to frame empty space.

This is done incrementally — a snapshot per layer plus a reset at the first layer boundary — so there is no second pass over the (potentially multi-million entry) `moves` array.

### Compatibility

The dominant real-world case, `G90` + `M83` (PrusaSlicer/Cura default), is unaffected by the extrusion changes. Behaviour changes only for files using `G91` together with `M82`, files using firmware retraction under absolute E, files that extrude before any `M82`/`M83`, and `M83` → `M82` transitions.

### Testing

`lint`, `type-check` and the existing unit suite (324 tests) all pass. There is no existing test coverage for this worker; verification of the rendering changes was done by inspection against Klipper source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
