### PR TITLE
fix(Spoolman): use case-insensitive regex

### DIFF
--- a/src/components/widgets/spoolman/QRReader.vue
+++ b/src/components/widgets/spoolman/QRReader.vue
@@ -32,8 +32,8 @@ import type { Spool } from '@/store/spoolman/types'
 import BrowserMixin from '@/mixins/browser'
 
 const spoomanDataPatterns = [
-  /web\+spoolman:s-(\d+)/,
-  /\/spool\/show\/(\d+)\/?/
+  /web\+spoolman:s-(\d+)/i,
+  /\/spool\/show\/(\d+)\/?/i
 ]
 
 @Component({


### PR DESCRIPTION
Ignore case when reading Spoolman QR codes.

Fixes #1930 