### PR TITLE
fix: resolve jobs outside the loaded history

### DIFF
--- a/src/api/socketActions.ts
+++ b/src/api/socketActions.ts
@@ -587,6 +587,18 @@ export const SocketActions = {
     )
   },
 
+  serverHistoryGetJob (uid: string, options?: NotifyOptions) {
+    return baseEmit<Moonraker.History.JobResponse>(
+      'server.history.get_job', {
+        dispatch: 'history/onHistoryJob',
+        ...options,
+        params: {
+          uid
+        }
+      }
+    )
+  },
+
   serverHistoryList (params?: { start?: number; limit?: number; before?: number; since?: number; order?: string }, options?: NotifyOptions) {
     return baseEmit<Moonraker.History.ListResponse>(
       'server.history.list', {

--- a/src/plugins/socketClient.ts
+++ b/src/plugins/socketClient.ts
@@ -96,7 +96,10 @@ export class WebSocketClient {
 
             consola.debug(`${LOG_PREFIX} Response error:`, socketResponse.error)
 
-            if (request?.suppressError !== true) {
+            if (
+              request?.suppressError !== true ||
+              socketResponse.error.code >= 500
+            ) {
               this.store.typedDispatch('socket/onSocketError', socketResponse.error)
             }
 

--- a/src/plugins/socketClient.ts
+++ b/src/plugins/socketClient.ts
@@ -96,7 +96,9 @@ export class WebSocketClient {
 
             consola.debug(`${LOG_PREFIX} Response error:`, socketResponse.error)
 
-            this.store.typedDispatch('socket/onSocketError', socketResponse.error)
+            if (request?.suppressError !== true) {
+              this.store.typedDispatch('socket/onSocketError', socketResponse.error)
+            }
 
             return
           }
@@ -208,7 +210,7 @@ export class WebSocketClient {
   emit (method: string, options: NotifyOptions = {}) {
     return new Promise((resolve, reject) => {
       try {
-        const { wait, params, dispatch, commit } = options
+        const { wait, params, dispatch, commit, suppressError } = options
 
         // Any non-'disconnected' state is eligible to emit; physical readiness
         // is enforced by the readyState check below.
@@ -239,6 +241,7 @@ export class WebSocketClient {
             commit,
             params,
             wait,
+            suppressError,
             onFulfilled: resolve,
             onRejected: reject
           }
@@ -304,6 +307,7 @@ export interface NotifyOptions {
   dispatch?: string;
   commit?: string;
   wait?: string;
+  suppressError?: boolean;
 }
 
 interface Request {
@@ -312,6 +316,7 @@ interface Request {
   commit?: string;
   params?: Record<string, any>;
   wait?: string;
+  suppressError?: boolean;
   onFulfilled: (value: unknown) => void;
   onRejected: (reason?: unknown) => void;
 }

--- a/src/store/files/actions.ts
+++ b/src/store/files/actions.ts
@@ -28,7 +28,7 @@ export const actions = {
     commit('setReset')
   },
 
-  async onServerFilesGetDirectory ({ commit }, payload: ObjectWithRequest<Moonraker.Files.GetDirectoryResponse>) {
+  async onServerFilesGetDirectory ({ commit, dispatch }, payload: ObjectWithRequest<Moonraker.Files.GetDirectoryResponse>) {
     const { disk_usage, files, dirs } = payload
     const { path } = payload.__request__.params ?? {}
     const [root] = path.split('/', 1)
@@ -42,6 +42,18 @@ export const actions = {
 
     commit('setDiskUsage', { root, disk_usage })
     commit('setServerFilesGetDirectory', { path, content: { files, dirs: filteredDirs } })
+
+    if (root === 'gcodes') {
+      const jobIds = files
+        .map(file => (
+          'job_id' in file
+            ? file.job_id
+            : null
+        ))
+        .filter(Boolean)
+
+      dispatch('history/fetchMissingJobs', jobIds, { root: true })
+    }
   },
 
   async onServerFilesRoots ({ commit }, payload: Moonraker.Files.RootsResponse) {
@@ -57,7 +69,7 @@ export const actions = {
   /**
    * If we request the metadata (a file..) then we load and update here.
    */
-  async onFileMetaData ({ commit }, payload: Moonraker.Files.FileWithMetaResponse) {
+  async onFileMetaData ({ commit, dispatch }, payload: Moonraker.Files.FileWithMetaResponse) {
     const paths = getFilePaths(payload.filename, 'gcodes')
 
     if (!paths.filtered) {
@@ -68,6 +80,10 @@ export const actions = {
       }
 
       commit('setFileUpdate', { paths, file })
+
+      if (file.job_id) {
+        dispatch('history/fetchMissingJobs', [file.job_id], { root: true })
+      }
     }
   },
 

--- a/src/store/history/actions.ts
+++ b/src/store/history/actions.ts
@@ -5,6 +5,13 @@ import { SocketActions } from '@/api/socketActions'
 import { Globals } from '@/globals'
 import getFilePaths from '@/util/get-file-paths'
 
+const isJobNotFoundError = (error: unknown): boolean => (
+  error != null &&
+  typeof error === 'object' &&
+  'code' in error &&
+  error.code === 404
+)
+
 export const actions = {
   /**
    * Reset our store
@@ -46,14 +53,23 @@ export const actions = {
 
     commit('setAddUnresolvedJobIds', jobIds)
 
-    for (const jobId of jobIds) {
-      SocketActions.serverHistoryGetJob(
-        jobId,
-        {
-          suppressError: true
-        }
-      ).catch(() => {})
-    }
+    await Promise.all(
+      jobIds
+        .map(async jobId => {
+          try {
+            await SocketActions.serverHistoryGetJob(
+              jobId,
+              {
+                suppressError: true
+              }
+            )
+          } catch (error) {
+            if (!isJobNotFoundError(error)) {
+              commit('setRemoveUnresolvedJobIds', [jobId])
+            }
+          }
+        })
+    )
   },
 
   async clearHistoryThumbnails ({ commit }, payload: string) {

--- a/src/store/history/actions.ts
+++ b/src/store/history/actions.ts
@@ -24,9 +24,35 @@ export const actions = {
     SocketActions.serverHistoryTotals()
   },
 
-  async updateHistory ({ commit }, payload: Moonraker.History.Job) {
-    if (payload) {
-      commit('setUpdateHistory', payload)
+  async fetchMissingJobs ({ commit, state, rootGetters }, payload: string[]) {
+    if (!rootGetters['server/componentSupport']('history')) {
+      return
+    }
+
+    const loadedJobIds = new Set(
+      state.jobs
+        .map(job => job.job_id)
+    )
+
+    const jobIds = [...new Set(payload)]
+      .filter(jobId => (
+        !loadedJobIds.has(jobId) &&
+        !state.unresolvedJobIds.has(jobId)
+      ))
+
+    if (jobIds.length === 0) {
+      return
+    }
+
+    commit('setAddUnresolvedJobIds', jobIds)
+
+    for (const jobId of jobIds) {
+      SocketActions.serverHistoryGetJob(
+        jobId,
+        {
+          suppressError: true
+        }
+      )
     }
   },
 
@@ -46,11 +72,33 @@ export const actions = {
   },
 
   /**
+   * Update a job in the store
+   */
+  async onHistoryJob ({ commit }, payload: Moonraker.History.JobResponse) {
+    if (payload.job) {
+      commit('setUpdateHistory', payload.job)
+    }
+  },
+
+  /**
    * Update the store with history
    */
-  async onHistoryList ({ commit }, payload: Moonraker.History.ListResponse) {
+  async onHistoryList ({ commit, dispatch, rootState }, payload: Moonraker.History.ListResponse) {
     if (payload) {
       commit('setHistoryList', payload)
+
+      commit('setClearUnresolvedJobIds')
+
+      const jobIds = Object.values(rootState.files.pathContent)
+        .flatMap(pathContent => pathContent?.files ?? [])
+        .map(file => (
+          'job_id' in file
+            ? file.job_id
+            : null
+        ))
+        .filter(Boolean)
+
+      await dispatch('fetchMissingJobs', jobIds)
     }
   },
 
@@ -63,7 +111,7 @@ export const actions = {
     if (payload) {
       switch (payload.action) {
         case 'added': {
-          commit('setAddHistory', payload.job)
+          commit('setUpdateHistory', payload.job)
 
           const { rootPath, filename } = getFilePaths(payload.job.filename, 'gcodes')
 
@@ -85,6 +133,6 @@ export const actions = {
   },
 
   async onDelete ({ commit }, payload: Moonraker.History.DeleteJobResponse) {
-    commit('setDeleteJob', payload.deleted_jobs)
+    commit('setDeleteJobs', payload.deleted_jobs)
   }
 } satisfies ActionTree<HistoryState, RootState>

--- a/src/store/history/actions.ts
+++ b/src/store/history/actions.ts
@@ -52,7 +52,7 @@ export const actions = {
         {
           suppressError: true
         }
-      )
+      ).catch(() => {})
     }
   },
 

--- a/src/store/history/mutations.ts
+++ b/src/store/history/mutations.ts
@@ -83,6 +83,12 @@ export const mutations = {
     }
   },
 
+  setRemoveUnresolvedJobIds (state, payload: string[]) {
+    for (const jobId of payload) {
+      state.unresolvedJobIds.delete(jobId)
+    }
+  },
+
   setClearUnresolvedJobIds (state) {
     state.unresolvedJobIds.clear()
   }

--- a/src/store/history/mutations.ts
+++ b/src/store/history/mutations.ts
@@ -26,19 +26,6 @@ export const mutations = {
       state.jobs = payload.jobs
         .map(job => Object.freeze(job))
     }
-    if (payload.count != null) {
-      state.count = payload.count
-    }
-  },
-
-  /**
-   * Adds a history item.
-   */
-  setAddHistory (state, payload: Moonraker.History.Job) {
-    if (payload) {
-      state.jobs.push(Object.freeze(payload))
-      state.count++
-    }
   },
 
   /**
@@ -47,17 +34,24 @@ export const mutations = {
   setUpdateHistory (state, payload: Moonraker.History.Job) {
     if (payload) {
       const i = state.jobs.findIndex(job => job.job_id === payload.job_id)
+
       if (i >= 0) {
         Vue.set(state.jobs, i, Object.freeze(payload))
+      } else {
+        state.jobs.push(Object.freeze(payload))
       }
+
+      state.unresolvedJobIds.delete(payload.job_id)
     }
   },
 
   setClearHistoryThumbnails (state, payload: string) {
     if (payload) {
       const i = state.jobs.findIndex(job => job.job_id === payload)
+
       if (i >= 0) {
         const job = state.jobs[i]
+
         Vue.set(state.jobs, i, Object.freeze({
           ...job,
           metadata: {
@@ -69,12 +63,27 @@ export const mutations = {
     }
   },
 
-  setDeleteJob (state, payload: string[]) {
+  setDeleteJobs (state, payload: string[]) {
     if (payload) {
-      payload.forEach((job_id) => {
-        const i = state.jobs.findIndex(job => job.job_id === job_id)
-        if (i >= 0) state.jobs.splice(i, 1)
-      })
+      for (const jobId of payload) {
+        const i = state.jobs.findIndex(job => job.job_id === jobId)
+
+        if (i >= 0) {
+          state.jobs.splice(i, 1)
+        }
+
+        state.unresolvedJobIds.add(jobId)
+      }
     }
+  },
+
+  setAddUnresolvedJobIds (state, payload: string[]) {
+    for (const jobId of payload) {
+      state.unresolvedJobIds.add(jobId)
+    }
+  },
+
+  setClearUnresolvedJobIds (state) {
+    state.unresolvedJobIds.clear()
   }
 } satisfies MutationTree<HistoryState>

--- a/src/store/history/state.ts
+++ b/src/store/history/state.ts
@@ -2,8 +2,8 @@ import type { HistoryState } from './types'
 
 export const defaultState = (): HistoryState => {
   return {
-    count: 0,
     jobs: [],
+    unresolvedJobIds: new Set(),
     job_totals: {
       total_jobs: 0,
       total_time: 0,

--- a/src/store/history/types.ts
+++ b/src/store/history/types.ts
@@ -1,9 +1,9 @@
 import type { AppFileMeta } from '@/store/files/types.metadata'
 
 export interface HistoryState {
-  count: number;
   jobs: Readonly<Moonraker.History.Job>[];
   job_totals: Moonraker.History.JobTotals;
+  unresolvedJobIds: Set<string>;
 }
 
 export interface HistoryItem extends Omit<Moonraker.History.Job, 'metadata'> {

--- a/src/typings/moonraker.history.d.ts
+++ b/src/typings/moonraker.history.d.ts
@@ -9,6 +9,10 @@ declare namespace Moonraker.History {
     jobs: Job[];
   }
 
+  export interface JobResponse {
+    job: Job;
+  }
+
   export interface DeleteJobResponse {
     deleted_jobs: string[];
   }


### PR DESCRIPTION
The G-code file browser shows a `Status` and `Total Duration` per file, both resolved from the history job the file's metadata names. Only the newest `JOB_HISTORY_LOAD` (50) jobs are ever loaded, so a file whose last print is older than that page renders blank — indistinguishable from a file that has never been printed. Opening History → Load All fixes it until the next reconnect, which re-runs `history/init` and drops back to 50.

Raising the constant only moves the cliff. The browser needs the job behind each file's *last* print, and those are spread across the whole history rather than clustered at the recent end — which is the one thing a "newest N" page guarantees. So this resolves the misses individually instead.

## How

A `gcodes` directory load, or a single file's metadata load, hands its job ids to `history/fetchMissingJobs`. Ids already in `state.jobs` or already asked for are dropped; the rest are recorded in `state.unresolvedJobIds` **before** the requests go out, so a repeat directory load asks for nothing. Each request goes through `server.history.get_job`, which carries `dispatch: 'history/onHistoryJob'` — responses land through the normal socket dispatch chain like every other call in `socketActions.ts` — and `setUpdateHistory` upserts the job and clears its entry. What is left in `unresolvedJobIds` once the responses land is exactly the ids Moonraker has no row for, so the 404 needs no handler of its own.

Those orphans are guaranteed, not hypothetical: Moonraker's `delete_job` only runs `DELETE FROM job_history` and never clears the `job_id` from the file metadata, so Fluidd's own **Remove All** leaves one behind for every file that has ever printed. A directory of them would otherwise be a red toast per file, hence the new per-request `suppressError` on `NotifyOptions`. It is opt-in per request — every other 4xx in the app keeps its toast.

`setHistoryList` replaces the loaded page wholesale, so `onHistoryList` clears the unresolved set and re-scans the loaded directories afterwards. `files` is not in `MODULES_TO_RESET_ON_DROP`, so nothing else reloads what is on screen after a reconnect.

One smaller thing falls out of the same code: `state.count` is removed. It held rows-returned rather than rows-that-exist, was never decremented on delete, and nothing read it. No reliable total is available to replace it either — `job_totals.total_jobs` is a lifetime counter that survives deletes and is zeroed by `server.history.reset_totals`.

## Not addressed

- The History page's own paginator shows 15 per page over the loaded jobs, so it still asserts a total that is not the number of jobs that exist — #1921.
- A user-configurable history limit — #998. This removes the pressure to raise the constant for the file browser's sake, but the History page still shows 50.
- `getHistoryById` scans `getHistory` linearly and is called once per file by `files/getDirectory`, so decorating a directory is O(files × jobs). Unchanged here, but `state.jobs` now holds the resolved jobs too, so it grows a little.

Fixes #1920
