### PR TITLE
docs: redirect legacy URLs to new structure

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
 codespell==2.4.3
-zensical==0.0.57
+zensical==0.0.58

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -83,6 +83,60 @@ auto_append = [
   "includes/glossary.md"
 ]
 
+[project.plugins.redirects.redirect_maps]
+# Installation -> Getting Started
+"installation/index.md" = "getting-started.md"
+"installation/kiauh.md" = "getting-started.md#kiauh"
+"installation/docker.md" = "getting-started.md#docker"
+"installation/manual.md" = "getting-started.md#manual-installation"
+"installation/fluiddpi.md" = "getting-started.md#fluiddpi"
+
+# Configuration
+"configuration/initial_setup.md" = "configuration.md#initial-setup"
+"configuration/required.md" = "configuration.md#initial-setup"
+"configuration/moonraker.md" = "configuration.md#moonraker"
+"configuration/moonraker_conf.md" = "configuration.md#example-configuration"
+"configuration/multiple_printers.md" = "configuration.md#multiple-printers"
+"configuration/fluidd_xyz.md" = "getting-started.md#fluiddxyz"
+"configuration/obico_for_remote_access.md" = "features/third-party-integrations.md#obico"
+"configuration/octoeverywhere_free_remote_access.md" = "features/third-party-integrations.md#octoeverywhere"
+
+# Customize
+"customize/layout.md" = "customize.md#application-layout"
+"customize/themes.md" = "customize.md#themes"
+"customize/hide.md" = "customize.md#hiding-components"
+
+# Top-level sections that moved under Features
+"authorization/index.md" = "features/authorization.md"
+"updates/index.md" = "features/updates.md"
+"updates/automated.md" = "features/updates.md#automated-updates"
+"updates/manual.md" = "features/updates.md#manual-updates"
+
+# Features -> Printing
+"features/gcode-viewer.md" = "features/printing.md#g-code-viewer"
+"features/bed_mesh.md" = "features/printing.md#bed-mesh"
+"features/print_history.md" = "features/printing.md#print-history"
+"features/thumbnails.md" = "features/printing.md#thumbnails"
+
+# Features -> Thermals
+"features/chart.md" = "features/thermals.md#chart"
+"features/presets.md" = "features/thermals.md#presets"
+"features/sensors.md" = "features/thermals.md#sensors"
+
+# Features -> Multi-Material
+"features/multiple_extruders.md" = "features/multi-material.md#multiple-extruders"
+"features/spoolman.md" = "features/multi-material.md#spool-management-spoolman"
+
+# Features -> renamed pages
+"features/printers.md" = "features/multiple-printers.md"
+"features/multiple_printers.md" = "features/multiple-printers.md"
+"features/system.md" = "features/system-and-notifications.md#system"
+"features/notifications.md" = "features/system-and-notifications.md#notifications"
+"features/integrations.md" = "features/third-party-integrations.md"
+
+# Development
+"development/localization.md" = "development.md#localization"
+
 [[project.extra.social]]
 icon = "fontawesome/brands/github"
 link = "https://github.com/fluidd-core/fluidd"


### PR DESCRIPTION
## What

Adds redirects from the legacy documentation URLs to the current Zensical structure, and bumps Zensical to `0.0.58`.

## Why

The Jekyll → Zensical migration collapsed a deep page tree into a few long pages, leaving ~30 old URLs returning 404. This isn't just stale bookmarks — older shipped Fluidd builds link into those paths from the app itself (`DOCS_AUTH`, `DOCS_MOONRAKER_COMPONENTS`, `DOCS_REQUIRED_CONFIGURATION`), so printers on older releases hit a 404 from their own help links.

Zensical `0.0.58` adds an `mkdocs-redirects`-compatible plugin, so this is fixed in config alone — no new Markdown files.

## How

`[project.plugins.redirects.redirect_maps]` in `docs/zensical.toml`, 35 entries. Old permalinks were extension-less and Jekyll wrote them as `dir/index.html` — the same layout Zensical produces with `use_directory_urls` — so it's a 1:1 map. Pages whose URL didn't change are deliberately excluded (a redirect there collides with the real page and fails the build).

Beyond the final Jekyll tree, the map also covers:

- `/configuration/required` and `/features/multiple_printers` — only referenced by older shipped builds.
- `/features/system` and `/features/integrations` — the page names that were briefly live between the migration and the later renames.

## Testing

Local build is clean, and all 35 redirects were verified to emit their page, resolve to an existing target, **and** land on a real heading id — the plugin validates the target page but not the fragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LqQHLnnLoyPL4jdUwuVZJc