### PR TITLE
fix(history): resolve jobs outside the loaded page

### DIFF
--- a/src/api/socketActions.ts
+++ b/src/api/socketActions.ts
@@ -587,6 +587,17 @@ export const SocketActions = {
     )
   },
 
+  serverHistoryGetJob (uid: string, options?: NotifyOptions) {
+    return baseEmit<Moonraker.History.JobResponse>(
+      'server.history.get_job', {
+        ...options,
+        params: {
+          uid
+        }
+      }
+    )
+  },
+
   serverHistoryList (params?: { start?: number; limit?: number; before?: number; since?: number; order?: string }, options?: NotifyOptions) {
     return baseEmit<Moonraker.History.ListResponse>(
       'server.history.list', {

--- a/src/plugins/__tests__/socketClient.spec.ts
+++ b/src/plugins/__tests__/socketClient.spec.ts
@@ -1,0 +1,127 @@
+import { TypedStore } from '@/store'
+import { WebSocketClient } from '@/plugins/socketClient'
+
+const sockets: FakeWebSocket[] = []
+
+class FakeWebSocket {
+  static readonly OPEN = 1
+
+  readyState = FakeWebSocket.OPEN
+  sent: string[] = []
+
+  onopen: (() => void) | null = null
+  onclose: ((event: unknown) => void) | null = null
+  onerror: ((event: unknown) => void) | null = null
+  onmessage: ((message: { data: string }) => void) | null = null
+
+  constructor () {
+    sockets.push(this)
+  }
+
+  send (data: string) {
+    this.sent.push(data)
+  }
+
+  close () {}
+}
+
+const socket = () => sockets[sockets.length - 1]
+
+const onSocketError = vi.fn()
+const onSetStatus = vi.fn()
+
+const createSocketStore = () => new TypedStore({
+  modules: {
+    socket: {
+      namespaced: true,
+      state: () => ({ status: 'ready' }),
+      actions: {
+        onSetStatus: (...args: unknown[]) => onSetStatus(...args),
+        onSocketError: (...args: unknown[]) => onSocketError(...args)
+      }
+    },
+    config: {
+      namespaced: true,
+      state: () => ({ socketUrl: 'ws://localhost:7125/websocket' })
+    },
+    wait: {
+      namespaced: true,
+      actions: {
+        addWait: () => {}
+      },
+      mutations: {
+        setRemoveWait: () => {}
+      }
+    }
+  }
+})
+
+/**
+ * Answers the last request the client sent with a JSON-RPC error.
+ */
+const respondWithError = (code: number, message: string) => {
+  const { sent, onmessage } = socket()
+  const { id } = JSON.parse(sent[sent.length - 1]) as { id: number }
+
+  onmessage?.({
+    data: JSON.stringify({
+      jsonrpc: '2.0',
+      id,
+      error: { code, message }
+    })
+  })
+}
+
+describe('WebSocketClient error handling', () => {
+  let client: WebSocketClient
+
+  beforeEach(() => {
+    onSocketError.mockClear()
+    onSetStatus.mockClear()
+
+    vi.stubGlobal('WebSocket', FakeWebSocket)
+
+    client = new WebSocketClient({ store: createSocketStore() })
+    client.connect()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('dispatches socket/onSocketError for an ordinary request', async () => {
+    const request = client.emit('server.files.delete_file', { params: { path: 'gcodes/a.gcode' } })
+
+    respondWithError(404, 'File not found')
+
+    await expect(request).rejects.toMatchObject({ code: 404 })
+
+    expect(onSocketError).toHaveBeenCalledTimes(1)
+    expect(onSocketError.mock.calls[0][1]).toMatchObject({ code: 404, message: 'File not found' })
+  })
+
+  it('does not dispatch socket/onSocketError when the request suppresses it', async () => {
+    const request = client.emit('server.history.get_job', {
+      params: { uid: '00000f' },
+      suppressError: true
+    })
+
+    respondWithError(404, 'Invalid job uid: 00000f')
+
+    await expect(request).rejects.toMatchObject({ code: 404 })
+
+    expect(onSocketError).not.toHaveBeenCalled()
+  })
+
+  it('dispatches socket/onSocketError for a response with no matching request', () => {
+    socket().onmessage?.({
+      data: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 999999,
+        error: { code: 500, message: 'Internal error' }
+      })
+    })
+
+    expect(onSocketError).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/plugins/socketClient.ts
+++ b/src/plugins/socketClient.ts
@@ -96,7 +96,13 @@ export class WebSocketClient {
 
             consola.debug(`${LOG_PREFIX} Response error:`, socketResponse.error)
 
-            this.store.typedDispatch('socket/onSocketError', socketResponse.error)
+            // `suppressError` is opt-in per request, for callers that handle
+            // the rejection themselves and must not raise a toast for it.
+            // Anything else - including a response we have no request for -
+            // keeps the global error handling.
+            if (!request?.suppressError) {
+              this.store.typedDispatch('socket/onSocketError', socketResponse.error)
+            }
 
             return
           }
@@ -208,7 +214,7 @@ export class WebSocketClient {
   emit (method: string, options: NotifyOptions = {}) {
     return new Promise((resolve, reject) => {
       try {
-        const { wait, params, dispatch, commit } = options
+        const { wait, params, dispatch, commit, suppressError } = options
 
         // Any non-'disconnected' state is eligible to emit; physical readiness
         // is enforced by the readyState check below.
@@ -239,6 +245,7 @@ export class WebSocketClient {
             commit,
             params,
             wait,
+            suppressError,
             onFulfilled: resolve,
             onRejected: reject
           }
@@ -304,6 +311,13 @@ export interface NotifyOptions {
   dispatch?: string;
   commit?: string;
   wait?: string;
+
+  /**
+   * Skips the global `socket/onSocketError` dispatch for this request only,
+   * so a handled error does not also raise a toast. The returned promise
+   * still rejects, and the caller is expected to deal with it.
+   */
+  suppressError?: boolean;
 }
 
 interface Request {
@@ -312,6 +326,7 @@ interface Request {
   commit?: string;
   params?: Record<string, any>;
   wait?: string;
+  suppressError?: boolean;
   onFulfilled: (value: unknown) => void;
   onRejected: (reason?: unknown) => void;
 }

--- a/src/store/files/__tests__/actions.spec.ts
+++ b/src/store/files/__tests__/actions.spec.ts
@@ -1,0 +1,142 @@
+import { SocketActions } from '@/api/socketActions'
+import type { TypedStore } from '@/store'
+import type { AppFileWithMeta, FileBrowserEntry } from '../types'
+import { createHistoryJob, createTestStore } from '@/../tests/unit/store'
+
+vi.mock('@/api/socketActions', () => ({
+  SocketActions: {
+    serverHistoryGetJob: vi.fn(),
+    serverHistoryList: vi.fn(),
+    serverHistoryTotals: vi.fn(),
+    serverFilesGetDirectory: vi.fn(),
+    serverFilesMetadata: vi.fn()
+  }
+}))
+
+const serverHistoryGetJob = vi.mocked(SocketActions.serverHistoryGetJob)
+
+const getDirectoryResponse = (path: string, files: Record<string, unknown>[]) => ({
+  disk_usage: { total: 0, used: 0, free: 0 },
+  dirs: [],
+  files,
+  root_info: { name: 'gcodes' },
+  __request__: { params: { path } }
+})
+
+describe('files actions - history decoration', () => {
+  let store: TypedStore
+
+  beforeEach(async () => {
+    store = createTestStore()
+
+    await store.dispatch('history/reset')
+
+    serverHistoryGetJob.mockReset()
+    serverHistoryGetJob.mockImplementation(async (uid: string) => ({
+      job: createHistoryJob({ job_id: uid, filename: 'a.gcode', total_duration: 4321 })
+    }))
+  })
+
+  describe('onServerFilesGetDirectory', () => {
+    it('resolves the job of every file that names one', async () => {
+      await store.dispatch('files/onServerFilesGetDirectory', getDirectoryResponse('gcodes', [
+        { filename: 'a.gcode', modified: 0, size: 1, job_id: '00000f' },
+        { filename: 'b.gcode', modified: 0, size: 1, job_id: '000010' }
+      ]))
+
+      await vi.waitFor(() => {
+        expect(serverHistoryGetJob).toHaveBeenCalledTimes(2)
+      })
+
+      expect(serverHistoryGetJob).toHaveBeenCalledWith('00000f', { suppressError: true })
+      expect(serverHistoryGetJob).toHaveBeenCalledWith('000010', { suppressError: true })
+    })
+
+    it('issues nothing for a directory of files that never printed', async () => {
+      const actions: string[] = []
+      const unsubscribe = store.subscribeAction(({ type }) => actions.push(type))
+
+      await store.dispatch('files/onServerFilesGetDirectory', getDirectoryResponse('gcodes', [
+        { filename: 'a.gcode', modified: 0, size: 1 },
+        { filename: 'b.gcode', modified: 0, size: 1, job_id: null }
+      ]))
+
+      unsubscribe()
+
+      expect(actions).not.toContain('history/fetchMissingJobs')
+      expect(serverHistoryGetJob).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('onFileMetaData', () => {
+    it('resolves the job of a single file', async () => {
+      await store.dispatch('files/onFileMetaData', {
+        filename: 'a.gcode',
+        modified: 0,
+        size: 1,
+        job_id: '00000f'
+      })
+
+      await vi.waitFor(() => {
+        expect(serverHistoryGetJob).toHaveBeenCalledWith('00000f', { suppressError: true })
+      })
+    })
+
+    it('issues nothing for a file that never printed', async () => {
+      await store.dispatch('files/onFileMetaData', {
+        filename: 'a.gcode',
+        modified: 0,
+        size: 1
+      })
+
+      expect(serverHistoryGetJob).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('getDirectory', () => {
+    const getFileEntry = (filename: string): AppFileWithMeta | undefined => {
+      const items: FileBrowserEntry[] = store.getters['files/getDirectory']('gcodes')
+
+      return items.find((item): item is AppFileWithMeta =>
+        item.type === 'file' && item.name === filename
+      )
+    }
+
+    it('populates history for a file whose job is outside the loaded page', async () => {
+      // The loaded page holds a different job entirely - exactly the case the
+      // browser used to render blank.
+      store.commit('history/setHistoryList', {
+        count: 1,
+        jobs: [createHistoryJob({ job_id: '000001' })]
+      })
+
+      await store.dispatch('files/onServerFilesGetDirectory', getDirectoryResponse('gcodes', [
+        { filename: 'a.gcode', modified: 0, size: 1, job_id: '00000f' }
+      ]))
+
+      await vi.waitFor(() => {
+        expect(getFileEntry('a.gcode')?.history).toBeDefined()
+      })
+
+      const history = getFileEntry('a.gcode')?.history
+
+      expect(history?.job_id).toBe('00000f')
+      expect(history?.status).toBe('completed')
+      expect(history?.total_duration).toBe(4321)
+    })
+
+    it('leaves history unset for a file whose job was deleted', async () => {
+      serverHistoryGetJob.mockRejectedValue({ code: 404, message: 'Invalid job uid: 00000f' })
+
+      await store.dispatch('files/onServerFilesGetDirectory', getDirectoryResponse('gcodes', [
+        { filename: 'a.gcode', modified: 0, size: 1, job_id: '00000f' }
+      ]))
+
+      await vi.waitFor(() => {
+        expect(store.state.history.missingJobIds['00000f']).toBe(true)
+      })
+
+      expect(getFileEntry('a.gcode')?.history).toBeUndefined()
+    })
+  })
+})

--- a/src/store/files/actions.ts
+++ b/src/store/files/actions.ts
@@ -28,7 +28,7 @@ export const actions = {
     commit('setReset')
   },
 
-  async onServerFilesGetDirectory ({ commit }, payload: ObjectWithRequest<Moonraker.Files.GetDirectoryResponse>) {
+  async onServerFilesGetDirectory ({ commit, dispatch }, payload: ObjectWithRequest<Moonraker.Files.GetDirectoryResponse>) {
     const { disk_usage, files, dirs } = payload
     const { path } = payload.__request__.params ?? {}
     const [root] = path.split('/', 1)
@@ -42,6 +42,17 @@ export const actions = {
 
     commit('setDiskUsage', { root, disk_usage })
     commit('setServerFilesGetDirectory', { path, content: { files, dirs: filteredDirs } })
+
+    // A file's status and total duration come from its history job, and only
+    // the newest page of history is loaded - resolve whatever this directory
+    // needs that the page does not cover.
+    const jobIds = files
+      .map(file => 'job_id' in file ? file.job_id : null)
+      .filter(jobId => jobId)
+
+    if (jobIds.length > 0) {
+      dispatch('history/fetchMissingJobs', jobIds, { root: true })
+    }
   },
 
   async onServerFilesRoots ({ commit }, payload: Moonraker.Files.RootsResponse) {
@@ -57,7 +68,7 @@ export const actions = {
   /**
    * If we request the metadata (a file..) then we load and update here.
    */
-  async onFileMetaData ({ commit }, payload: Moonraker.Files.FileWithMetaResponse) {
+  async onFileMetaData ({ commit, dispatch }, payload: Moonraker.Files.FileWithMetaResponse) {
     const paths = getFilePaths(payload.filename, 'gcodes')
 
     if (!paths.filtered) {
@@ -68,6 +79,12 @@ export const actions = {
       }
 
       commit('setFileUpdate', { paths, file })
+
+      // `getFile` decorates with history too, so a single file needs the same
+      // treatment as a directory load.
+      if (file.job_id) {
+        dispatch('history/fetchMissingJobs', [file.job_id], { root: true })
+      }
     }
   },
 

--- a/src/store/history/__tests__/actions.spec.ts
+++ b/src/store/history/__tests__/actions.spec.ts
@@ -1,0 +1,277 @@
+import { SocketActions } from '@/api/socketActions'
+import type { TypedStore } from '@/store'
+import type { HistoryState } from '../types'
+import { createHistoryJob, createTestStore } from '@/../tests/unit/store'
+
+vi.mock('@/api/socketActions', () => ({
+  SocketActions: {
+    serverHistoryGetJob: vi.fn(),
+    serverHistoryList: vi.fn(),
+    serverHistoryTotals: vi.fn(),
+    serverFilesGetDirectory: vi.fn(),
+    serverFilesMetadata: vi.fn()
+  }
+}))
+
+const serverHistoryGetJob = vi.mocked(SocketActions.serverHistoryGetJob)
+
+const flush = () => new Promise(resolve => setTimeout(resolve, 0))
+
+const socketError = (code: number, message: string) => ({ code, message })
+
+describe('history/fetchMissingJobs', () => {
+  let store: TypedStore
+
+  beforeEach(async () => {
+    store = createTestStore()
+
+    // Also clears the module-local in-flight set.
+    await store.dispatch('history/reset')
+
+    vi.mocked(SocketActions.serverHistoryList).mockResolvedValue({ count: 0, jobs: [] })
+    serverHistoryGetJob.mockReset()
+  })
+
+  const historyState = (): HistoryState => store.state.history
+
+  const fetch = (jobIds: (string | null | undefined)[]) =>
+    store.dispatch('history/fetchMissingJobs', jobIds)
+
+  it('issues nothing when moonraker has no history component', async () => {
+    store = createTestStore([])
+
+    await fetch(['00000f'])
+
+    expect(serverHistoryGetJob).not.toHaveBeenCalled()
+  })
+
+  it('caches every resolved job in a single commit', async () => {
+    serverHistoryGetJob.mockImplementation(async (uid: string) => ({
+      job: createHistoryJob({ job_id: uid, filename: `${uid}.gcode` })
+    }))
+
+    const commits: string[] = []
+    const unsubscribe = store.subscribe(({ type }) => commits.push(type))
+
+    await fetch(['00000f', '000010'])
+
+    unsubscribe()
+
+    expect(serverHistoryGetJob).toHaveBeenCalledTimes(2)
+    expect(commits.filter(type => type === 'history/setJobsById')).toHaveLength(1)
+    expect(store.getters['history/getHistoryById']('00000f')?.filename).toBe('00000f.gcode')
+    expect(store.getters['history/getHistoryById']('000010')?.filename).toBe('000010.gcode')
+  })
+
+  it('suppresses the global error toast for these requests', async () => {
+    serverHistoryGetJob.mockRejectedValue(socketError(404, 'Invalid job uid: 00000f'))
+
+    await fetch(['00000f'])
+
+    expect(serverHistoryGetJob).toHaveBeenCalledWith('00000f', { suppressError: true })
+  })
+
+  it('records a 404 so the orphaned id is never requested again', async () => {
+    serverHistoryGetJob.mockRejectedValue(socketError(404, 'Invalid job uid: 00000f'))
+
+    await fetch(['00000f'])
+
+    expect(historyState().missingJobIds['00000f']).toBe(true)
+
+    await fetch(['00000f'])
+
+    expect(serverHistoryGetJob).toHaveBeenCalledTimes(1)
+  })
+
+  it('leaves a transient failure retryable', async () => {
+    serverHistoryGetJob.mockRejectedValueOnce(new Error('Socket disconnected'))
+
+    await fetch(['00000f'])
+
+    expect(historyState().missingJobIds['00000f']).toBeUndefined()
+
+    serverHistoryGetJob.mockResolvedValueOnce({ job: createHistoryJob({ job_id: '00000f' }) })
+
+    await fetch(['00000f'])
+
+    expect(serverHistoryGetJob).toHaveBeenCalledTimes(2)
+    expect(store.getters['history/getHistoryById']('00000f')).toBeDefined()
+  })
+
+  it('skips ids the loaded page already covers', async () => {
+    store.commit('history/setHistoryList', {
+      count: 1,
+      jobs: [createHistoryJob({ job_id: '000001' })]
+    })
+
+    await fetch(['000001'])
+
+    expect(serverHistoryGetJob).not.toHaveBeenCalled()
+  })
+
+  it('skips ids that are already cached', async () => {
+    store.commit('history/setJobsById', [createHistoryJob({ job_id: '00000f' })])
+
+    await fetch(['00000f'])
+
+    expect(serverHistoryGetJob).not.toHaveBeenCalled()
+  })
+
+  it('skips empty ids, and issues nothing when nothing is left', async () => {
+    await fetch([null, undefined, ''])
+
+    expect(serverHistoryGetJob).not.toHaveBeenCalled()
+  })
+
+  it('requests a duplicated id once', async () => {
+    serverHistoryGetJob.mockImplementation(async (uid: string) => ({
+      job: createHistoryJob({ job_id: uid })
+    }))
+
+    await fetch(['00000f', '00000f'])
+
+    expect(serverHistoryGetJob).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not re-request an id that is still in flight', async () => {
+    let resolveJob: (value: Moonraker.History.JobResponse) => void = () => {}
+
+    serverHistoryGetJob.mockReturnValueOnce(new Promise((resolve) => {
+      resolveJob = resolve
+    }))
+
+    const first = fetch(['00000f'])
+    await flush()
+
+    await fetch(['00000f'])
+
+    expect(serverHistoryGetJob).toHaveBeenCalledTimes(1)
+
+    resolveJob({ job: createHistoryJob({ job_id: '00000f' }) })
+    await first
+  })
+
+  it('keeps at most two requests in flight', async () => {
+    const pending: (() => void)[] = []
+    let inFlight = 0
+    let maxInFlight = 0
+
+    serverHistoryGetJob.mockImplementation((uid: string) => {
+      inFlight++
+      maxInFlight = Math.max(maxInFlight, inFlight)
+
+      return new Promise((resolve) => {
+        pending.push(() => {
+          inFlight--
+          resolve({ job: createHistoryJob({ job_id: uid }) })
+        })
+      })
+    })
+
+    const drain = fetch(['00000f', '000010', '000011', '000012'])
+
+    await flush()
+
+    expect(maxInFlight).toBe(2)
+    expect(serverHistoryGetJob).toHaveBeenCalledTimes(2)
+
+    while (pending.length > 0) {
+      pending.shift()?.()
+      await flush()
+    }
+
+    await drain
+
+    expect(serverHistoryGetJob).toHaveBeenCalledTimes(4)
+    expect(maxInFlight).toBe(2)
+  })
+})
+
+describe('history/repairMissingJobs', () => {
+  let store: TypedStore
+
+  beforeEach(async () => {
+    store = createTestStore()
+
+    await store.dispatch('history/reset')
+
+    serverHistoryGetJob.mockReset()
+  })
+
+  it('drops stale negatives and re-scans the loaded directories', async () => {
+    store.commit('files/setServerFilesGetDirectory', {
+      path: 'gcodes',
+      content: {
+        dirs: [],
+        files: [
+          { filename: 'a.gcode', modified: 0, size: 1, job_id: '00000f' },
+          { filename: 'b.gcode', modified: 0, size: 1, job_id: null },
+          { filename: 'c.gcode', modified: 0, size: 1 }
+        ]
+      }
+    })
+
+    store.commit('history/setMissingJobIds', ['00000f'])
+
+    serverHistoryGetJob.mockImplementation(async (uid: string) => ({
+      job: createHistoryJob({ job_id: uid })
+    }))
+
+    await store.dispatch('history/repairMissingJobs')
+
+    expect(serverHistoryGetJob).toHaveBeenCalledTimes(1)
+    expect(serverHistoryGetJob).toHaveBeenCalledWith('00000f', { suppressError: true })
+    expect(store.getters['history/getHistoryById']('00000f')).toBeDefined()
+  })
+
+  it('issues nothing when no directory is loaded', async () => {
+    await store.dispatch('history/repairMissingJobs')
+
+    expect(serverHistoryGetJob).not.toHaveBeenCalled()
+  })
+})
+
+describe('history/init', () => {
+  let store: TypedStore
+
+  beforeEach(async () => {
+    store = createTestStore()
+
+    await store.dispatch('history/reset')
+
+    serverHistoryGetJob.mockReset()
+  })
+
+  it('repairs the loaded directories once the new page has landed', async () => {
+    store.commit('files/setServerFilesGetDirectory', {
+      path: 'gcodes',
+      content: {
+        dirs: [],
+        files: [{ filename: 'a.gcode', modified: 0, size: 1, job_id: '00000f' }]
+      }
+    })
+
+    vi.mocked(SocketActions.serverHistoryList).mockResolvedValue({ count: 0, jobs: [] })
+    serverHistoryGetJob.mockResolvedValue({ job: createHistoryJob({ job_id: '00000f' }) })
+
+    await store.dispatch('history/init')
+
+    expect(serverHistoryGetJob).toHaveBeenCalledWith('00000f', { suppressError: true })
+  })
+
+  it('does not repair when the history list request failed', async () => {
+    store.commit('files/setServerFilesGetDirectory', {
+      path: 'gcodes',
+      content: {
+        dirs: [],
+        files: [{ filename: 'a.gcode', modified: 0, size: 1, job_id: '00000f' }]
+      }
+    })
+
+    vi.mocked(SocketActions.serverHistoryList).mockRejectedValue(new Error('Socket disconnected'))
+
+    await store.dispatch('history/init')
+
+    expect(serverHistoryGetJob).not.toHaveBeenCalled()
+  })
+})

--- a/src/store/history/__tests__/getters.spec.ts
+++ b/src/store/history/__tests__/getters.spec.ts
@@ -1,0 +1,97 @@
+import type { TypedStore } from '@/store'
+import type { HistoryItem } from '../types'
+import { createHistoryJob, createTestStore } from '@/../tests/unit/store'
+
+describe('history getters', () => {
+  let store: TypedStore
+
+  beforeEach(() => {
+    store = createTestStore()
+  })
+
+  const getHistoryById = (jobId: string): HistoryItem | undefined =>
+    store.getters['history/getHistoryById'](jobId)
+
+  describe('getHistoryById', () => {
+    it('resolves a job in the loaded page', () => {
+      store.commit('history/setHistoryList', {
+        count: 1,
+        jobs: [createHistoryJob({ job_id: '000001', filename: 'loaded.gcode' })]
+      })
+
+      expect(getHistoryById('000001')?.filename).toBe('loaded.gcode')
+    })
+
+    it('resolves a job that is only in the cache', () => {
+      store.commit('history/setJobsById', [
+        createHistoryJob({ job_id: '00000f', filename: 'fetched.gcode' })
+      ])
+
+      expect(getHistoryById('00000f')?.filename).toBe('fetched.gcode')
+    })
+
+    it('normalizes a cached job the same way as a loaded one', () => {
+      store.commit('history/setJobsById', [
+        createHistoryJob({
+          job_id: '00000f',
+          metadata: {
+            modified: '2026-08-09T12:00:00.000Z',
+            size: 1024,
+            filament_name: 'Black PLA;Red PLA'
+          }
+        })
+      ])
+
+      const metadata = getHistoryById('00000f')?.metadata
+
+      expect(metadata?.modified).toBe(1786276800)
+      expect(metadata?.filament_name).toStrictEqual(['Black PLA', 'Red PLA'])
+    })
+
+    it('returns undefined when the job is in neither', () => {
+      expect(getHistoryById('00000f')).toBeUndefined()
+    })
+
+    it('prefers the loaded page over the cache', () => {
+      store.commit('history/setJobsById', [
+        createHistoryJob({ job_id: '000001', filename: 'stale.gcode' })
+      ])
+      store.commit('history/setHistoryList', {
+        count: 1,
+        jobs: [createHistoryJob({ job_id: '000001', filename: 'fresh.gcode' })]
+      })
+
+      expect(getHistoryById('000001')?.filename).toBe('fresh.gcode')
+    })
+  })
+
+  describe('getHistory', () => {
+    it('does not include individually fetched jobs', () => {
+      store.commit('history/setHistoryList', {
+        count: 1,
+        jobs: [createHistoryJob({ job_id: '000001' })]
+      })
+      store.commit('history/setJobsById', [
+        createHistoryJob({ job_id: '00000f' })
+      ])
+
+      const history: HistoryItem[] = store.getters['history/getHistory']
+
+      expect(history.map(job => job.job_id)).toStrictEqual(['000001'])
+    })
+
+    it('sorts by start time, newest first', () => {
+      store.commit('history/setHistoryList', {
+        count: 2,
+        jobs: [
+          createHistoryJob({ job_id: '000001', start_time: 100 }),
+          createHistoryJob({ job_id: '000002', start_time: 200 })
+        ]
+      })
+
+      const history: HistoryItem[] = store.getters['history/getHistory']
+
+      expect(history.map(job => job.job_id)).toStrictEqual(['000002', '000001'])
+    })
+  })
+})

--- a/src/store/history/__tests__/mutations.spec.ts
+++ b/src/store/history/__tests__/mutations.spec.ts
@@ -1,0 +1,142 @@
+import type { TypedStore } from '@/store'
+import type { HistoryState } from '../types'
+import { createHistoryJob, createTestStore } from '@/../tests/unit/store'
+
+describe('history mutations', () => {
+  let store: TypedStore
+
+  beforeEach(() => {
+    store = createTestStore()
+  })
+
+  const historyState = (): HistoryState => store.state.history
+
+  describe('setJobsById', () => {
+    it('caches every job in one commit and freezes it', () => {
+      store.commit('history/setJobsById', [
+        createHistoryJob({ job_id: '00000f' }),
+        createHistoryJob({ job_id: '000010' })
+      ])
+
+      expect(Object.keys(historyState().jobsById)).toStrictEqual(['00000f', '000010'])
+      expect(Object.isFrozen(historyState().jobsById['00000f'])).toBe(true)
+    })
+
+    it('clears a negative entry for the same id', () => {
+      store.commit('history/setMissingJobIds', ['00000f'])
+      store.commit('history/setJobsById', [createHistoryJob({ job_id: '00000f' })])
+
+      expect(historyState().missingJobIds['00000f']).toBeUndefined()
+    })
+  })
+
+  describe('setMissingJobIds', () => {
+    it('records the ids and drops any cached job', () => {
+      store.commit('history/setJobsById', [createHistoryJob({ job_id: '00000f' })])
+      store.commit('history/setMissingJobIds', ['00000f'])
+
+      expect(historyState().missingJobIds['00000f']).toBe(true)
+      expect(historyState().jobsById['00000f']).toBeUndefined()
+    })
+  })
+
+  describe('setDeleteJob', () => {
+    it('stops the file browser resolving a deleted job', () => {
+      store.commit('history/setJobsById', [createHistoryJob({ job_id: '00000f' })])
+
+      expect(store.getters['history/getHistoryById']('00000f')).toBeDefined()
+
+      store.commit('history/setDeleteJob', ['00000f'])
+
+      expect(store.getters['history/getHistoryById']('00000f')).toBeUndefined()
+      expect(historyState().missingJobIds['00000f']).toBe(true)
+    })
+
+    it('removes the job from the loaded page too', () => {
+      store.commit('history/setHistoryList', {
+        count: 1,
+        jobs: [createHistoryJob({ job_id: '000001' })]
+      })
+      store.commit('history/setDeleteJob', ['000001'])
+
+      expect(store.getters['history/getHistoryById']('000001')).toBeUndefined()
+    })
+  })
+
+  describe('setAddHistory', () => {
+    it('clears a negative entry, because moonraker reuses deleted job ids', () => {
+      store.commit('history/setMissingJobIds', ['000001'])
+      store.commit('history/setAddHistory', createHistoryJob({ job_id: '000001' }))
+
+      expect(historyState().missingJobIds['000001']).toBeUndefined()
+      expect(store.getters['history/getHistoryById']('000001')).toBeDefined()
+    })
+  })
+
+  describe('setUpdateHistory', () => {
+    it('clears a negative entry', () => {
+      store.commit('history/setHistoryList', {
+        count: 1,
+        jobs: [createHistoryJob({ job_id: '000001', status: 'in_progress' })]
+      })
+      store.commit('history/setMissingJobIds', ['000001'])
+      store.commit('history/setUpdateHistory', createHistoryJob({ job_id: '000001', status: 'completed' }))
+
+      expect(historyState().missingJobIds['000001']).toBeUndefined()
+      expect(store.getters['history/getHistoryById']('000001')?.status).toBe('completed')
+    })
+  })
+
+  describe('setHistoryList', () => {
+    it('prunes cache entries the new page covers, including negatives', () => {
+      store.commit('history/setJobsById', [createHistoryJob({ job_id: '000001' })])
+      store.commit('history/setMissingJobIds', ['000002'])
+
+      store.commit('history/setHistoryList', {
+        count: 2,
+        jobs: [
+          createHistoryJob({ job_id: '000001' }),
+          createHistoryJob({ job_id: '000002' })
+        ]
+      })
+
+      expect(historyState().jobsById['000001']).toBeUndefined()
+      expect(historyState().missingJobIds['000002']).toBeUndefined()
+    })
+
+    it('leaves cache entries the new page does not cover', () => {
+      store.commit('history/setJobsById', [createHistoryJob({ job_id: '00000f' })])
+
+      store.commit('history/setHistoryList', {
+        count: 1,
+        jobs: [createHistoryJob({ job_id: '000001' })]
+      })
+
+      expect(historyState().jobsById['00000f']).toBeDefined()
+    })
+  })
+
+  describe('setClearMissingJobIds', () => {
+    it('drops every negative entry and keeps the cached jobs', () => {
+      store.commit('history/setJobsById', [createHistoryJob({ job_id: '00000f' })])
+      store.commit('history/setMissingJobIds', ['000010'])
+
+      store.commit('history/setClearMissingJobIds')
+
+      expect(historyState().missingJobIds).toStrictEqual({})
+      expect(historyState().jobsById['00000f']).toBeDefined()
+    })
+  })
+
+  describe('setReset', () => {
+    it('clears both caches', () => {
+      store.commit('history/setJobsById', [createHistoryJob({ job_id: '00000f' })])
+      store.commit('history/setMissingJobIds', ['000010'])
+
+      store.commit('history/setReset')
+
+      expect(historyState().jobsById).toStrictEqual({})
+      expect(historyState().missingJobIds).toStrictEqual({})
+    })
+  })
+})

--- a/src/store/history/__tests__/to-history-item.spec.ts
+++ b/src/store/history/__tests__/to-history-item.spec.ts
@@ -1,0 +1,67 @@
+import { createHistoryJob, installTestFilters } from '@/../tests/unit/store'
+import toHistoryItem from '../to-history-item'
+
+describe('toHistoryItem', () => {
+  beforeAll(() => {
+    installTestFilters()
+  })
+
+  it('leaves a job without metadata alone', () => {
+    const item = toHistoryItem(createHistoryJob({ job_id: '000001' }))
+
+    expect(item.job_id).toBe('000001')
+    expect(item.metadata).toBeUndefined()
+  })
+
+  it('converts a moonraker modified date to a unix time', () => {
+    const item = toHistoryItem(createHistoryJob({
+      job_id: '000001',
+      metadata: {
+        modified: '2026-08-09T12:00:00.000Z',
+        size: 1024
+      }
+    }))
+
+    expect(item.metadata?.modified).toBe(1786276800)
+  })
+
+  it('passes a numeric modified date through', () => {
+    const item = toHistoryItem(createHistoryJob({
+      job_id: '000001',
+      metadata: {
+        modified: 1786276800,
+        size: 1024
+      }
+    }))
+
+    expect(item.metadata?.modified).toBe(1786276800)
+  })
+
+  it('splits filament_name and filament_type into arrays', () => {
+    const item = toHistoryItem(createHistoryJob({
+      job_id: '000001',
+      metadata: {
+        modified: 0,
+        size: 1024,
+        filament_name: 'Black PLA;Red PLA',
+        filament_type: 'PLA;PLA'
+      }
+    }))
+
+    expect(item.metadata?.filament_name).toStrictEqual(['Black PLA', 'Red PLA'])
+    expect(item.metadata?.filament_type).toStrictEqual(['PLA', 'PLA'])
+  })
+
+  it('omits filament fields that the job does not carry', () => {
+    const item = toHistoryItem(createHistoryJob({
+      job_id: '000001',
+      metadata: {
+        modified: 0,
+        size: 1024
+      }
+    }))
+
+    expect(item.metadata?.filament_name).toBeUndefined()
+    expect(item.metadata?.filament_type).toBeUndefined()
+  })
+})

--- a/src/store/history/actions.ts
+++ b/src/store/history/actions.ts
@@ -1,27 +1,190 @@
 import type { ActionTree } from 'vuex'
+import { consola } from 'consola'
 import type { HistoryItem, HistoryState } from './types'
 import type { RootState } from '../types'
 import { SocketActions } from '@/api/socketActions'
 import { Globals } from '@/globals'
 import getFilePaths from '@/util/get-file-paths'
 
+/**
+ * Individually fetched jobs - lifecycle
+ * =====================================
+ *
+ * `history/init` loads only the newest `JOB_HISTORY_LOAD` jobs, but the file
+ * browser needs the job behind each file's last print, and those are spread
+ * across the whole history. Files whose job falls outside that page are
+ * resolved one at a time instead.
+ *
+ *   files/onServerFilesGetDirectory ─┐
+ *   files/onFileMetaData ────────────┴─> fetchMissingJobs(jobIds)
+ *                                          │
+ *                                          ├─ history component unsupported? stop
+ *                                          ├─ drop ids already in `jobs`,
+ *                                          │  in `jobsById`, in `missingJobIds`,
+ *                                          │  or in flight
+ *                                          ├─ drain through a bounded pool
+ *                                          └─ commit ONCE per drain
+ *                                               ├─ setJobsById   (resolved)
+ *                                               └─ setMissingJobIds (404 only)
+ *
+ * Invalidated by:
+ *   setDeleteJob         evict + mark missing (the job really is gone)
+ *   setAddHistory        clear missing (SQLite reuses deleted job ids)
+ *   setUpdateHistory     clear missing
+ *   setHistoryList       drop whatever the new page covers
+ *   repairMissingJobs    clear all negatives + re-scan on reconnect
+ *   setReset             cleared via defaultState() on instance switch
+ *
+ * Keep this comment in step with any change to that flow.
+ */
+
+/**
+ * Moonraker serializes every history endpoint behind a single lock, so
+ * concurrency here buys no wall-clock - it only bounds how many promises are
+ * pending client-side. Kept deliberately low so a long drain does not hold
+ * that lock against the history page or an in-flight delete.
+ */
+const JOB_FETCH_CONCURRENCY = 2
+
+/**
+ * Module-local, not state: Vuex strict mode forbids writing to state outside a
+ * mutation, and this never needs to be reactive.
+ */
+const inFlightJobIds = new Set<string>()
+
+const isJobNotFoundError = (error: unknown): boolean => (
+  error != null &&
+  typeof error === 'object' &&
+  'code' in error &&
+  error.code === 404
+)
+
 export const actions = {
   /**
    * Reset our store
    */
   async reset ({ commit }) {
+    inFlightJobIds.clear()
+
     commit('setReset')
   },
 
   /**
    * Inits moonraker component
    */
-  async init () {
+  async init ({ dispatch }) {
     // Get the last 50 history items.
-    SocketActions.serverHistoryList({ limit: Globals.JOB_HISTORY_LOAD })
+    const historyList = SocketActions.serverHistoryList({ limit: Globals.JOB_HISTORY_LOAD })
 
     // Load the known totals.
     SocketActions.serverHistoryTotals()
+
+    try {
+      await historyList
+    } catch (error) {
+      consola.debug('Error loading history list', error)
+
+      return
+    }
+
+    await dispatch('repairMissingJobs')
+  },
+
+  /**
+   * `init` re-runs on every socket ready and `setHistoryList` replaces the
+   * loaded page wholesale, so jobs added while we were away are only in the
+   * new page, and any 404 we recorded belongs to a connection that is gone.
+   * `files` is not reset on a socket drop, so nothing else reloads the
+   * directories that are on screen - re-scan them here.
+   */
+  async repairMissingJobs ({ commit, dispatch, rootState }) {
+    commit('setClearMissingJobIds')
+
+    const jobIds = Object.values(rootState.files.pathContent)
+      .flatMap(pathContent => pathContent?.files ?? [])
+      .map(file => 'job_id' in file ? file.job_id : null)
+
+    await dispatch('fetchMissingJobs', jobIds)
+  },
+
+  /**
+   * Resolves jobs the loaded history page does not cover, one request each.
+   *
+   * Ids that are already known - loaded, cached, known missing, or in flight -
+   * are dropped, so repeat directory loads issue nothing.
+   */
+  async fetchMissingJobs ({ commit, state, rootGetters }, payload: (string | null | undefined)[]) {
+    if (!rootGetters['server/componentSupport']('history')) {
+      return
+    }
+
+    const loadedJobIds = new Set(state.jobs.map(job => job.job_id))
+
+    const queue = [...new Set(payload)]
+      .filter((jobId): jobId is string => (
+        !!jobId &&
+        !loadedJobIds.has(jobId) &&
+        state.jobsById[jobId] == null &&
+        state.missingJobIds[jobId] == null &&
+        !inFlightJobIds.has(jobId)
+      ))
+
+    if (queue.length === 0) {
+      return
+    }
+
+    for (const jobId of queue) {
+      inFlightJobIds.add(jobId)
+    }
+
+    const jobs: Moonraker.History.Job[] = []
+    const missingJobIds: string[] = []
+
+    const worker = async () => {
+      while (queue.length > 0) {
+        const jobId = queue.shift()
+
+        if (jobId == null) {
+          return
+        }
+
+        try {
+          // suppressError: an orphaned job_id is expected - Moonraker never
+          // clears it from the file metadata when the job is deleted - and a
+          // directory of them would otherwise be a toast per file.
+          const { job } = await SocketActions.serverHistoryGetJob(jobId, { suppressError: true })
+
+          if (job != null) {
+            jobs.push(job)
+          }
+        } catch (error) {
+          if (isJobNotFoundError(error)) {
+            missingJobIds.push(jobId)
+          } else {
+            // Transient - a dropped socket, say. Left uncached so the next
+            // directory load tries again.
+            consola.debug('Error fetching history job', jobId, error)
+          }
+        } finally {
+          inFlightJobIds.delete(jobId)
+        }
+      }
+    }
+
+    await Promise.all(
+      Array.from(
+        { length: Math.min(JOB_FETCH_CONCURRENCY, queue.length) },
+        worker
+      )
+    )
+
+    if (jobs.length > 0) {
+      commit('setJobsById', jobs)
+    }
+
+    if (missingJobIds.length > 0) {
+      commit('setMissingJobIds', missingJobIds)
+    }
   },
 
   async updateHistory ({ commit }, payload: Moonraker.History.Job) {

--- a/src/store/history/getters.ts
+++ b/src/store/history/getters.ts
@@ -1,49 +1,53 @@
-import Vue from 'vue'
 import type { GetterTree } from 'vuex'
 import type { HistoryItem, HistoryState } from './types'
 import type { RootState } from '../types'
+import toHistoryItem from './to-history-item'
 
 export const getters = {
   /**
    * Returns all history, sorted by start time.
+   *
+   * Only the loaded page - jobs resolved individually for the file browser are
+   * deliberately absent, so this stays a contiguous page of the history.
    */
   getHistory: (state) => {
     return state.jobs
-      .map((job): HistoryItem => {
-        const { metadata, ...restOfJob } = job
-
-        const item: HistoryItem = restOfJob
-
-        if (metadata != null) {
-          const { filament_name, filament_type, ...restOfMetadata } = metadata
-
-          item.metadata = {
-            ...restOfMetadata,
-            modified: Vue.$filters.moonrakerDateAsUnixTime(metadata.modified)
-          }
-
-          if (filament_name != null) {
-            item.metadata.filament_name = Vue.$filters.getStringArray(filament_name)
-          }
-
-          if (filament_type != null) {
-            item.metadata.filament_type = Vue.$filters.getStringArray(filament_type)
-          }
-        }
-
-        return item
-      })
+      .map(toHistoryItem)
       .sort((a, b) => b.start_time - a.start_time)
+  },
+
+  /**
+   * An index of every job we can resolve, by id.
+   *
+   * A derived getter rather than state: `getHistoryById` is called once per
+   * file by `files/getDirectory`, and a `.find()` there makes that render
+   * O(files x jobs). Deriving it also keeps the Map out of state, which Vue 2
+   * cannot make reactive.
+   */
+  getHistoryByIdMap: (state, getters): Map<string, HistoryItem> => {
+    const map = new Map<string, HistoryItem>()
+
+    for (const [jobId, job] of Object.entries(state.jobsById)) {
+      if (job != null) {
+        map.set(jobId, toHistoryItem(job))
+      }
+    }
+
+    // The loaded page wins over the cache - it is the fresher copy.
+    for (const item of getters.getHistory as HistoryItem[]) {
+      map.set(item.job_id, item)
+    }
+
+    return map
   },
 
   /**
    * Return a history item given a job id.
    */
-  getHistoryById: (state, getters) => (jobId: string) => {
-    const history: HistoryItem[] = getters.getHistory
+  getHistoryById: (state, getters) => (jobId: string): HistoryItem | undefined => {
+    const map: Map<string, HistoryItem> = getters.getHistoryByIdMap
 
-    return history
-      .find(job => job.job_id === jobId)
+    return map.get(jobId)
   },
 
   /**

--- a/src/store/history/mutations.ts
+++ b/src/store/history/mutations.ts
@@ -3,6 +3,15 @@ import type { MutationTree } from 'vuex'
 import { defaultState } from './state'
 import type { HistoryState } from './types'
 
+/**
+ * Drops both cache entries for a job id, positive and negative, because
+ * `state.jobs` now answers for it.
+ */
+const forgetCachedJob = (state: HistoryState, jobId: string) => {
+  Vue.delete(state.jobsById, jobId)
+  Vue.delete(state.missingJobIds, jobId)
+}
+
 export const mutations = {
   /**
    * Reset state
@@ -25,6 +34,13 @@ export const mutations = {
     if (payload.jobs != null) {
       state.jobs = payload.jobs
         .map(job => Object.freeze(job))
+
+      // Anything the new page covers is served from `jobs`, so drop it from
+      // the cache - including any negative entry, which the page just proved
+      // wrong.
+      for (const job of state.jobs) {
+        forgetCachedJob(state, job.job_id)
+      }
     }
     if (payload.count != null) {
       state.count = payload.count
@@ -38,6 +54,11 @@ export const mutations = {
     if (payload) {
       state.jobs.push(Object.freeze(payload))
       state.count++
+
+      // Moonraker's job ids are a SQLite `INTEGER PRIMARY KEY` with no
+      // AUTOINCREMENT, so an id is reused once the newest job is deleted. A
+      // negative entry for it is now stale.
+      forgetCachedJob(state, payload.job_id)
     }
   },
 
@@ -50,7 +71,39 @@ export const mutations = {
       if (i >= 0) {
         Vue.set(state.jobs, i, Object.freeze(payload))
       }
+
+      forgetCachedJob(state, payload.job_id)
     }
+  },
+
+  /**
+   * Applies jobs fetched individually for files whose job is outside the
+   * loaded page. Committed once per drain rather than once per response, so
+   * a directory's worth of results is a single re-render.
+   */
+  setJobsById (state, payload: Moonraker.History.Job[]) {
+    for (const job of payload) {
+      Vue.set(state.jobsById, job.job_id, Object.freeze(job))
+      Vue.delete(state.missingJobIds, job.job_id)
+    }
+  },
+
+  /**
+   * Records job ids Moonraker has no row for, so they are not re-requested.
+   */
+  setMissingJobIds (state, payload: string[]) {
+    for (const jobId of payload) {
+      Vue.set(state.missingJobIds, jobId, true)
+      Vue.delete(state.jobsById, jobId)
+    }
+  },
+
+  /**
+   * Drops every negative cache entry. A 404 recorded against a previous
+   * connection is not evidence about this one.
+   */
+  setClearMissingJobIds (state) {
+    state.missingJobIds = {}
   },
 
   setClearHistoryThumbnails (state, payload: string) {
@@ -74,6 +127,11 @@ export const mutations = {
       payload.forEach((job_id) => {
         const i = state.jobs.findIndex(job => job.job_id === job_id)
         if (i >= 0) state.jobs.splice(i, 1)
+
+        // Without this the file browser keeps rendering a deleted job, and
+        // re-fetching the id would only 404.
+        Vue.delete(state.jobsById, job_id)
+        Vue.set(state.missingJobIds, job_id, true)
       })
     }
   }

--- a/src/store/history/state.ts
+++ b/src/store/history/state.ts
@@ -4,6 +4,8 @@ export const defaultState = (): HistoryState => {
   return {
     count: 0,
     jobs: [],
+    jobsById: {},
+    missingJobIds: {},
     job_totals: {
       total_jobs: 0,
       total_time: 0,

--- a/src/store/history/to-history-item.ts
+++ b/src/store/history/to-history-item.ts
@@ -1,0 +1,35 @@
+import Vue from 'vue'
+import type { HistoryItem } from './types'
+
+/**
+ * Normalizes a raw Moonraker job into the shape the app consumes.
+ *
+ * State holds raw jobs everywhere - both the loaded page and the individually
+ * fetched cache - so this is the single place that converts them.
+ */
+const toHistoryItem = (job: Readonly<Moonraker.History.Job>): HistoryItem => {
+  const { metadata, ...restOfJob } = job
+
+  const item: HistoryItem = restOfJob
+
+  if (metadata != null) {
+    const { filament_name, filament_type, ...restOfMetadata } = metadata
+
+    item.metadata = {
+      ...restOfMetadata,
+      modified: Vue.$filters.moonrakerDateAsUnixTime(metadata.modified)
+    }
+
+    if (filament_name != null) {
+      item.metadata.filament_name = Vue.$filters.getStringArray(filament_name)
+    }
+
+    if (filament_type != null) {
+      item.metadata.filament_type = Vue.$filters.getStringArray(filament_type)
+    }
+  }
+
+  return item
+}
+
+export default toHistoryItem

--- a/src/store/history/types.ts
+++ b/src/store/history/types.ts
@@ -4,6 +4,24 @@ export interface HistoryState {
   count: number;
   jobs: Readonly<Moonraker.History.Job>[];
   job_totals: Moonraker.History.JobTotals;
+
+  /**
+   * Jobs resolved individually via `server.history.get_job`, for files whose
+   * job sits outside the page `jobs` holds. Kept apart from `jobs` so the
+   * history page keeps showing a contiguous page rather than an arbitrary
+   * set of jobs the file browser happened to ask for.
+   *
+   * A plain object rather than a Map: Vue 2 cannot make a Map reactive, so
+   * this is mutated with `Vue.set` / `Vue.delete`.
+   */
+  jobsById: Record<string, Readonly<Moonraker.History.Job> | undefined>;
+
+  /**
+   * Job ids Moonraker answered `404` for - the job was deleted but the file
+   * metadata still names it. Cached so a directory of orphaned files does not
+   * re-request them on every load.
+   */
+  missingJobIds: Record<string, true | undefined>;
 }
 
 export interface HistoryItem extends Omit<Moonraker.History.Job, 'metadata'> {

--- a/src/typings/moonraker.history.d.ts
+++ b/src/typings/moonraker.history.d.ts
@@ -9,6 +9,10 @@ declare namespace Moonraker.History {
     jobs: Job[];
   }
 
+  export interface JobResponse {
+    job: Job;
+  }
+
   export interface DeleteJobResponse {
     deleted_jobs: string[];
   }

--- a/tests/unit/store.ts
+++ b/tests/unit/store.ts
@@ -1,0 +1,67 @@
+import Vue from 'vue'
+import { TypedStore } from '@/store'
+import { history } from '@/store/history'
+import { files } from '@/store/files'
+import { server } from '@/store/server'
+import dateTimeFormatters from '@/util/date-time-formatters'
+import stringFormatters from '@/util/string-formatters'
+
+/**
+ * The history getters normalize job metadata through `Vue.$filters`. Installing
+ * the real plugin would drag in the router and the app store, so the two
+ * formatter modules it composes are wired up directly.
+ */
+export const installTestFilters = () => {
+  Vue.$filters = {
+    ...Vue.$filters,
+    ...dateTimeFormatters(() => 'iso', () => 'iso'),
+    ...stringFormatters()
+  }
+}
+
+export const defaultServerInfo = (components: string[] = ['history']): Moonraker.Server.InfoResponse => ({
+  klippy_connected: true,
+  klippy_state: 'ready',
+  components,
+  failed_components: [],
+  registered_directories: [],
+  warnings: []
+})
+
+/**
+ * A store holding only the modules under test.
+ *
+ * Module state is a module-level singleton in this codebase, so a fresh store
+ * still starts on whatever the previous one left behind - hence the explicit
+ * resets.
+ */
+export const createTestStore = (components: string[] = ['history']) => {
+  installTestFilters()
+
+  const store = new TypedStore({
+    modules: {
+      history,
+      files,
+      server
+    }
+  })
+
+  store.commit('history/setReset')
+  store.commit('files/setReset')
+  store.commit('server/setReset')
+  store.commit('server/setServerInfo', defaultServerInfo(components))
+
+  return store
+}
+
+export const createHistoryJob = (job: Partial<Moonraker.History.Job> & Pick<Moonraker.History.Job, 'job_id'>): Moonraker.History.Job => ({
+  exists: true,
+  end_time: null,
+  filament_used: 0,
+  filename: `${job.job_id}.gcode`,
+  print_duration: 0,
+  status: 'completed',
+  start_time: 0,
+  total_duration: 0,
+  ...job
+})

--- a/tests/unit/vue-augmentations.d.ts
+++ b/tests/unit/vue-augmentations.d.ts
@@ -1,0 +1,28 @@
+import type dateTimeFormatters from '@/util/date-time-formatters'
+import type stringFormatters from '@/util/string-formatters'
+
+/**
+ * The app declares `$filters` and `$colorset` by augmenting Vue from inside the
+ * plugins that install them, and those plugins pull in the router and the app
+ * entry - neither of which this project has any reason to compile. Store code
+ * reached by the specs still calls them, so they are declared here instead.
+ *
+ * Deliberately loose: `tsconfig.app.json` is what type-checks their real shapes.
+ * Only the formatters the specs actually exercise are typed precisely.
+ */
+type TestFilters =
+  ReturnType<typeof dateTimeFormatters> &
+  ReturnType<typeof stringFormatters> &
+  Record<string, any>
+
+declare module 'vue/types/vue' {
+  interface Vue {
+    $filters: TestFilters;
+    $colorset: any;
+  }
+
+  interface VueConstructor {
+    $filters: TestFilters;
+    $colorset: any;
+  }
+}

--- a/tsconfig.vitest.json
+++ b/tsconfig.vitest.json
@@ -1,19 +1,16 @@
 {
   "extends": "./tsconfig.app.json",
   "compilerOptions": {
-    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.vitest.tsbuildinfo",
-
-    "lib": [],
-    "types": [
-      "node",
-      "jsdom"
-    ]
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.vitest.tsbuildinfo"
   },
 
   "include": [
     "tests/**/*",
     "src/**/__tests__/*",
     "src/typings/*.d.ts",
+    // The app project picks the WebWorker lib up from `src/sw.ts`. Specs reach
+    // `src/workers/*` transitively, so this project needs it too.
+    "src/sw.ts",
     "env.d.ts",
   ],
 


### PR DESCRIPTION
Refs #998

The G-code file browser shows a `Status` and `Total Duration` per file, both resolved from the history job the file's metadata names. Only the newest `JOB_HISTORY_LOAD` (50) jobs are ever loaded, so a file whose last print is older than that page renders blank — indistinguishable from a file that has never been printed. Opening History → Load All fixes it until the next reconnect, which re-runs `history/init` and drops back to 50.

Raising the constant only moves the cliff. The browser needs the job behind each file's *last* print, and those are spread across the whole history rather than clustered at the recent end, which is the one thing a "newest N" page guarantees. On a printer with 127 jobs and 75 linked files, a page of 50 renders 33 and blanks 42; a page of 100 renders 73 and blanks 2; only "all" renders every one — and "all" is exactly what a default must not be.

So instead of widening the page, this resolves the misses individually. A directory load collects the job ids its files name, drops the ones already loaded, already resolved, already known missing, or already in flight, and fetches the rest through `server.history.get_job` — two requests in flight at a time, because Moonraker serializes every history endpoint behind one lock, so more concurrency buys no wall-clock and a wide pool would hold that lock against the History page. Results are committed once per drain and kept beside the loaded page rather than merged into it, so History keeps showing a contiguous page. The same trigger runs for a single file's metadata, because `files/getFile` is decorated the same way and has eight consumers.

Deleting a job leaves its `job_id` on the file — Moonraker's `delete_job` only touches `job_history` — so orphaned ids are easy to produce, and Fluidd's own Remove All produces them for every file at once. Those come back 404. Each one is recorded so it is asked for exactly once, and the 404 is suppressed rather than toasted, via a new per-request `suppressError` on `NotifyOptions`. It is opt-in per request: every other 4xx in the app keeps its toast, which is what the first test below guards. The negative cache is dropped on reconnect, since a 404 recorded against a previous connection is not evidence about this one, and cleared for an id when a job is added under it — Moonraker's job ids are a SQLite `INTEGER PRIMARY KEY` with no `AUTOINCREMENT`, so they are reused.

Two measurements, one printer each, both read from Moonraker's own API rather than off a rendered page. A stock Creality K1C with no local patches: 184 history jobs, 112 G-code files, 105 carrying a `job_id`, of which 64 fall outside the 50-row page. All 64 were probed with `server.history.get_job` and all 64 resolve — zero orphans — so every one is a completed print still in the database that the browser renders as blank. That is 61% of the files that have ever printed, or 57% of all G-code files. The 127-job figures above come from a second printer.

An alternative was considered and rejected on measurement: one `server.history.list` scoped by `since: min(print_start_time)` over the misses, which would have been a single round trip and no 404 path at all. Against the stock printer that query returns 183 of 184 rows — 99% of the history — because the oldest miss sits at the very start of it. It collapses into `limit: 0`.

While in `getHistoryById`, it now reads from an index rather than a linear scan. It is a method-style getter called once per file by `files/getDirectory`, which made decorating a directory O(files × jobs).

## Test plan

- [x] `pnpm run lint` clean
- [x] `pnpm run type-check` clean
- [x] `pnpm run test:unit` — 447 tests pass, including 47 new ones covering the cache, its invalidation, the bounded drain, the reconnect repair, and `files/getDirectory` returning a populated `history` for a file outside the loaded page
- [x] `pnpm run circular-check` clean
- [ ] Manual test pass (see checklist below) — **not performed**; no printer was available to the session that opened this PR

## Manual test pass

- [ ] On a printer with more than 50 history jobs, open Jobs. A file whose last print is older than the 50th-newest job shows a real Status (e.g. `Completed`) and a real Total Duration (e.g. `1h 12m`) without visiting History → Load All.
- [ ] History → Remove All, then open Jobs. Zero red toasts; every Status and Total Duration is blank.
- [ ] Delete one job in History whose file is visible in Jobs. That file's Status and Total Duration go blank immediately.
- [ ] Trigger any other Moonraker 4xx (e.g. delete a file that no longer exists). Its usual red toast still appears.
- [ ] Restart Moonraker while on Jobs. After the socket reconnects, the columns are still populated.

## Not addressed

- `getHistoryByFilename` has no consumers and carries the same window defect. Left alone to keep this single-concern.
- The History page's own paginator shows 15 per page over the loaded 50, so a 184-job history presents a four-page paginator that looks complete. Same root cause, worse symptom — filed separately as #1921.
- `state.count` is the number of rows returned, not the number of rows that exist, and is never decremented on delete. Nothing reads it today, and no "is everything loaded" signal can be built from it. Filed separately as #1920.
- Porting the history store to Pinia to match #1918. Not a contributor's call to make.
