### PR TITLE
refactor: dialogs visibility logic and state

### DIFF
--- a/src/components/settings/macros/MacroCategoryDialog.vue
+++ b/src/components/settings/macros/MacroCategoryDialog.vue
@@ -43,7 +43,15 @@ export default class MacroCategoryDialog extends Vue {
 
   get customRules () {
     return {
-      uniqueName: (v: string) => this.categories.findIndex(c => c.name.toLowerCase() === v.toLowerCase()) < 0 || this.$t('app.general.simple_form.error.exists')
+      uniqueName: (v: string) => {
+        return (
+          (
+            v.toLowerCase() === this.name.toLowerCase() ||
+            !this.categories.some(c => c.name.toLowerCase() === v.toLowerCase())
+          ) ||
+          this.$t('app.general.simple_form.error.exists')
+        )
+      }
     }
   }
 

--- a/src/components/widgets/beacon/BeaconCard.vue
+++ b/src/components/widgets/beacon/BeaconCard.vue
@@ -124,7 +124,6 @@
     </v-card-text>
 
     <save-model-dialog
-      v-if="saveDialogState.open"
       v-model="saveDialogState.open"
       :existing-name="saveDialogState.existingName"
       @save="handleModelSave"

--- a/src/components/widgets/beacon/SaveModelDialog.vue
+++ b/src/components/widgets/beacon/SaveModelDialog.vue
@@ -35,7 +35,7 @@
 </template>
 
 <script lang="ts">
-import { Component, Mixins, Prop, VModel } from 'vue-property-decorator'
+import { Component, Mixins, Prop, VModel, Watch } from 'vue-property-decorator'
 import StateMixin from '@/mixins/state'
 import ToolheadMixin from '@/mixins/toolhead'
 
@@ -47,13 +47,16 @@ export default class SaveModelDialog extends Mixins(StateMixin, ToolheadMixin) {
   @Prop({ type: String })
   readonly existingName!: string
 
-  mounted () {
-    this.name = 'default'
-    this.removeDefault = false
-  }
-
   name = 'default'
   removeDefault = false
+
+  @Watch('open')
+  onOpenChanged (value: boolean) {
+    if (value) {
+      this.name = 'default'
+      this.removeDefault = false
+    }
+  }
 
   handleSubmit () {
     this.$emit('save', { name: this.name, removeDefault: this.removeDefault })

--- a/src/components/widgets/bedmesh/BedMeshControls.vue
+++ b/src/components/widgets/bedmesh/BedMeshControls.vue
@@ -258,7 +258,6 @@
     </v-card-text>
 
     <save-mesh-dialog
-      v-if="saveDialogState.open"
       v-model="saveDialogState.open"
       :existing-name="saveDialogState.existingName"
       :adaptive="saveDialogState.adaptive"

--- a/src/components/widgets/bedmesh/SaveMeshDialog.vue
+++ b/src/components/widgets/bedmesh/SaveMeshDialog.vue
@@ -37,7 +37,7 @@
 </template>
 
 <script lang="ts">
-import { Component, Mixins, Prop, VModel } from 'vue-property-decorator'
+import { Component, Mixins, Prop, VModel, Watch } from 'vue-property-decorator'
 import StateMixin from '@/mixins/state'
 import ToolheadMixin from '@/mixins/toolhead'
 
@@ -52,13 +52,16 @@ export default class SaveMeshDialog extends Mixins(StateMixin, ToolheadMixin) {
   @Prop({ type: Boolean })
   readonly adaptive!: boolean
 
-  mounted () {
-    this.name = 'default'
-    this.removeDefault = false
-  }
-
   name = 'default'
   removeDefault = false
+
+  @Watch('open')
+  onOpenChanged (value: boolean) {
+    if (value) {
+      this.name = 'default'
+      this.removeDefault = false
+    }
+  }
 
   handleSubmit () {
     this.$emit('save', { name: this.name, removeDefault: this.removeDefault })

--- a/src/components/widgets/filesystem/FileEditorDialog.vue
+++ b/src/components/widgets/filesystem/FileEditorDialog.vue
@@ -146,7 +146,7 @@
       </v-toolbar>
 
       <file-editor
-        v-if="contents !== undefined && !useTextOnlyEditor"
+        v-if="open && !useTextOnlyEditor"
         ref="editor"
         v-model="updatedContent"
         :path="path"
@@ -162,7 +162,7 @@
       />
 
       <file-editor-text-only
-        v-if="contents !== undefined && useTextOnlyEditor"
+        v-if="open && useTextOnlyEditor"
         v-model="updatedContent"
         :filename="filename"
         :readonly="readonly"
@@ -271,9 +271,18 @@ export default class FileEditorDialog extends Mixins(StateMixin, BrowserMixin) {
     return this.$typedState.config.uiSettings.editor.codeLens
   }
 
-  created () {
-    this.updatedContent = this.contents
-    this.lastSavedContent = this.contents
+  @Watch('open')
+  onOpenChanged (value: boolean) {
+    if (value) {
+      this.updatedContent = this.contents
+      this.lastSavedContent = this.contents
+    } else {
+      this.updatedContent = null
+      this.lastSavedContent = null
+      this.peripheralsDialogOpen = false
+    }
+
+    this.editorReady = false
   }
 
   mounted () {

--- a/src/components/widgets/filesystem/FileEditorDialog.vue
+++ b/src/components/widgets/filesystem/FileEditorDialog.vue
@@ -276,17 +276,17 @@ export default class FileEditorDialog extends Mixins(StateMixin, BrowserMixin) {
     if (value) {
       this.updatedContent = this.contents
       this.lastSavedContent = this.contents
+
+      window.addEventListener('beforeunload', this.handleBeforeUnload)
     } else {
       this.updatedContent = null
       this.lastSavedContent = null
       this.peripheralsDialogOpen = false
+
+      window.removeEventListener('beforeunload', this.handleBeforeUnload)
     }
 
     this.editorReady = false
-  }
-
-  mounted () {
-    window.addEventListener('beforeunload', this.handleBeforeUnload)
   }
 
   beforeDestroy () {

--- a/src/components/widgets/filesystem/FileNameDialog.vue
+++ b/src/components/widgets/filesystem/FileNameDialog.vue
@@ -23,7 +23,7 @@
 </template>
 
 <script lang="ts">
-import { Component, Mixins, Prop, VModel } from 'vue-property-decorator'
+import { Component, Mixins, Prop, VModel, Watch } from 'vue-property-decorator'
 import StateMixin from '@/mixins/state'
 
 @Component({})
@@ -45,8 +45,11 @@ export default class FileNameDialog extends Mixins(StateMixin) {
 
   newName = ''
 
-  mounted () {
-    this.newName = this.name
+  @Watch('open')
+  onOpenChanged (value: boolean) {
+    if (value) {
+      this.newName = this.name
+    }
   }
 
   handleFocus (event: FocusEvent) {

--- a/src/components/widgets/filesystem/FilePreviewDialog.vue
+++ b/src/components/widgets/filesystem/FilePreviewDialog.vue
@@ -104,6 +104,8 @@ export default class FilePreviewDialog extends Mixins(StateMixin) {
 
   renderedMarkdown: string | null = null
 
+  abortController: AbortController | null = null
+
   get calculatedWidth () {
     const defaultWidth = window.innerWidth * (this.$vuetify.breakpoint.mdAndDown ? 1 : 0.75)
     return Math.min(window.innerWidth * 0.9, Math.max(this.width ?? defaultWidth, defaultWidth / 2))
@@ -125,7 +127,7 @@ export default class FilePreviewDialog extends Mixins(StateMixin) {
     return this.$typedState.config.apiUrl
   }
 
-  async LoadMarkdown () {
+  async LoadMarkdown (signal: AbortSignal) {
     if (!this.path) {
       // refuse rendering markdown if no base path has been supplied
       consola.error('[FilePreviewDialog] missing path property in markdown viewer')
@@ -133,35 +135,50 @@ export default class FilePreviewDialog extends Mixins(StateMixin) {
       return
     }
 
-    const response = await fetch(this.src)
-    const data = await response.text()
+    try {
+      const response = await fetch(this.src, { signal })
+      const data = await response.text()
 
-    const apiFileUrl = `${this.apiUrl}/server/files/${this.path}/`
+      const apiFileUrl = `${this.apiUrl}/server/files/${this.path}/`
 
-    const baseUrlExtension = baseUrl(apiFileUrl)
+      const baseUrlExtension = baseUrl(apiFileUrl)
 
-    const customExtension: MarkedExtension = {
-      renderer: {
-        link (args: Tokens.Link) {
-          const html = this.constructor.prototype.link.call(this, args)
+      const customExtension: MarkedExtension = {
+        renderer: {
+          link (args: Tokens.Link) {
+            const html = this.constructor.prototype.link.call(this, args)
 
-          return html.replace(/^<a /, '<a target="_blank" rel="noopener noreferrer" ')
+            return html.replace(/^<a /, '<a target="_blank" rel="noopener noreferrer" ')
+          }
         }
       }
+
+      const marked = new Marked(baseUrlExtension, customExtension)
+
+      const renderedMarkdown = await marked.parse(data, {
+        async: true
+      })
+
+      if (!signal.aborted) {
+        this.renderedMarkdown = renderedMarkdown
+      }
+    } catch (error: unknown) {
+      if (!signal.aborted) {
+        consola.error('[FilePreviewDialog] load markdown', error)
+      }
     }
-
-    const marked = new Marked(baseUrlExtension, customExtension)
-
-    this.renderedMarkdown = await marked.parse(data, {
-      async: true
-    })
   }
 
   @Watch('open')
   onOpenChanged (value: boolean) {
     if (value && this.isMarkdown) {
-      this.LoadMarkdown()
+      const controller = this.abortController = new AbortController()
+
+      this.LoadMarkdown(controller.signal)
     } else {
+      this.abortController?.abort()
+      this.abortController = null
+
       this.renderedMarkdown = null
     }
   }

--- a/src/components/widgets/filesystem/FilePreviewDialog.vue
+++ b/src/components/widgets/filesystem/FilePreviewDialog.vue
@@ -66,7 +66,7 @@
 </template>
 
 <script lang="ts">
-import { Component, Prop, Mixins, VModel } from 'vue-property-decorator'
+import { Component, Prop, Mixins, VModel, Watch } from 'vue-property-decorator'
 import StateMixin from '@/mixins/state'
 import type { AppFile } from '@/store/files/types'
 import { Marked, type MarkedExtension, type Tokens } from 'marked'
@@ -157,9 +157,12 @@ export default class FilePreviewDialog extends Mixins(StateMixin) {
     })
   }
 
-  mounted () {
-    if (this.isMarkdown) {
+  @Watch('open')
+  onOpenChanged (value: boolean) {
+    if (value && this.isMarkdown) {
       this.LoadMarkdown()
+    } else {
+      this.renderedMarkdown = null
     }
   }
 }

--- a/src/components/widgets/filesystem/FilePreviewDialog.vue
+++ b/src/components/widgets/filesystem/FilePreviewDialog.vue
@@ -182,6 +182,10 @@ export default class FilePreviewDialog extends Mixins(StateMixin) {
       this.renderedMarkdown = null
     }
   }
+
+  beforeDestroy () {
+    this.abortController?.abort()
+  }
 }
 </script>
 

--- a/src/components/widgets/filesystem/FileSystem.vue
+++ b/src/components/widgets/filesystem/FileSystem.vue
@@ -83,7 +83,6 @@
     />
 
     <file-editor-dialog
-      v-if="fileEditorDialogState.open"
       v-model="fileEditorDialogState.open"
       :contents="fileEditorDialogState.contents"
       :filename="fileEditorDialogState.filename"
@@ -98,7 +97,6 @@
     <!-- A generic dialog to define the name of a file, or folder.
          Used to create, or rename a file or folder. -->
     <file-name-dialog
-      v-if="fileNameDialogState.open"
       v-model="fileNameDialogState.open"
       :name="fileNameDialogState.value"
       :title="fileNameDialogState.title"
@@ -115,7 +113,6 @@
     />
 
     <file-preview-dialog
-      v-if="filePreviewState.open"
       v-model="filePreviewState.open"
       :file="filePreviewState.file"
       :filename="filePreviewState.filename"
@@ -130,7 +127,6 @@
     />
 
     <file-system-go-to-file-dialog
-      v-if="goToFileDialogOpen"
       v-model="goToFileDialogOpen"
       :root="currentRoot"
       @path-change="loadFiles"

--- a/src/components/widgets/filesystem/FileSystemGoToFileDialog.vue
+++ b/src/components/widgets/filesystem/FileSystemGoToFileDialog.vue
@@ -110,9 +110,14 @@ export default class FileSystemGoToFileDialog extends Mixins(StateMixin) {
     this.open = false
   }
 
-  mounted () {
-    this.loaded = false
-    SocketActions.serverFilesList(this.root)
+  @Watch('open')
+  onOpenChanged (value: boolean) {
+    if (value) {
+      this.search = ''
+      this.loaded = false
+
+      SocketActions.serverFilesList(this.root)
+    }
   }
 }
 </script>

--- a/src/components/widgets/status/StatusTab.vue
+++ b/src/components/widgets/status/StatusTab.vue
@@ -225,7 +225,6 @@
     </v-card-text>
 
     <file-preview-dialog
-      v-if="filePreviewState.open"
       v-model="filePreviewState.open"
       :filename="filePreviewState.filename"
       :src="filePreviewState.src"


### PR DESCRIPTION
Removes the `v-if` on some dialogs so they stay mounted instead of being recreated on every open.

Per-open initialization that used to live in `mounted()`/`created()` now runs from `@Watch('open')` handlers, since the components no longer remount each time; the inner Monaco editor still keeps its own `v-if` so it's created and disposed per open as before.