### PR TITLE
feat: improves print history loading

### DIFF
--- a/docs/docs/features/printing.md
+++ b/docs/docs/features/printing.md
@@ -132,9 +132,10 @@ insights into past prints.
 | **Statistics**    | Track total print time and filament usage over time.                  |
 | **Re-print**      | Re-start failed or cancelled jobs directly from the history.          |
 
-Fluidd loads the last 50 prints by default. The full history can hold up to
+Fluidd loads the last 100 prints by default. The full history can hold up to
 10,000 entries — a dedicated History page is available from the main navigation
-for a full-screen view.
+for a full-screen view. Use **Load all** to pull the remaining entries; the
+button greys out once everything has been loaded.
 
 ![Print history list with job name, status, and duration columns](/assets/images/print_history.png)
 ![Print statistics showing total print time and filament usage](/assets/images/print_stats.png)

--- a/src/components/widgets/history/JobHistory.vue
+++ b/src/components/widgets/history/JobHistory.vue
@@ -39,6 +39,16 @@
       sort-desc
       fixed-header
     >
+      <template #[`footer.page-text`]="{ pageStart, pageStop, itemsLength }">
+        {{
+          itemsLength === 0
+            ? '–'
+            : allLoaded
+              ? $t('app.general.table.footer.item_range', { pageStart, pageStop, itemsLength })
+              : $t('app.general.table.footer.item_range_loaded', { pageStart, pageStop, itemsLength })
+        }}
+      </template>
+
       <template #item="{ headers, item }">
         <app-data-table-row
           :key="item.job_id"
