### PR TITLE
ci: add dependabot for actions and docs dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,39 @@
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: friday
+    cooldown:
+      default-days: 7
+    groups:
+      github-actions:
+        patterns:
+          - '*'
+    commit-message:
+      prefix: chore
+      include: scope
+    labels:
+      - 'Code - Deps'
+      - 'Code - Infrastructure'
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: pip
+    directory: /docs
+    schedule:
+      interval: weekly
+      day: friday
+    cooldown:
+      default-days: 7
+    groups:
+      docs:
+        patterns:
+          - '*'
+    commit-message:
+      prefix: chore
+      include: scope
+    labels:
+      - 'Code - Deps'
+    open-pull-requests-limit: 5


### PR DESCRIPTION
Adds `.github/dependabot.yml` watching the **`github-actions`** and **`pip`** ecosystems.

## Why

Dependency maintenance is manual today, batched into periodic `chore: dependency updates` commits. The cost of that just surfaced: `actions/upload-pages-artifact` was pinned to `@v7`, a version that has never existed (latest is `v5.0.0`), and the docs workflow had been failing at "Set up job" since June — unnoticed, because `docs.yml` only triggers on `docs/**`. An actions watcher is precisely the mechanism that catches that class of drift.

## Configuration

- **Weekly, Fridays**, one grouped pull request per ecosystem — matching the existing habit of batching dependency updates rather than taking them one at a time.
- **`commit-message.prefix: chore` + `include: scope`** produces `chore(deps): ...` titles. These satisfy `semantic_pull_request.yml` on merit, rather than skipping validation via the `bot` entry in its `ignoreLabels`.
- **`cooldown: default-days: 7`** — above GitHub's 3-day default, and in the spirit of the existing `minimumReleaseAge: 1440` policy in `pnpm-workspace.yaml`. Security updates bypass cooldown regardless.
- **Existing `Code - Deps` label reused** rather than introducing a new `dependencies` one; `github-actions` updates also get `Code - Infrastructure`.
- **`target-branch` deliberately omitted** — `develop` is already the default branch, and specifying a non-default target changes how security updates behave.

## Why npm is excluded

Two independent blockers:

1. [dependabot/dependabot-core#14339](https://github.com/dependabot/dependabot-core/issues/14339) is open (filed March 2026): updating a pnpm catalog entry produces a `pnpm-lock.yaml` with catalog packages dropped, breaking `pnpm i --frozen-lockfile` — the first step of CI. It reproduces on lockfile v9.0 with current pnpm, which is exactly this repository's configuration, and there are five catalog entries.
2. Vue 2 being EOL and pinned would require a long ignore list — `vue`, `vuetify`, `vuex`, `vue-router`, `vue-i18n`, `vue-tsc`, `unplugin-vue-components` and more.

Worth revisiting once #14339 closes. Enabling **Dependabot alerts and security updates** in repository settings — both currently disabled — still covers npm vulnerabilities in the meantime, without opening version-bump pull requests.

`docker` is excluded too: the base images use floating `:alpine` tags, so there is nothing for Dependabot to bump until they are digest-pinned.

## Verification

The config parses and both labels already exist on the repository. A malformed config surfaces under Insights → Dependency graph → Dependabot rather than in CI, so that page is the place to confirm both ecosystems register after merge. First run should propose `mindsers/changelog-reader-action` v2.2.3 → v2.4.0.
