### PR TITLE
docs: add security policy

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,84 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please report security vulnerabilities through
+[GitHub's private vulnerability reporting](https://github.com/fluidd-core/fluidd/security/advisories/new).
+
+**Please do not report vulnerabilities through public issues, pull requests, or
+Discord.** Private reporting lets us assess and fix an issue before it becomes
+public knowledge.
+
+Helpful things to include:
+
+- The Fluidd version (shown in the bottom right corner, e.g. `v1.37.3-bc79728`)
+- Your browser and operating system
+- Your Moonraker version, if the issue involves communication with the printer
+- Steps to reproduce, ideally minimal
+- What an attacker could achieve — the impact matters more than the mechanism
+
+Fluidd is maintained by volunteers, so we do not commit to a response deadline.
+Reports are reviewed as maintainers are available.
+
+## Scope
+
+Fluidd is a browser application with no server side of its own. It is served as
+static files and talks to [Moonraker](https://github.com/Arksine/moonraker),
+which is where authentication, network exposure and printer access are actually
+enforced. That boundary determines what belongs here:
+
+| In scope                                                                       | Out of scope                                                                                                                                           |
+| ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Cross-site scripting via G-code, filenames, console output or macro parameters | Moonraker itself — report to [Arksine/moonraker](https://github.com/Arksine/moonraker/security)                                                        |
+| The sandboxed evaluation worker (`src/workers/sandboxedEval.worker.ts`)        | Klipper itself — report to [Klipper3d/klipper](https://github.com/Klipper3d/klipper/security)                                                          |
+| Sanitization bypasses in `v-safe-html` (`src/directives/safe-html.ts`)         | "Fluidd has no login" — authentication is Moonraker's `[authorization]`, see the [Authorization docs](https://docs.fluidd.xyz/features/authorization/) |
+| Token handling — JWT storage and refresh, oneshot tokens                       | A printer deliberately exposed to the internet without a reverse proxy or VPN                                                                          |
+| The published container images under `ghcr.io/fluidd-core`                     | Dependency scanner output with no demonstrated exploit path in Fluidd                                                                                  |
+| The hosted instance at [app.fluidd.xyz](https://app.fluidd.xyz)                |                                                                                                                                                        |
+
+If you are unsure which side of that line a finding falls on, report it anyway
+and we will redirect it.
+
+## Dependencies and Vue 2
+
+Fluidd is built on Vue 2, which reached end of life in December 2023. This is a
+known and deliberately managed constraint: the Vue 2 packages are pinned, and
+the project accepts responsibility for assessing their risk rather than
+inheriting fixes from upstream.
+
+We will assess any reported vulnerability in a dependency for whether it is
+exploitable **in the way Fluidd actually uses that dependency**. A match in an
+advisory database, or a scanner report listing an affected package version, is
+not on its own a vulnerability report — please include the path by which it can
+be reached through Fluidd.
+
+## Supported versions
+
+Only the most recent release receives security fixes. There are no maintained
+release branches, so fixes ship in the next release rather than being backported.
+
+## Coordinated disclosure
+
+We will work with you through the private advisory: confirming the issue,
+preparing a fix, and publishing an advisory when the fix is released. Reporters
+are credited in the published advisory unless they would rather not be. We will
+not ask you to delay disclosure indefinitely, and we ask that you give us a
+reasonable opportunity to ship a fix first.
+
+## Verifying release artifacts
+
+Fluidd's release artifacts carry signed build provenance, so you can confirm a
+download was built by this repository's CI and not modified afterwards. This
+requires the [GitHub CLI](https://cli.github.com/).
+
+For a container image:
+
+```bash
+gh attestation verify oci://ghcr.io/fluidd-core/fluidd:latest-master -R fluidd-core/fluidd
+```
+
+For a release archive — attested for releases published after `v1.37.3`:
+
+```bash
+gh attestation verify fluidd.zip -R fluidd-core/fluidd
+```

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -22,10 +22,11 @@ Reports are reviewed as maintainers are available.
 
 ## Scope
 
-Fluidd is a browser application with no server side of its own. It is served as
-static files and talks to [Moonraker](https://github.com/Arksine/moonraker),
-which is where authentication, network exposure and printer access are actually
-enforced. That boundary determines what belongs here:
+Fluidd is a browser application with no server-side component of its own. It is
+served as static files and talks to
+[Moonraker](https://github.com/Arksine/moonraker), which is where
+authentication, network exposure and printer access are actually enforced. That
+boundary determines what belongs here:
 
 | In scope                                                                       | Out of scope                                                                                                                                           |
 | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------ |

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ Fluidd is a free and open-source Klipper web interface for managing your 3d prin
 See our [Docs](https://docs.fluidd.xyz).
 Join our [Discord!](https://discord.gg/GZ3D5tqfcF).
 
+Want to help out? Read the [contributing guidelines](/CONTRIBUTING.md) and our [code of conduct](/.github/CODE_OF_CONDUCT.md).
+
+Found a security issue? Please follow our [security policy](/.github/SECURITY.md).
+
 ## How to use?
 
 Fluidd can be easily installed via [KIAUH](https://github.com/dw-0/kiauh), along with Klipper, Moonraker, and all of the required dependencies.


### PR DESCRIPTION
Adds `.github/SECURITY.md`. The repository had no security policy, which is why GitHub scored its community profile at 75% — and, more practically, meant the only way to report a vulnerability was a public issue or Discord.

**Private vulnerability reporting is now enabled on the repository**, so the advisory link in the policy resolves to a working form, and a "Report a vulnerability" button appears on the Security tab.

## What the policy says

**Reporting** — private vulnerability reporting is the single channel. No security email and no PGP key, so there is nothing extra to own or keep alive. No response deadline is promised: the project is maintained by volunteers, and a missed commitment reads worse than never making one.

**Scope** — this section does most of the work. Fluidd is a browser application with no server side; authentication, network exposure and printer access are all enforced by Moonraker. Most inbound reports will be Moonraker configuration or exposure issues, so the policy says where those belong rather than absorbing them:

- *In scope* — XSS via G-code, filenames, console output or macro parameters; `sandboxedEval.worker.ts`; `v-safe-html` sanitization bypasses; JWT and oneshot token handling; the GHCR images; `app.fluidd.xyz`.
- *Out of scope* — Moonraker and Klipper themselves; "Fluidd has no login"; printers deliberately exposed to the internet; scanner output with no demonstrated exploit path.

**Vue 2** — addressed directly rather than left to recur. The packages are pinned as a known managed constraint, reported CVEs are assessed for exploitability in Fluidd's actual usage, and an advisory database match is not by itself a report.

**Supported versions** — latest release only. No matrix, because there are no maintained release branches and a table promising backports would be fiction.

**Artifact verification** — documents `gh attestation verify` for both the container images and the release archive.

## README

Links the security policy, the contributing guidelines and the code of conduct from the Support section. The README previously pointed at none of the three, so all of them were findable only by browsing the repository.

## Verification

`markdownlint` and `codespell` both clean on the new file. All six external links return 200, including the advisory form. The container-image `gh attestation verify` command was run against `ghcr.io/fluidd-core/fluidd:latest-master` and succeeds.

One caveat recorded in the file itself: release archives are attested only from the release *after* `v1.37.3`, since that work is still in #1923. Verified — `gh attestation verify fluidd.zip` currently returns 404 against v1.37.3. The caveat should be dropped once a release ships with the attestation in place.

## Note

`README.md` has two pre-existing `markdownlint` MD059 warnings (`[here]` link text) that are unrelated to this change and left alone — they fail identically on an untouched `develop`, and no CI job lints the README.