@@ -428,6 +438,10 @@ export default class JobHistory extends Mixins(FilesMixin) {
 
   get history (): HistoryItem[] {
     return this.$typedGetters['history/getHistory']
+  }
+
+  get allLoaded (): boolean {
+    return this.$typedState.history.allLoaded
   }
 
   getFilePaths (filename: string) {

--- a/src/components/widgets/history/PrintHistoryCard.vue
+++ b/src/components/widgets/history/PrintHistoryCard.vue
@@ -1,6 +1,7 @@
 <template>
   <collapsable-card
     :title="$t('app.general.title.history')"
+    :help-tooltip="$t('app.history.tooltip.help')"
     icon="$history"
   >
     <job-history />
@@ -10,6 +11,7 @@
         <app-btn
           small
           class="ms-1 my-1"
+          :disabled="allLoaded"
           @click="handleLoadAll"
         >
           <v-icon
@@ -51,6 +53,10 @@ import { SocketActions } from '@/api/socketActions'
 export default class PrinterHistoryCard extends Vue {
   @Prop({ type: Boolean })
   readonly narrow?: boolean
+
+  get allLoaded (): boolean {
+    return this.$typedState.history.allLoaded
+  }
 
   async handleRemoveAll () {
     const result = await this.$confirm(

--- a/src/globals.ts
+++ b/src/globals.ts
@@ -241,7 +241,7 @@ export const Globals = Object.freeze({
   CONSOLE_COMMAND_HISTORY: 20,
   CHART_HISTORY_RETENTION: 1200,
   CHART_SYSTEM_RETENTION: 600, // system / mcu / sensor charts, in seconds
-  JOB_HISTORY_LOAD: 50,
+  JOB_HISTORY_LOAD: 100,
   KLIPPY_DISCONNECTED_REDIRECT: '/configuration',
   LOCAL_CARDSTATE_STORAGE_KEY: 'cardState', // collapsed or not
   LOCAL_CARDLAYOUT_STORAGE_KEY: 'cardLayout2', // Specific layout / enabled / disabled

--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -586,6 +586,9 @@ app:
         no_file_preview: >-
           %{name} cannot currently be previewed.
     table:
+      footer:
+        item_range: "%{pageStart}-%{pageStop} of %{itemsLength}"
+        item_range_loaded: "%{pageStart}-%{pageStop} of %{itemsLength} loaded"
       header:
         actions: Actions
         chamber_temp: Chamber temp
@@ -691,6 +694,9 @@ app:
       confirm: Are you sure? This will clear all history, and printer statistics
       confirm_jobs: Are you sure? This will clear all jobs.
       confirm_stats: Are you sure? This will clear all stats.
+    tooltip:
+      help: Only the most recent jobs are loaded on connect. Use Load all to
+        fetch the complete history.
   job_queue:
     msg:
       confirm: Are you sure? This will clear the entire printer queue

--- a/src/store/history/actions.ts
+++ b/src/store/history/actions.ts
@@ -4,6 +4,7 @@ import type { RootState } from '../types'
 import { SocketActions } from '@/api/socketActions'
 import { Globals } from '@/globals'
 import getFilePaths from '@/util/get-file-paths'
+import type { ObjectWithRequest } from '@/plugins/socketClient'
 
 const isJobNotFoundError = (error: unknown): boolean => (
   error != null &&
@@ -99,9 +100,13 @@ export const actions = {
   /**
    * Update the store with history
    */
-  async onHistoryList ({ commit, dispatch, rootState }, payload: Moonraker.History.ListResponse) {
+  async onHistoryList ({ commit, dispatch, rootState }, payload: ObjectWithRequest<Moonraker.History.ListResponse>) {
     if (payload) {
       commit('setHistoryList', payload)
+
+      const { limit } = payload.__request__.params ?? {}
+
+      commit('setAllLoaded', limit === 0 || (limit != null && (payload.jobs?.length ?? 0) < limit))
 
       commit('setClearUnresolvedJobIds')
 

--- a/src/store/history/getters.ts
+++ b/src/store/history/getters.ts
@@ -37,13 +37,21 @@ export const getters = {
   },
 
   /**
+   * Returns all history, indexed by job id.
+   */
+  getHistoryByIdMap: (state, getters) => {
+    const history: HistoryItem[] = getters.getHistory
+
+    return new Map(history.map(job => [job.job_id, job]))
+  },
+
+  /**
    * Return a history item given a job id.
    */
   getHistoryById: (state, getters) => (jobId: string) => {
-    const history: HistoryItem[] = getters.getHistory
+    const historyByIdMap: Map<string, HistoryItem> = getters.getHistoryByIdMap
 
-    return history
-      .find(job => job.job_id === jobId)
+    return historyByIdMap.get(jobId)
   },
 
   /**

--- a/src/store/history/mutations.ts
+++ b/src/store/history/mutations.ts
@@ -91,5 +91,9 @@ export const mutations = {
 
   setClearUnresolvedJobIds (state) {
     state.unresolvedJobIds.clear()
+  },
+
+  setAllLoaded (state, payload: boolean) {
+    state.allLoaded = payload
   }
 } satisfies MutationTree<HistoryState>

--- a/src/store/history/state.ts
+++ b/src/store/history/state.ts
@@ -4,6 +4,7 @@ export const defaultState = (): HistoryState => {
   return {
     jobs: [],
     unresolvedJobIds: new Set(),
+    allLoaded: false,
     job_totals: {
       total_jobs: 0,
       total_time: 0,

--- a/src/store/history/types.ts
+++ b/src/store/history/types.ts
@@ -4,6 +4,7 @@ export interface HistoryState {
   jobs: Readonly<Moonraker.History.Job>[];
   job_totals: Moonraker.History.JobTotals;
   unresolvedJobIds: Set<string>;
+  allLoaded: boolean;
 }
 
 export interface HistoryItem extends Omit<Moonraker.History.Job, 'metadata'> {


### PR DESCRIPTION
The History table paginated over only the loaded jobs, so the footer read "1–15 of 50" and reaching the last page looked like reaching the end of the history. **Load all** was always rendered and always active, so it signalled nothing either way.

No truthful total is available to print instead — `server.history.list` returns `count` as rows *returned*, and `job_totals.total_jobs` is a lifetime counter that is never decremented on delete. So the footer now states what it actually knows.

### Changes

- Footer reads "1–15 of 100 **loaded**" while the history is partial, and drops back to the plain range once everything is in
- **Load all** disables itself when there is nothing left to fetch
- New `allLoaded` state, derived from the originating request's `limit` (a short page means the table is exhausted)
- Card gains a permanent help tooltip explaining the load behaviour
- `JOB_HISTORY_LOAD` 50 → 100
- `getHistoryById` now reads a `Map` index instead of `.find()`ing the whole history per file — removes an O(files × jobs) term from every directory render, which is what makes the higher limit a non-event on phones
- Footer strings go through `$t`, so they're localised via Weblate — Vuetify's own footer text is hardcoded English today

### Notes

- The `allLoaded` flag and short-page detection are **Mainsail's design** (`src/store/server/history/actions.ts`, `HistoryListPanel.vue`); the chained multi-page fetch it sits on there is not adopted
- A history holding exactly the requested limit leaves **Load all** enabled for one redundant click — detecting that needs a total Moonraker doesn't provide
- **Remove all** leaves `allLoaded` as-is; an empty loaded list isn't proof the server is empty

Resolves #1921