### PR TITLE
fix: use debian base image for dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,17 +1,20 @@
-FROM node:24-alpine
+# NOTE: must stay on a glibc base. typescript-native-bridge (the `typescript`
+# catalog entry) ships a Go c-shared NAPI bridge with no musl build — on Alpine
+# it fails to load, and segfaults even with `gcompat`. See issue #1938.
+FROM node:24-trixie-slim
 
 RUN \
-  apk update \
-  && apk add \
+  apt-get update \
+  && apt-get install -y --no-install-recommends \
+    ca-certificates \
     git \
-    git-zsh-completion \
+    wget \
     zsh \
-    zsh-completions \
-  && sed -i '/^node:/s|/bin/ash|/bin/zsh|' /etc/passwd \
+  && usermod --shell /bin/zsh node \
   && corepack enable \
   && mkdir -p /workspaces/fluidd/node_modules /workspaces/fluidd/.pnpm-store \
   && chown -R node:node /workspaces/fluidd \
-  && rm -f /etc/apk/cache/* /root/.cache
+  && rm -rf /var/lib/apt/lists/*
 
 USER node
 WORKDIR /workspaces/fluidd

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
-// README at: https://github.com/devcontainers/templates/tree/main/src/alpine
+// README at: https://github.com/devcontainers/templates/tree/main/src/debian
 {
   "name": "Fluidd Dev",
   "dockerComposeFile": "docker-compose.yml",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -273,6 +273,7 @@ src/
 ## Dev Container
 
 - VSCode Dev Container (`.devcontainer/`) bundles a `docker-klipper-simulavr` container — real Klipper/Moonraker simulation on port 7125, Fluidd on port 8080
+- Base image **must stay glibc** (`node:24-trixie-slim`) — `typescript-native-bridge` ships a Go `c-shared` NAPI bridge with glibc-only native packages (no `-musl` build), so on Alpine it fails to load and segfaults even with `gcompat`
 - `postCreateCommand` runs `pnpm i --frozen-lockfile` automatically (which in turn runs `prepare`)
 
 ## Documentation Site


### PR DESCRIPTION
Changing devcontainer base image from Alpine to Debian as typeScript-native-bridge does not work with Alpine/musl.

Fixes #1938 